### PR TITLE
add cross-account leverage control and improve layout

### DIFF
--- a/frontend/src/pages/Portfolio/components/FactorsPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/FactorsPanel.tsx
@@ -1,49 +1,54 @@
 import { clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface FactorExposure {
   name: string
-  value: number
+  value: string // should be a number or decimal in future
 }
 
 interface FactorAttribution {
   factor: string
-  contribution: number
+  contribution: string // should be a number or decimal in future
 }
 
 interface ConcentrationMetric {
   metric: string
-  value: number
+  value: string // should be a number or decimal in future
 }
 
 const mockExposures: FactorExposure[] = [
-  { name: "β to BTC", value: 0.85 },
-  { name: "β to SPY", value: 0.42 },
-  { name: "Momentum", value: 0.28 },
-  { name: "Carry", value: -0.15 },
-  { name: "Volatility", value: 0.12 },
+  { name: "β to SPY", value: "TODO" },
+  { name: "Momentum", value: "TODO" },
+  { name: "Carry", value: "TODO" },
+  { name: "Volatility", value: "TODO" },
 ]
 
 const mockAttribution: FactorAttribution[] = [
-  { factor: "β to BTC", contribution: 0.156 },
-  { factor: "β to SPY", contribution: 0.042 },
-  { factor: "Momentum", contribution: 0.098 },
-  { factor: "Carry", contribution: -0.023 },
-  { factor: "Volatility", contribution: 0.025 },
-  { factor: "Idiosyncratic", contribution: 0.044 },
+  { factor: "β to BTC", contribution: "TODO" },
+  { factor: "β to SPY", contribution: "TODO" },
+  { factor: "Momentum", contribution: "TODO" },
+  { factor: "Carry", contribution: "TODO" },
+  { factor: "Volatility", contribution: "TODO" },
+  { factor: "Idiosyncratic", contribution: "TODO" },
 ]
 
 const mockConcentration: ConcentrationMetric[] = [
-  { metric: "Top Position", value: 0.23 },
-  { metric: "Top 3 Positions", value: 0.46 },
-  { metric: "Top 5 Positions", value: 0.59 },
-  { metric: "Herfindahl Index", value: 0.12 },
-  { metric: "Effective Positions", value: 8.3 },
+  { metric: "Top Position", value: "TODO" },
+  { metric: "Top 3 Positions", value: "TODO" },
+  { metric: "Top 5 Positions", value: "TODO" },
+  { metric: "Herfindahl Index", value: "TODO" },
+  { metric: "Effective Positions", value: "TODO" },
 ]
 
-export const FactorsPanel = () => {
+interface FactorsPanelProps {
+  beta: number | null
+  isBetaLoading: boolean
+}
+
+export const FactorsPanel = ({ beta, isBetaLoading }: FactorsPanelProps) => {
   return (
-    <div className="shrink-0 border border-border rounded flex flex-col min-w-0 relative">
+    <div className="shrink-0 border border-border rounded flex flex-col min-w-[25%] relative">
       <div className="px-2 py-1 border-b border-border bg-muted/30 font-medium flex items-center justify-between">
         <span>FACTORS</span>
         <div className="flex items-center gap-2">
@@ -65,6 +70,28 @@ export const FactorsPanel = () => {
           <div className="text-[10px] text-muted-foreground font-medium">
             Exposures
           </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground truncate">β to BTC</span>
+            <span className="font-mono">
+              {isBetaLoading ? (
+                <Skeleton className="inline-block h-3 w-10 align-middle" />
+              ) : beta !== null ? (
+                <span
+                  className={twMerge(
+                    clsx(
+                      beta > 0 && "text-green-500",
+                      beta < 0 && "text-red-500",
+                    ),
+                  )}
+                >
+                  {beta >= 0 ? "+" : ""}
+                  {beta.toFixed(2)}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </span>
+          </div>
           {mockExposures.map(exposure => (
             <div
               key={exposure.name}
@@ -73,10 +100,7 @@ export const FactorsPanel = () => {
               <span className="text-muted-foreground truncate">
                 {exposure.name}
               </span>
-              <span className="font-mono">
-                {exposure.value >= 0 ? "+" : ""}
-                {exposure.value.toFixed(2)}
-              </span>
+              <span className="font-mono">{exposure.value}</span>
             </div>
           ))}
         </div>
@@ -94,18 +118,8 @@ export const FactorsPanel = () => {
               <span className="text-muted-foreground truncate">
                 {attribution.factor}
               </span>
-              <span
-                className={twMerge(
-                  clsx(
-                    "w-14 text-right font-mono",
-                    attribution.contribution >= 0
-                      ? "text-green-500"
-                      : "text-red-500",
-                  ),
-                )}
-              >
-                {attribution.contribution >= 0 ? "+" : ""}
-                {(attribution.contribution * 100).toFixed(1)}%
+              <span className={twMerge(clsx("w-14 text-right font-mono"))}>
+                {attribution.contribution}
               </span>
             </div>
           ))}
@@ -123,11 +137,7 @@ export const FactorsPanel = () => {
                 className="flex items-center justify-between"
               >
                 <span className="text-muted-foreground">{metric.metric}</span>
-                <span className="font-mono">
-                  {metric.value <= 1
-                    ? `${(metric.value * 100).toFixed(0)}%`
-                    : metric.value.toFixed(1)}
-                </span>
+                <span className="font-mono">{metric.value}</span>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/Portfolio/components/RiskPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/RiskPanel.tsx
@@ -1,14 +1,14 @@
 const mockRiskMetrics = {
-  var95: -0.12,
-  var99: -0.2,
-  diversificationRatio: 1.35,
-  effectiveBets: 4.7,
+  var95: "TODO",
+  var99: "TODO",
+  diversificationRatio: "TODO",
+  effectiveBets: "TODO",
 }
 
 const mockStressTests = [
-  { scenario: "BTC -20%", portfolioImpact: -0.18 },
-  { scenario: "SPX -10%", portfolioImpact: -0.08 },
-  { scenario: "Rates +200bps", portfolioImpact: -0.05 },
+  { scenario: "BTC -20%", portfolioImpact: "TODO" },
+  { scenario: "SPX -10%", portfolioImpact: "TODO" },
+  { scenario: "Rates +200bps", portfolioImpact: "TODO" },
 ]
 
 const mockMonteCarlo = [
@@ -58,8 +58,6 @@ const getCorrelationColor = (value: number): string => {
   return "bg-muted text-foreground"
 }
 
-const formatPct = (v: number): string => `${(v * 100).toFixed(1)}%`
-
 export const RiskPanel = () => {
   return (
     <div className="flex-1 border border-border rounded flex flex-col min-w-0">
@@ -72,26 +70,24 @@ export const RiskPanel = () => {
           <div className="flex justify-between">
             <span className="text-muted-foreground">VaR 95%</span>
             <span className="text-red-400 font-mono">
-              {formatPct(mockRiskMetrics.var95)}
+              {mockRiskMetrics.var95}
             </span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">VaR 99%</span>
             <span className="text-red-400 font-mono">
-              {formatPct(mockRiskMetrics.var99)}
+              {mockRiskMetrics.var99}
             </span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Diversification</span>
             <span className="font-mono">
-              {mockRiskMetrics.diversificationRatio.toFixed(2)}x
+              {mockRiskMetrics.diversificationRatio}
             </span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Effective Bets</span>
-            <span className="font-mono">
-              {mockRiskMetrics.effectiveBets.toFixed(1)}
-            </span>
+            <span className="font-mono">{mockRiskMetrics.effectiveBets}</span>
           </div>
         </div>
 
@@ -109,14 +105,8 @@ export const RiskPanel = () => {
                 <span className="text-muted-foreground truncate">
                   {stressTest.scenario}
                 </span>
-                <span
-                  className={
-                    stressTest.portfolioImpact < 0
-                      ? "text-red-400 font-mono"
-                      : "text-green-400 font-mono"
-                  }
-                >
-                  {formatPct(stressTest.portfolioImpact)}
+                <span className={"text-white-500 font-mono"}>
+                  {stressTest.portfolioImpact}
                 </span>
               </div>
             ))}
@@ -126,7 +116,7 @@ export const RiskPanel = () => {
         {/* Monte Carlo */}
         <div className="border-t border-border/50 pt-2">
           <div className="text-[10px] text-muted-foreground font-medium mb-1.5">
-            Monte Carlo (1 Year)
+            Monte Carlo (1 Year) TODO
           </div>
           <div className="flex items-end gap-px h-12">
             {mockMonteCarlo.map(monteCarloPoint => (
@@ -148,7 +138,7 @@ export const RiskPanel = () => {
         {/* Correlation heatmap */}
         <div className="border-t border-border/50 pt-2">
           <div className="text-[10px] text-muted-foreground font-medium mb-1.5">
-            Correlation
+            Correlation TODO
           </div>
           <table className="w-full">
             <thead>

--- a/frontend/src/pages/Portfolio/components/StagedChangesPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/StagedChangesPanel.tsx
@@ -39,6 +39,12 @@ const formatUnsignedPct = (weightFraction: number): string =>
 
 const formatUsdPrecise = (value: number): string => `$${value.toFixed(2)}`
 
+// Minimum notional change to show an arrow in the notional preview.
+// Difference between initial and target notional arises because
+// initial total notional is rounded to 2 decimal places while target
+// is computed from accountValue * leverage separately.
+const NOTIONAL_EPSILON_USD = 0.1
+
 export const StagedChangesPanel = ({
   stagedTrades: stagedTradesProp,
   initialTotalNotional,
@@ -52,6 +58,16 @@ export const StagedChangesPanel = ({
 }: StagedChangesPanelProps) => {
   const stagedTrades = stagedTradesProp ?? []
   const hasStaged = stagedTrades.length > 0
+  const shouldShowNotionalArrow =
+    initialTotalNotional !== undefined &&
+    targetNotional !== undefined &&
+    Math.abs(targetNotional - initialTotalNotional) >= NOTIONAL_EPSILON_USD
+  const initialLeverage = initialCrossAccountLeverage
+  const currentLeverage = crossAccountLeverage
+  const shouldShowLeverageArrow =
+    initialLeverage !== null &&
+    currentLeverage !== undefined &&
+    initialLeverage !== currentLeverage
 
   return (
     <div className="flex-1 border border-border rounded flex flex-col min-w-0">
@@ -160,19 +176,23 @@ export const StagedChangesPanel = ({
               <span className="font-mono">
                 {initialTotalNotional !== undefined &&
                 targetNotional !== undefined ? (
-                  <>
-                    {formatUsdPrecise(initialTotalNotional)}{" "}
-                    <span className="text-muted-foreground">→</span>{" "}
-                    <span
-                      className={
-                        targetNotional >= initialTotalNotional
-                          ? "text-green-500"
-                          : "text-red-500"
-                      }
-                    >
-                      {formatUsdPrecise(targetNotional)}
-                    </span>
-                  </>
+                  shouldShowNotionalArrow ? (
+                    <>
+                      {formatUsdPrecise(initialTotalNotional)}{" "}
+                      <span className="text-muted-foreground">→</span>{" "}
+                      <span
+                        className={
+                          targetNotional >= initialTotalNotional
+                            ? "text-green-500"
+                            : "text-red-500"
+                        }
+                      >
+                        {formatUsdPrecise(targetNotional)}
+                      </span>
+                    </>
+                  ) : (
+                    formatUsdPrecise(targetNotional)
+                  )
                 ) : (
                   "TODO"
                 )}
@@ -182,15 +202,17 @@ export const StagedChangesPanel = ({
               <span className="text-muted-foreground">Leverage</span>
               <span className="font-mono">
                 {crossAccountLeverage !== undefined ? (
-                  <>
-                    {(
-                      initialCrossAccountLeverage ?? crossAccountLeverage
-                    ).toFixed(2)}
-                    x <span className="text-muted-foreground">→</span>{" "}
-                    <span className="text-yellow-500">
-                      {crossAccountLeverage.toFixed(2)}x
-                    </span>
-                  </>
+                  shouldShowLeverageArrow ? (
+                    <>
+                      {initialLeverage?.toFixed(2)}x{" "}
+                      <span className="text-muted-foreground">→</span>{" "}
+                      <span className="text-yellow-500">
+                        {currentLeverage.toFixed(2)}x
+                      </span>
+                    </>
+                  ) : (
+                    `${crossAccountLeverage.toFixed(2)}x`
+                  )
                 ) : (
                   "TODO"
                 )}

--- a/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
+++ b/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
@@ -475,9 +475,13 @@ export const usePortfolioState = (
       } = recalculateFromNotionals(mergedTokens)
 
       if (accountValue > 0) {
-        const newLeverage = calcLeverage(fullTotalNotional, accountValue)
-        setCrossAccountLeverage(newLeverage)
-        setInitialCrossAccountLeverage(newLeverage)
+        // crossAccountLeverage reflects the merged (current) portfolio,
+        // but initialCrossAccountLeverage must stay tied to the pure
+        // exchange snapshot (initialLeverage) so that leverage deltas
+        // in the staged panel are measured vs. actual exchange state.
+        const mergedLeverage = calcLeverage(fullTotalNotional, accountValue)
+        setCrossAccountLeverage(mergedLeverage)
+        setInitialCrossAccountLeverage(initialLeverage)
       }
 
       setSelectedTokens(tokensWithPercentages)
@@ -1302,12 +1306,17 @@ export const usePortfolioState = (
 
     setCrossAccountLeverage(baseLeverage)
     latestCrossAccountLeverageRef.current = baseLeverage
-    setSelectedTokensAndPersist(initialPortfolio)
+    setSelectedTokensAndPersist(() => {
+      // Start from the pure exchange snapshot and let updateByNotionalChange
+      // recompute percentages and leverage from notionals so that weights
+      // renormalize to 100% without any local-only tokens.
+      return updateByNotionalChange(initialPortfolio)
+    })
   }, [
     initialPortfolio,
     initialCrossAccountLeverage,
-    latestCrossAccountLeverageRef,
     setSelectedTokensAndPersist,
+    updateByNotionalChange,
   ])
 
   const disableSubmit =

--- a/frontend/src/pages/Portfolio/index.tsx
+++ b/frontend/src/pages/Portfolio/index.tsx
@@ -215,34 +215,15 @@ const PortfolioPage = () => {
 
             {/* Footer */}
             <div className="sticky bottom-0 bg-background/80 backdrop-blur mt-auto">
-              <div className=" text-[12px] flex flex-wrap items-center justify-start gap-3 border-t border-border pt-3">
-                <div className="font-semibold text-muted-foreground">
-                  <span>Beta (vs BTC) </span>
-                  {isBetaLoading ? (
-                    <Skeleton className="inline-block h-4 w-16 align-middle" />
-                  ) : beta !== null ? (
-                    <span
-                      className={twMerge(
-                        clsx(
-                          beta > 0 && "text-green-500",
-                          beta < 0 && "text-red-500",
-                        ),
-                      )}
-                    >
-                      {beta.toFixed(2)}
-                    </span>
-                  ) : (
-                    <span className="text-muted-foreground">—</span>
-                  )}
-                </div>
-                <div className="flex items-center gap-4">
+              <div className="text-[12px] border-t border-border pt-3 flex items-center">
+                <div className="flex items-center gap-4 w-full">
                   {/* Cross Account Leverage Slider */}
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 flex-1">
                     <span className="font-semibold text-muted-foreground whitespace-nowrap">
-                      Leverage:
+                      Leverage
                     </span>
                     {isBalanceLoading ? (
-                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-4 w-full" />
                     ) : (
                       <>
                         <Slider
@@ -253,7 +234,7 @@ const PortfolioPage = () => {
                           min={LEVERAGE_MIN}
                           max={LEVERAGE_MAX}
                           step={LEVERAGE_STEP}
-                          className="w-32"
+                          className="flex-1"
                         />
                         <input
                           type="number"
@@ -272,13 +253,13 @@ const PortfolioPage = () => {
                           min={LEVERAGE_MIN}
                           max={LEVERAGE_MAX}
                           step={LEVERAGE_STEP}
-                          className="w-14 rounded-md border border-border bg-transparent px-2 py-1 text-center font-medium [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                          className="w-16 rounded-md border border-border bg-transparent px-2 py-1 text-center font-medium [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                         />
                         <span className="text-sm font-medium">x</span>
                       </>
                     )}
                   </div>
-                  <div className="flex gap-4">
+                  <div className="flex items-center gap-4">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button
@@ -326,19 +307,25 @@ const PortfolioPage = () => {
           <div className="flex flex-col gap-1 min-h-0 w-full">
             <PerformancePanel />
             <div className="flex-1 flex gap-1 min-h-0">
-              <StagedChangesPanel
-                stagedTrades={stagedTrades}
-                initialTotalNotional={initialTotalNotional}
-                targetNotional={targetNotional}
-                initialCrossAccountLeverage={initialCrossAccountLeverage}
-                crossAccountLeverage={crossAccountLeverage}
-                onRebalance={handleOpenPositions}
-                isRebalancing={isRebalancing}
-                disableSubmit={disableSubmit}
-                onClearAll={handleResetToInitial}
-              />
-              <FactorsPanel />
-              <RiskPanel />
+              <div className="flex flex-[0_0_40%] min-w-0">
+                <StagedChangesPanel
+                  stagedTrades={stagedTrades}
+                  initialTotalNotional={initialTotalNotional}
+                  targetNotional={targetNotional}
+                  initialCrossAccountLeverage={initialCrossAccountLeverage}
+                  crossAccountLeverage={crossAccountLeverage}
+                  onRebalance={handleOpenPositions}
+                  isRebalancing={isRebalancing}
+                  disableSubmit={disableSubmit}
+                  onClearAll={handleResetToInitial}
+                />
+              </div>
+              <div className="flex-[0_0_25%] min-w-0">
+                <FactorsPanel beta={beta} isBetaLoading={isBetaLoading} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <RiskPanel />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Why

Beta display didn't give users direct control over leverage, and the analysis
panel layout wasted screen space.

## How

Replaced beta display with a cross-account leverage slider and numeric input.
Restructured analysis panels into optimized column widths with skeleton loading
states.