### PR TITLE
add systemd timer for periodic data ingestion

### DIFF
--- a/os.nix
+++ b/os.nix
@@ -141,7 +141,25 @@ in {
   users.groups.moneymentum = { };
   programs.bash.interactiveShellInit = "set -o vi";
 
-  systemd.services = lib.mapAttrs mkService enabledServices;
+  systemd.services = lib.mapAttrs mkService enabledServices // {
+    moneymentum-ingest = {
+      description = "Trigger moneymentum data ingestion";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart =
+          "${pkgs.curl}/bin/curl -sS -X POST http://127.0.0.1:8000/ingest";
+      };
+    };
+  };
+
+  systemd.timers.moneymentum-ingest = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "5min";
+      OnUnitActiveSec = "6h";
+      Persistent = true;
+    };
+  };
 
   system.activationScripts.moneymentum-cleanup.text =
     "mkdir -p /run/moneymentum /mnt/data/staging";


### PR DESCRIPTION
- Adds a systemd timer + oneshot service that hits `POST /ingest` every 6 hours
- First run 5 minutes after boot, `Persistent = true` catches up if missed
- Zero Rust changes — uses existing ingestion endpoint

## Verification

After deploy: `ssh root@host systemctl list-timers` shows `moneymentum-ingest.timer`.
Manual trigger: `systemctl start moneymentum-ingest`.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #83 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #84
- <kbd>&nbsp;2&nbsp;</kbd> #71
- <kbd>&nbsp;1&nbsp;</kbd> #70
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive GitButler CLI documentation including workflow guides, concepts reference, command reference, and real-world usage examples

* **Infrastructure**
  * Introduced staging environment configuration for testing and development
  * Enhanced CI/CD workflow with improved parallel processing and deployment stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->