### PR TITLE
make token picker work without wallet connection

### DIFF
--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -23,6 +23,7 @@ const mockMethods = {
   rebalancePositions: vi.fn(),
   getNetworkMode: vi.fn(),
   getPublicKey: vi.fn(),
+  fetchPerpTickers: vi.fn(),
 }
 
 // Mock the HyperliquidClient as a class
@@ -36,6 +37,8 @@ vi.mock("@/services/hyperliquid-client", () => ({
     getNetworkMode = mockMethods.getNetworkMode
     getPublicKey = mockMethods.getPublicKey
   },
+  fetchPerpTickers: (...args: unknown[]) =>
+    mockMethods.fetchPerpTickers(...args),
   preloadMarkets: vi.fn().mockResolvedValue(undefined),
 }))
 
@@ -198,6 +201,31 @@ describe("useTrading hooks", () => {
   })
 
   describe("useHyperliquidTickers", () => {
+    it("fetches tickers without wallet connected", async () => {
+      // No wallet in localStorage — simulates staging on a different port
+      // where localStorage doesn't have wallet credentials.
+      // Market data is public, so tickers should load regardless.
+      mockMethods.fetchPerpTickers.mockResolvedValue([
+        "BTC/USDC:USDC",
+        "ETH/USDC:USDC",
+        "SOL/USDC:USDC",
+      ])
+
+      const { result } = renderHook(() => useHyperliquidTickers(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual([
+        "BTC/USDC:USDC",
+        "ETH/USDC:USDC",
+        "SOL/USDC:USDC",
+      ])
+    })
+
     it("fetches tickers when connected", async () => {
       localStorage.setItem(
         "hyperliquid-wallet",
@@ -207,7 +235,7 @@ describe("useTrading hooks", () => {
           privateKey: "0xTestSecret",
         }),
       )
-      mockMethods.listPerpTickers.mockResolvedValue([
+      mockMethods.fetchPerpTickers.mockResolvedValue([
         "BTC/USDC:USDC",
         "ETH/USDC:USDC",
         "SOL/USDC:USDC",

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -1,11 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useWallet } from "./useWallet"
-import type {
-  Position,
-  OrderResult,
-  CurrentPosition,
-  LeverageLimit,
-  OrderSide,
+import {
+  fetchPerpTickers,
+  type Position,
+  type OrderResult,
+  type CurrentPosition,
+  type LeverageLimit,
+  type OrderSide,
 } from "@/services/hyperliquid-client"
 
 export type { OrderSide, OrderResult, CurrentPosition, LeverageLimit }
@@ -128,15 +129,11 @@ export const useHyperliquidPositions = () => {
 }
 
 export const useHyperliquidTickers = () => {
-  const { client, isConnected } = useHyperliquidClient()
+  const { networkMode } = useWallet()
 
   return useQuery({
     queryKey: QUERY_KEYS.tickers,
-    queryFn: async () => {
-      if (!client) throw new Error("Wallet not connected")
-      return client.listPerpTickers()
-    },
-    enabled: isConnected && client !== null,
+    queryFn: () => fetchPerpTickers(networkMode),
     staleTime: 60000,
   })
 }

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -36,7 +36,7 @@ vi.mock("ccxt", () => {
   }
 })
 
-import { HyperliquidClient } from "./hyperliquid-client"
+import { HyperliquidClient, fetchPerpTickers } from "./hyperliquid-client"
 import type { WalletCredentials } from "@/contexts/wallet-context"
 import type { Position } from "./hyperliquid-client"
 
@@ -1174,5 +1174,68 @@ describe("HyperliquidClient", () => {
 
       expect(client.getNetworkMode()).toBe("mainnet")
     })
+  })
+})
+
+describe("fetchPerpTickers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it("returns perp symbols from loaded markets", async () => {
+    mockExchange.loadMarkets.mockResolvedValue({
+      "BTC/USDC:USDC": { swap: true },
+      "ETH/USDC:USDC": { swap: true },
+      "SOL/USDC:USDC": { swap: true },
+      "BTC/USDC": { spot: true },
+    })
+
+    const tickers = await fetchPerpTickers("testnet")
+
+    expect(tickers).toEqual(["BTC/USDC:USDC", "ETH/USDC:USDC", "SOL/USDC:USDC"])
+  })
+
+  it("filters out spot markets", async () => {
+    mockExchange.loadMarkets.mockResolvedValue({
+      "BTC/USDC:USDC": { swap: true },
+      "BTC/USDC": { spot: true },
+      "ETH/USDC": { spot: true },
+    })
+
+    const tickers = await fetchPerpTickers("testnet")
+
+    expect(tickers).toEqual(["BTC/USDC:USDC"])
+  })
+
+  it("filters out markets where swap is false", async () => {
+    mockExchange.loadMarkets.mockResolvedValue({
+      "BTC/USDC:USDC": { swap: true },
+      "ETH/USDC:USDC": { swap: false },
+    })
+
+    const tickers = await fetchPerpTickers("testnet")
+
+    expect(tickers).toEqual(["BTC/USDC:USDC"])
+  })
+
+  it("returns empty array when preloadMarkets fails", async () => {
+    mockExchange.loadMarkets.mockRejectedValue(new Error("Network error"))
+
+    const tickers = await fetchPerpTickers("testnet")
+
+    expect(tickers).toEqual([])
+  })
+
+  it("returns sorted symbols", async () => {
+    mockExchange.loadMarkets.mockResolvedValue({
+      "SOL/USDC:USDC": { swap: true },
+      "BTC/USDC:USDC": { swap: true },
+      "ETH/USDC:USDC": { swap: true },
+    })
+
+    const tickers = await fetchPerpTickers("testnet")
+
+    expect(tickers).toEqual(["BTC/USDC:USDC", "ETH/USDC:USDC", "SOL/USDC:USDC"])
   })
 })

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -121,6 +121,23 @@ export const preloadMarkets = async (
   }
 }
 
+const extractPerpSymbols = (markets: Record<string, unknown>): string[] =>
+  Object.entries(markets)
+    .filter(
+      ([symbol, data]) =>
+        symbol.includes(":") && (data as { swap?: boolean }).swap,
+    )
+    .map(([symbol]) => symbol)
+    .sort()
+
+export const fetchPerpTickers = async (
+  networkMode: NetworkMode,
+): Promise<string[]> => {
+  const markets = await preloadMarkets(networkMode)
+  if (!markets) return []
+  return extractPerpSymbols(markets)
+}
+
 export type OrderSide = "buy" | "sell"
 export type PositionStatus =
   | "untouched"
@@ -323,14 +340,7 @@ export class HyperliquidClient {
     // Update cache with fresh markets data
     setCachedMarkets(markets, this.networkMode)
 
-    const perpSymbols = Object.entries(markets)
-      .filter(
-        ([symbol, data]) =>
-          symbol.includes(":") && (data as { swap?: boolean }).swap,
-      )
-      .map(([symbol]) => symbol)
-      .sort()
-    return perpSymbols
+    return extractPerpSymbols(markets)
   }
 
   async getLeverageLimits(): Promise<LeverageLimit[]> {


### PR DESCRIPTION
## Motivation

Staging runs on port 8080 while prod runs on port 80. localStorage is
origin-scoped (protocol + hostname + port), so wallet credentials configured on
prod are not available on staging. Without a wallet, `useHyperliquidTickers`
never fires because it gates on `isConnected && client !== null` — leaving the
token picker empty with "Nothing found".

## Solution

Extracted perp symbol filtering from `HyperliquidClient.listPerpTickers` into a
standalone `fetchPerpTickers` function that uses `preloadMarkets` (which creates
a temporary exchange without credentials). `useHyperliquidTickers` now calls
this directly with just the network mode, decoupling ticker fetching from wallet
state. Market data is public and doesn't need wallet credentials.

## Stacked on

- #86 (beta-api-fallback)
  - #85 (add-gitbutler-skill-v2)
    - #84 (staging-environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Perpetual tickers can now be fetched independently without requiring an active wallet connection, improving platform flexibility.
  * Extended position status indicators to include additional states: modified, deleted, idle, and working for more granular order tracking.

* **Tests**
  * Comprehensive test coverage added for new ticker fetching functionality and position status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->