### PR TITLE
replace exceptions with typed Effect errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,8 @@ such a sweep, and never apply it to `*.tsx`, `*.ts`, or to quoted strings inside
   specific case (e.g., conventional loop indices in tight numeric code where a
   longer name would obscure intent).
 - No abbreviations unless universally understood (`id`, `url`, `http`, `msg`,
-  `tx` are fine)
+  `tx` are fine). This includes namespace import aliases: `import * as Hl` is
+  wrong, use `import * as Hyperliquid`
 
 ### Colocate types
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,9 +268,13 @@ user-visible output (UI text, CLI messages). Use ASCII equivalents in comments:
 ### Descriptive names
 
 - Avoid generic names like `result`, `data`, `value`, `item` - name what it IS
-- No single-letter variables in closures: `|r|` is unreadable, use `|rate|`
+- **No single-letter variable or parameter names anywhere**: `c` is unreadable,
+  use `client`. `r` is unreadable, use `rate`. This applies to function
+  parameters, arrow function args, local variables, destructured bindings, and
+  loop variables. The only exception is `_` for intentionally unused values
 - No abbreviations unless universally understood (`id`, `url`, `http`, `msg`,
-  `tx` are fine)
+  `tx` are fine). This includes namespace import aliases: `import * as Hl` is
+  wrong, use `import * as Hyperliquid`
 
 ### Colocate types
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -26,6 +26,8 @@
         "tailwindcss-animate": "^1.0.7",
       },
       "devDependencies": {
+        "@effect/eslint-plugin": "^0.3.2",
+        "@effect/language-service": "^0.79.0",
         "@eslint/js": "^9.25.0",
         "@solidjs/testing-library": "^0.8.10",
         "@tailwindcss/vite": "^4.1.8",
@@ -93,6 +95,14 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
+
+    "@dprint/formatter": ["@dprint/formatter@0.4.1", "", {}, "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g=="],
+
+    "@dprint/typescript": ["@dprint/typescript@0.91.8", "", {}, "sha512-tuKn4leCPItox1O4uunHcQF0QllDCvPWklnNQIh2PiWWVtRAGltJJnM4Cwj5AciplosD1Hiz7vAY3ew3crLb3A=="],
+
+    "@effect/eslint-plugin": ["@effect/eslint-plugin@0.3.2", "", { "dependencies": { "@dprint/formatter": "^0.4.1", "@dprint/typescript": "^0.91.3", "prettier-linter-helpers": "^1.0.0" } }, "sha512-c4Vs9t3r54A4Zpl+wo8+PGzZz3JWYsip41H+UrebRLjQ2Hk/ap63IeCgN/HWcYtxtyhRopjp7gW9nOQ2Snbl+g=="],
+
+    "@effect/language-service": ["@effect/language-service@0.79.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-DEmIOsg1GjjP6s9HXH1oJrW+gDmzkhVv9WOZl6to5eNyyCrjz1S2PDqQ7aYrW/HuifhfwI5Bik1pK4pj7Z+lrg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -618,6 +628,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
+
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
@@ -883,6 +895,8 @@
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "decimal.js": "^10.6.0",
+        "effect": "^3.19.19",
         "lightweight-charts": "^5.1.0",
         "lucide-solid": "^0.577.0",
         "multicoin-address-validator": "^0.5.26",
@@ -561,6 +562,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "effect": ["effect@3.19.19", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
@@ -610,6 +613,8 @@
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fancy-canvas": ["fancy-canvas@2.1.0", "", {}, "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -890,6 +895,8 @@
     "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
 
     "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "decimal.js": "^10.6.0",
+        "effect": "^3.19.19",
         "lightweight-charts": "^5.1.0",
         "lucide-solid": "^0.577.0",
         "protobufjs": "^8.0.0",
@@ -550,6 +551,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "effect": ["effect@3.19.19", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
@@ -599,6 +602,8 @@
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fancy-canvas": ["fancy-canvas@2.1.0", "", {}, "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -871,6 +876,8 @@
     "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
 
     "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -25,6 +25,8 @@
         "tailwindcss-animate": "^1.0.7",
       },
       "devDependencies": {
+        "@effect/eslint-plugin": "^0.3.2",
+        "@effect/language-service": "^0.79.0",
         "@eslint/js": "^9.25.0",
         "@solidjs/testing-library": "^0.8.10",
         "@tailwindcss/vite": "^4.1.8",
@@ -92,6 +94,14 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
+
+    "@dprint/formatter": ["@dprint/formatter@0.4.1", "", {}, "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g=="],
+
+    "@dprint/typescript": ["@dprint/typescript@0.91.8", "", {}, "sha512-tuKn4leCPItox1O4uunHcQF0QllDCvPWklnNQIh2PiWWVtRAGltJJnM4Cwj5AciplosD1Hiz7vAY3ew3crLb3A=="],
+
+    "@effect/eslint-plugin": ["@effect/eslint-plugin@0.3.2", "", { "dependencies": { "@dprint/formatter": "^0.4.1", "@dprint/typescript": "^0.91.3", "prettier-linter-helpers": "^1.0.0" } }, "sha512-c4Vs9t3r54A4Zpl+wo8+PGzZz3JWYsip41H+UrebRLjQ2Hk/ap63IeCgN/HWcYtxtyhRopjp7gW9nOQ2Snbl+g=="],
+
+    "@effect/language-service": ["@effect/language-service@0.79.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-DEmIOsg1GjjP6s9HXH1oJrW+gDmzkhVv9WOZl6to5eNyyCrjz1S2PDqQ7aYrW/HuifhfwI5Bik1pK4pj7Z+lrg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -607,6 +617,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
+
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
@@ -864,6 +876,8 @@
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/frontend/bun.nix
+++ b/frontend/bun.nix
@@ -105,6 +105,22 @@
     url = "https://registry.npmjs.org/@corvu/utils/-/utils-0.4.2.tgz";
     hash = "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==";
   };
+  "@dprint/formatter@0.4.1" = fetchurl {
+    url = "https://registry.npmjs.org/@dprint/formatter/-/formatter-0.4.1.tgz";
+    hash = "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g==";
+  };
+  "@dprint/typescript@0.91.8" = fetchurl {
+    url = "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.91.8.tgz";
+    hash = "sha512-tuKn4leCPItox1O4uunHcQF0QllDCvPWklnNQIh2PiWWVtRAGltJJnM4Cwj5AciplosD1Hiz7vAY3ew3crLb3A==";
+  };
+  "@effect/eslint-plugin@0.3.2" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/eslint-plugin/-/eslint-plugin-0.3.2.tgz";
+    hash = "sha512-c4Vs9t3r54A4Zpl+wo8+PGzZz3JWYsip41H+UrebRLjQ2Hk/ap63IeCgN/HWcYtxtyhRopjp7gW9nOQ2Snbl+g==";
+  };
+  "@effect/language-service@0.79.0" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/language-service/-/language-service-0.79.0.tgz";
+    hash = "sha512-DEmIOsg1GjjP6s9HXH1oJrW+gDmzkhVv9WOZl6to5eNyyCrjz1S2PDqQ7aYrW/HuifhfwI5Bik1pK4pj7Z+lrg==";
+  };
   "@emnapi/core@1.8.1" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz";
     hash = "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==";
@@ -833,6 +849,10 @@
     url = "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz";
     hash = "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==";
   };
+  "base-x@4.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz";
+    hash = "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==";
+  };
   "base64-js@1.5.1" = fetchurl {
     url = "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz";
     hash = "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
@@ -869,6 +889,10 @@
     url = "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz";
     hash = "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==";
   };
+  "browserify-bignum@1.3.0-2" = fetchurl {
+    url = "https://registry.npmjs.org/browserify-bignum/-/browserify-bignum-1.3.0-2.tgz";
+    hash = "sha512-PwVvKC3WIV7ENfsG6VAIDq4R5st6kQt+Fod3WL5l7+MRONClo3J6xGQvRJHHM/ScwcNCH3GfYX5UOCuoNN/rLw==";
+  };
   "browserify-cipher@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz";
     hash = "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==";
@@ -901,9 +925,17 @@
     url = "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz";
     hash = "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==";
   };
+  "buffer@6.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz";
+    hash = "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==";
+  };
   "builtin-status-codes@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz";
     hash = "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==";
+  };
+  "bundle@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/bundle/-/bundle-2.1.0.tgz";
+    hash = "sha512-d7TeT8m2HuymDjSEmMppWe/h5SSPPUZkaWKrAofx6gNXDdZ3FL/81oOTGPG+LIaZbNr9m4rtUi98Yw0Q1vHIIw==";
   };
   "call-bind-apply-helpers@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz";
@@ -924,6 +956,10 @@
   "caniuse-lite@1.0.30001777" = fetchurl {
     url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz";
     hash = "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==";
+  };
+  "cbor-js@0.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz";
+    hash = "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==";
   };
   "ccxt@4.5.42" = fetchurl {
     url = "https://registry.npmjs.org/ccxt/-/ccxt-4.5.42.tgz";
@@ -976,6 +1012,10 @@
   "core-util-is@1.0.3" = fetchurl {
     url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz";
     hash = "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==";
+  };
+  "crc@4.3.2" = fetchurl {
+    url = "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz";
+    hash = "sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==";
   };
   "create-ecdh@4.0.4" = fetchurl {
     url = "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz";
@@ -1064,6 +1104,10 @@
   "dunder-proto@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz";
     hash = "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==";
+  };
+  "effect@3.19.19" = fetchurl {
+    url = "https://registry.npmjs.org/effect/-/effect-3.19.19.tgz";
+    hash = "sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==";
   };
   "electron-to-chromium@1.5.307" = fetchurl {
     url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz";
@@ -1181,9 +1225,17 @@
     url = "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz";
     hash = "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==";
   };
+  "fast-check@3.23.2" = fetchurl {
+    url = "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz";
+    hash = "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==";
+  };
   "fast-deep-equal@3.1.3" = fetchurl {
     url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
     hash = "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==";
+  };
+  "fast-diff@1.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz";
+    hash = "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==";
   };
   "fast-json-stable-stringify@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
@@ -1429,6 +1481,10 @@
     url = "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz";
     hash = "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==";
   };
+  "js-sha512@0.9.0" = fetchurl {
+    url = "https://registry.npmjs.org/js-sha512/-/js-sha512-0.9.0.tgz";
+    hash = "sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg==";
+  };
   "js-tokens@10.0.0" = fetchurl {
     url = "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz";
     hash = "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==";
@@ -1460,6 +1516,10 @@
   "json5@2.2.3" = fetchurl {
     url = "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz";
     hash = "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
+  };
+  "jssha@3.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz";
+    hash = "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==";
   };
   "kebab-case@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.2.tgz";
@@ -1532,6 +1592,10 @@
   "locate-path@6.0.0" = fetchurl {
     url = "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz";
     hash = "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==";
+  };
+  "lodash.isequal@4.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz";
+    hash = "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==";
   };
   "lodash.merge@4.6.2" = fetchurl {
     url = "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz";
@@ -1608,6 +1672,10 @@
   "ms@2.1.3" = fetchurl {
     url = "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz";
     hash = "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
+  };
+  "multicoin-address-validator@0.5.26" = fetchurl {
+    url = "https://registry.npmjs.org/multicoin-address-validator/-/multicoin-address-validator-0.5.26.tgz";
+    hash = "sha512-WM9Zo7J+eVBa1tgzC/LZwaI1eu+FEwE+8X8KbEIIrb1Ghyi5tK38mzZdVp8PmIypZ1x4BHlNncWGOqvWw2/Cmg==";
   };
   "nanoid@3.3.11" = fetchurl {
     url = "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz";
@@ -1725,6 +1793,10 @@
     url = "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz";
     hash = "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==";
   };
+  "prettier-linter-helpers@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz";
+    hash = "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==";
+  };
   "pretty-format@27.5.1" = fetchurl {
     url = "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz";
     hash = "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==";
@@ -1752,6 +1824,10 @@
   "punycode@2.3.1" = fetchurl {
     url = "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz";
     hash = "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==";
+  };
+  "pure-rand@6.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz";
+    hash = "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==";
   };
   "qs@6.15.0" = fetchurl {
     url = "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz";

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,6 +2,7 @@ import js from "@eslint/js"
 import globals from "globals"
 import solid from "eslint-plugin-solid/configs/typescript"
 import tseslint from "typescript-eslint"
+import effectPlugin from "@effect/eslint-plugin"
 
 export default tseslint.config(
   { ignores: ["dist", "node_modules", "coverage"] },
@@ -58,6 +59,15 @@ export default tseslint.config(
       "curly": ["error", "multi-line"],
       "no-throw-literal": "error",
       "func-style": ["error", "expression"],
+
+      // Effect
+      "@effect/no-import-from-barrel-package": [
+        "error",
+        { packageNames: ["effect"] },
+      ],
+    },
+    plugins: {
+      "@effect": effectPlugin,
     },
   },
   // Test files - relax some rules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,8 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@effect/eslint-plugin": "^0.3.2",
+    "@effect/language-service": "^0.79.0",
     "@eslint/js": "^9.25.0",
     "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/vite": "^4.1.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "decimal.js": "^10.6.0",
+    "effect": "^3.19.19",
     "lightweight-charts": "^5.1.0",
     "lucide-solid": "^0.577.0",
     "multicoin-address-validator": "^0.5.26",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,8 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@effect/eslint-plugin": "^0.3.2",
+    "@effect/language-service": "^0.79.0",
     "@eslint/js": "^9.25.0",
     "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/vite": "^4.1.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "decimal.js": "^10.6.0",
+    "effect": "^3.19.19",
     "lightweight-charts": "^5.1.0",
     "lucide-solid": "^0.577.0",
     "protobufjs": "^8.0.0",

--- a/frontend/src/hooks/useApi.test.tsx
+++ b/frontend/src/hooks/useApi.test.tsx
@@ -55,7 +55,10 @@ describe("useApi hooks with Timeframe type", () => {
         expect(result.isSuccess).toBe(true)
       })
 
-      expect(global.fetch).toHaveBeenCalledWith("/api/date-range?timeframe=1h")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/date-range?timeframe=1h",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      )
       expect(result.data).toEqual(mockResponse)
     })
 
@@ -80,7 +83,10 @@ describe("useApi hooks with Timeframe type", () => {
         expect(result.isSuccess).toBe(true)
       })
 
-      expect(global.fetch).toHaveBeenCalledWith("/api/date-range?timeframe=15m")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/date-range?timeframe=15m",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      )
     })
 
     it("enforces Timeframe type safety", () => {
@@ -188,7 +194,10 @@ describe("useApi hooks with Timeframe type", () => {
         expect(result.isSuccess).toBe(true)
       })
 
-      expect(global.fetch).toHaveBeenCalledWith("/api/token/BTC?timeframe=1h")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/token/BTC?timeframe=1h",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      )
     })
 
     it("constructs URL correctly with 15m timeframe", async () => {
@@ -220,7 +229,10 @@ describe("useApi hooks with Timeframe type", () => {
         expect(result.isSuccess).toBe(true)
       })
 
-      expect(global.fetch).toHaveBeenCalledWith("/api/token/ETH?timeframe=15m")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/token/ETH?timeframe=15m",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      )
     })
 
     it("does not query when ticker is undefined", () => {

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,5 +1,7 @@
+import * as Effect from "effect/Effect"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/solid-query"
 import type { Timeframe } from "@/components/ui/timeframe-select"
+import { fetchJson, postJson, postEmpty, fetchStreamChecked } from "@/lib/http"
 
 export type TradingData = {
   timestamp: string
@@ -25,10 +27,6 @@ export type TradingData = {
   sortino: number | null
 }
 
-interface ApiError {
-  detail?: string
-}
-
 export interface DateRange {
   min_date: string
   max_date: string
@@ -44,16 +42,12 @@ export interface AnalysisDataParams {
 export const useDateRange = (timeframe: () => Timeframe) => {
   return useQuery<DateRange>(() => ({
     queryKey: ["dateRange", timeframe()],
-    queryFn: async () => {
-      const response = await fetch(`/api/date-range?timeframe=${timeframe()}`)
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as ApiError
-        throw new Error(
-          errorData.detail ?? `HTTP error! status: ${String(response.status)}`,
-        )
-      }
-      return response.json() as Promise<DateRange>
-    },
+    queryFn: ({ signal }) =>
+      Effect.runPromise(
+        fetchJson<DateRange>(`/api/date-range?timeframe=${timeframe()}`, {
+          signal,
+        }),
+      ),
   }))
 }
 
@@ -62,36 +56,17 @@ export const useAnalysisData = (params: () => AnalysisDataParams) => {
     const { startDate, endDate, timeframe } = params()
     return {
       queryKey: ["analysisData", timeframe, startDate, endDate],
-      queryFn: async () => {
-        const startDateTime = `${startDate}T00:00:00Z`
-        const endDateTime = `${endDate}T23:59:59Z`
-
-        const response = await fetch(`/api/data?timeframe=${timeframe}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            start_date: startDateTime,
-            end_date: endDateTime,
-          }),
-        })
-
-        if (!response.ok) {
-          const errorData = (await response
-            .json()
-            .catch(() => ({}))) as ApiError
-          throw new Error(
-            errorData.detail ??
-              `HTTP error! status: ${String(response.status)}`,
-          )
-        }
-
-        return response.json() as Promise<{
-          data: TradingData[]
-          message: string | null
-        }>
-      },
+      queryFn: ({ signal }) =>
+        Effect.runPromise(
+          postJson<{ data: TradingData[]; message: string | null }>(
+            `/api/data?timeframe=${timeframe}`,
+            {
+              start_date: `${startDate}T00:00:00Z`,
+              end_date: `${endDate}T23:59:59Z`,
+            },
+            { signal },
+          ),
+        ),
       enabled: !!startDate && !!endDate,
     }
   })
@@ -103,30 +78,24 @@ export const useTokenData = (
 ) => {
   return useQuery<{ data: TradingData[]; message?: string }>(() => ({
     queryKey: ["tokenData", ticker(), timeframe()],
-    queryFn: async () => {
-      const t = ticker()
-      if (!t) {
-        throw new Error("Ticker is required")
+    queryFn: ({ signal }) => {
+      const tickerValue = ticker()
+      if (!tickerValue) {
+        return Promise.reject(new Error("Ticker is required"))
       }
 
-      const response = await fetch(
-        `/api/token/${encodeURIComponent(t)}?timeframe=${timeframe()}`,
+      return Effect.runPromise(
+        fetchJson<{ data: TradingData[]; message?: string }>(
+          `/api/token/${encodeURIComponent(tickerValue)}?timeframe=${timeframe()}`,
+          { signal },
+        ).pipe(
+          Effect.flatMap(tokenResponse =>
+            tokenResponse.message
+              ? Effect.fail(new Error(tokenResponse.message))
+              : Effect.succeed(tokenResponse),
+          ),
+        ),
       )
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${String(response.status)}`)
-      }
-
-      const result = (await response.json()) as {
-        data: TradingData[]
-        message?: string
-      }
-
-      if (result.message) {
-        throw new Error(result.message)
-      }
-
-      return result
     },
     enabled: !!ticker(),
   }))
@@ -137,20 +106,13 @@ export const useReloadData = () => {
 
   return useMutation(() => ({
     mutationFn: async ({ mode }: { mode: string }) => {
-      const controller = new AbortController()
-
-      const response = await fetch("/api/reload_data/stream", {
-        method: "POST",
-        signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ mode }),
-      })
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${String(response.status)}`)
-      }
+      const response = await Effect.runPromise(
+        fetchStreamChecked("/api/reload_data/stream", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode }),
+        }),
+      )
 
       if (!response.body) {
         throw new Error("No response body received")
@@ -182,29 +144,19 @@ export const useReloadData = () => {
 
 export const useStopReload = () => {
   return useMutation(() => ({
-    mutationFn: async () => {
-      const response = await fetch("/api/stop_reload", {
-        method: "POST",
-      })
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${String(response.status)}`)
-      }
-    },
+    mutationFn: () => Effect.runPromise(postEmpty("/api/stop_reload")),
   }))
 }
 
 export const useBudgetPreference = () => {
   return useQuery<{ budget: number }>(() => ({
     queryKey: ["hyperliquid", "budget-preference"],
-    queryFn: async () => {
-      const response = await fetch("/api/hyperliquid/budget-preference")
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as ApiError
-        throw new Error(errorData.detail ?? "Unable to fetch budget preference")
-      }
-      return response.json() as Promise<{ budget: number }>
-    },
+    queryFn: ({ signal }) =>
+      Effect.runPromise(
+        fetchJson<{ budget: number }>("/api/hyperliquid/budget-preference", {
+          signal,
+        }),
+      ),
   }))
 }
 
@@ -212,20 +164,12 @@ export const useSaveBudgetPreference = () => {
   const queryClient = useQueryClient()
 
   return useMutation(() => ({
-    mutationFn: async (payload: { budget: number }) => {
-      const response = await fetch("/api/hyperliquid/budget-preference", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-      })
-
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as ApiError
-        throw new Error(errorData.detail ?? "Unable to save budget preference")
-      }
-    },
+    mutationFn: (payload: { budget: number }) =>
+      Effect.runPromise(
+        postJson("/api/hyperliquid/budget-preference", payload).pipe(
+          Effect.asVoid,
+        ),
+      ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: ["hyperliquid", "budget-preference"],

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,5 +1,7 @@
+import * as Effect from "effect/Effect"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/solid-query"
 import type { Timeframe } from "@/components/ui/timeframe-select"
+import { fetchJson, postJson, postEmpty, fetchStreamChecked } from "@/lib/http"
 
 export type TradingData = {
   timestamp: string
@@ -25,10 +27,6 @@ export type TradingData = {
   sortino: number | null
 }
 
-interface ApiError {
-  detail?: string
-}
-
 export interface DateRange {
   min_date: string
   max_date: string
@@ -44,16 +42,12 @@ export interface AnalysisDataParams {
 export const useDateRange = (timeframe: () => Timeframe) => {
   return useQuery<DateRange>(() => ({
     queryKey: ["dateRange", timeframe()],
-    queryFn: async () => {
-      const response = await fetch(`/api/date-range?timeframe=${timeframe()}`)
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as ApiError
-        throw new Error(
-          errorData.detail ?? `HTTP error! status: ${String(response.status)}`,
-        )
-      }
-      return response.json() as Promise<DateRange>
-    },
+    queryFn: ({ signal }) =>
+      Effect.runPromise(
+        fetchJson<DateRange>(`/api/date-range?timeframe=${timeframe()}`, {
+          signal,
+        }),
+      ),
   }))
 }
 
@@ -62,36 +56,17 @@ export const useAnalysisData = (params: () => AnalysisDataParams) => {
     const { startDate, endDate, timeframe } = params()
     return {
       queryKey: ["analysisData", timeframe, startDate, endDate],
-      queryFn: async () => {
-        const startDateTime = `${startDate}T00:00:00Z`
-        const endDateTime = `${endDate}T23:59:59Z`
-
-        const response = await fetch(`/api/data?timeframe=${timeframe}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            start_date: startDateTime,
-            end_date: endDateTime,
-          }),
-        })
-
-        if (!response.ok) {
-          const errorData = (await response
-            .json()
-            .catch(() => ({}))) as ApiError
-          throw new Error(
-            errorData.detail ??
-              `HTTP error! status: ${String(response.status)}`,
-          )
-        }
-
-        return response.json() as Promise<{
-          data: TradingData[]
-          message: string | null
-        }>
-      },
+      queryFn: ({ signal }) =>
+        Effect.runPromise(
+          postJson<{ data: TradingData[]; message: string | null }>(
+            `/api/data?timeframe=${timeframe}`,
+            {
+              start_date: `${startDate}T00:00:00Z`,
+              end_date: `${endDate}T23:59:59Z`,
+            },
+            { signal },
+          ),
+        ),
       enabled: !!startDate && !!endDate,
     }
   })
@@ -103,30 +78,24 @@ export const useTokenData = (
 ) => {
   return useQuery<{ data: TradingData[]; message?: string }>(() => ({
     queryKey: ["tokenData", ticker(), timeframe()],
-    queryFn: async () => {
-      const t = ticker()
-      if (!t) {
-        throw new Error("Ticker is required")
+    queryFn: ({ signal }) => {
+      const tickerValue = ticker()
+      if (!tickerValue) {
+        return Promise.reject(new Error("Ticker is required"))
       }
 
-      const response = await fetch(
-        `/api/token/${encodeURIComponent(t)}?timeframe=${timeframe()}`,
+      return Effect.runPromise(
+        fetchJson<{ data: TradingData[]; message?: string }>(
+          `/api/token/${encodeURIComponent(tickerValue)}?timeframe=${timeframe()}`,
+          { signal },
+        ).pipe(
+          Effect.flatMap(result =>
+            result.message
+              ? Effect.fail(new Error(result.message))
+              : Effect.succeed(result),
+          ),
+        ),
       )
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${String(response.status)}`)
-      }
-
-      const result = (await response.json()) as {
-        data: TradingData[]
-        message?: string
-      }
-
-      if (result.message) {
-        throw new Error(result.message)
-      }
-
-      return result
     },
     enabled: !!ticker(),
   }))
@@ -137,20 +106,13 @@ export const useReloadData = () => {
 
   return useMutation(() => ({
     mutationFn: async ({ mode }: { mode: string }) => {
-      const controller = new AbortController()
-
-      const response = await fetch("/api/reload_data/stream", {
-        method: "POST",
-        signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ mode }),
-      })
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${String(response.status)}`)
-      }
+      const response = await Effect.runPromise(
+        fetchStreamChecked("/api/reload_data/stream", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode }),
+        }),
+      )
 
       if (!response.body) {
         throw new Error("No response body received")
@@ -182,47 +144,29 @@ export const useReloadData = () => {
 
 export const useStopReload = () => {
   return useMutation(() => ({
-    mutationFn: async () => {
-      const response = await fetch("/api/stop_reload", {
-        method: "POST",
-      })
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${String(response.status)}`)
-      }
-    },
+    mutationFn: () => Effect.runPromise(postEmpty("/api/stop_reload")),
   }))
 }
 
 export const useBudgetPreference = () => {
   return useQuery<{ budget: number }>(() => ({
     queryKey: ["hyperliquid", "budget-preference"],
-    queryFn: async () => {
-      const response = await fetch("/api/hyperliquid/budget-preference")
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as ApiError
-        throw new Error(errorData.detail ?? "Unable to fetch budget preference")
-      }
-      return response.json() as Promise<{ budget: number }>
-    },
+    queryFn: ({ signal }) =>
+      Effect.runPromise(
+        fetchJson<{ budget: number }>("/api/hyperliquid/budget-preference", {
+          signal,
+        }),
+      ),
   }))
 }
 
 export const useSaveBudgetPreference = () => {
   return useMutation(() => ({
-    mutationFn: async (payload: { budget: number }) => {
-      const response = await fetch("/api/hyperliquid/budget-preference", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-      })
-
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as ApiError
-        throw new Error(errorData.detail ?? "Unable to save budget preference")
-      }
-    },
+    mutationFn: (payload: { budget: number }) =>
+      Effect.runPromise(
+        postJson("/api/hyperliquid/budget-preference", payload).pipe(
+          Effect.asVoid,
+        ),
+      ),
   }))
 }

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -278,7 +278,8 @@ describe("useTrading hooks", () => {
         expect(result.isError).toBe(true)
       })
 
-      expect(result.error?.message).toBe("Wallet not connected")
+      expect(result.error).toBeTruthy()
+      expect(String(result.error)).toContain("WalletNotConnected")
     })
 
     it("calls rebalancePositions with correct parameters", async () => {

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -321,7 +321,8 @@ describe("useTrading hooks", () => {
         expect(result.isError).toBe(true)
       })
 
-      expect(result.error?.message).toBe("Wallet not connected")
+      expect(result.error).toBeInstanceOf(Error)
+      expect(String(result.error)).toContain("WalletNotConnected")
     })
 
     it("calls rebalancePositions with correct parameters", async () => {

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -1,3 +1,4 @@
+import * as Effect from "effect/Effect"
 import { createMemo } from "solid-js"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/solid-query"
 import { useWallet } from "./useWallet"
@@ -10,6 +11,7 @@ import {
   type OrderSide,
   type HyperliquidMarketsResponse,
 } from "@/services/hyperliquid-client"
+import * as Hyperliquid from "@/services/hyperliquid"
 import type { RebalanceAction } from "@/pages/Portfolio/hooks/portfolioRebalancer"
 
 export type {
@@ -57,11 +59,7 @@ export const useHyperliquidBalance = () => {
       credentials()?.accountAddress,
       networkMode(),
     ],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      return c.getBalance()
-    },
+    queryFn: () => Effect.runPromise(Hyperliquid.getBalance(client())),
     enabled: isConnected() && client() !== null,
     staleTime: Infinity,
   }))
@@ -84,18 +82,18 @@ export const useHyperliquidAccountSummary = () => {
       credentials()?.accountAddress,
       networkMode(),
     ],
-    queryFn: async (): Promise<AccountSummary> => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      const summary = await c.getAccountSummary()
-
-      const crossAccountLeverage =
-        summary.accountValue > 0
-          ? summary.totalNotionalPosition / summary.accountValue
-          : 0
-
-      return { ...summary, crossAccountLeverage }
-    },
+    queryFn: (): Promise<AccountSummary> =>
+      Effect.runPromise(
+        Hyperliquid.getAccountSummary(client()).pipe(
+          Effect.map(summary => {
+            const crossAccountLeverage =
+              summary.accountValue > 0
+                ? summary.totalNotionalPosition / summary.accountValue
+                : 0
+            return { ...summary, crossAccountLeverage }
+          }),
+        ),
+      ),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -111,26 +109,25 @@ export const useHyperliquidPositions = () => {
       credentials()?.accountAddress,
       networkMode(),
     ],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-
-      const positions = await c.getCurrentPositions()
-      const totalNotional = positions.reduce(
-        (sum, pos) => sum + pos.notional,
-        0,
-      )
-      const result = {
-        positions: positions.map(pos => ({
-          ...pos,
-          percentage:
-            totalNotional > 0 ? (pos.notional / totalNotional) * 100 : 0,
-        })),
-        totalNotional,
-      }
-
-      return result
-    },
+    queryFn: () =>
+      Effect.runPromise(
+        Hyperliquid.getCurrentPositions(client()).pipe(
+          Effect.map(positions => {
+            const totalNotional = positions.reduce(
+              (sum, pos) => sum + pos.notional,
+              0,
+            )
+            return {
+              positions: positions.map(pos => ({
+                ...pos,
+                percentage:
+                  totalNotional > 0 ? (pos.notional / totalNotional) * 100 : 0,
+              })),
+              totalNotional,
+            }
+          }),
+        ),
+      ),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -187,11 +184,7 @@ export const useHyperliquidFundingRates = () => {
 
   return useQuery(() => ({
     queryKey: [...QUERY_KEYS.fundingRates, networkMode()],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      return c.getFundingRates()
-    },
+    queryFn: () => Effect.runPromise(Hyperliquid.getFundingRates(client())),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -206,13 +199,12 @@ export const useRebalanceHyperliquidPositions = () => {
   const queryClient = useQueryClient()
 
   return useMutation(() => ({
-    mutationFn: async (params: RebalanceParams) => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-
-      const results = await c.rebalancePositions(params.actions)
-      return { orders: results }
-    },
+    mutationFn: (params: RebalanceParams) =>
+      Effect.runPromise(
+        Hyperliquid.rebalancePositions(client(), params.actions).pipe(
+          Effect.map(orders => ({ orders })),
+        ),
+      ),
     onSuccess: () => {
       const account = credentials()?.accountAddress
       const network = networkMode()

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -1,3 +1,4 @@
+import * as Effect from "effect/Effect"
 import { createMemo } from "solid-js"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/solid-query"
 import { useWallet } from "./useWallet"
@@ -8,6 +9,7 @@ import type {
   LeverageLimit,
   OrderSide,
 } from "@/services/hyperliquid-client"
+import * as Hyperliquid from "@/services/hyperliquid"
 
 export type { OrderSide, OrderResult, CurrentPosition, LeverageLimit }
 
@@ -37,11 +39,7 @@ export const useHyperliquidBalance = () => {
       credentials()?.accountAddress,
       networkMode(),
     ],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      return c.getBalance()
-    },
+    queryFn: () => Effect.runPromise(Hyperliquid.getBalance(client())),
     enabled: isConnected() && client() !== null,
     staleTime: Infinity,
   }))
@@ -64,18 +62,18 @@ export const useHyperliquidAccountSummary = () => {
       credentials()?.accountAddress,
       networkMode(),
     ],
-    queryFn: async (): Promise<AccountSummary> => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      const summary = await c.getAccountSummary()
-
-      const crossAccountLeverage =
-        summary.accountValue > 0
-          ? summary.totalNotionalPosition / summary.accountValue
-          : 0
-
-      return { ...summary, crossAccountLeverage }
-    },
+    queryFn: (): Promise<AccountSummary> =>
+      Effect.runPromise(
+        Hyperliquid.getAccountSummary(client()).pipe(
+          Effect.map(summary => {
+            const crossAccountLeverage =
+              summary.accountValue > 0
+                ? summary.totalNotionalPosition / summary.accountValue
+                : 0
+            return { ...summary, crossAccountLeverage }
+          }),
+        ),
+      ),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -91,26 +89,25 @@ export const useHyperliquidPositions = () => {
       credentials()?.accountAddress,
       networkMode(),
     ],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-
-      const positions = await c.getCurrentPositions()
-      const totalNotional = positions.reduce(
-        (sum, pos) => sum + pos.notional,
-        0,
-      )
-      const result = {
-        positions: positions.map(pos => ({
-          ...pos,
-          percentage:
-            totalNotional > 0 ? (pos.notional / totalNotional) * 100 : 0,
-        })),
-        totalNotional,
-      }
-
-      return result
-    },
+    queryFn: () =>
+      Effect.runPromise(
+        Hyperliquid.getCurrentPositions(client()).pipe(
+          Effect.map(positions => {
+            const totalNotional = positions.reduce(
+              (sum, pos) => sum + pos.notional,
+              0,
+            )
+            return {
+              positions: positions.map(pos => ({
+                ...pos,
+                percentage:
+                  totalNotional > 0 ? (pos.notional / totalNotional) * 100 : 0,
+              })),
+              totalNotional,
+            }
+          }),
+        ),
+      ),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -121,11 +118,7 @@ export const useHyperliquidTickers = () => {
 
   return useQuery(() => ({
     queryKey: [...QUERY_KEYS.tickers, networkMode()],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      return c.listPerpTickers()
-    },
+    queryFn: () => Effect.runPromise(Hyperliquid.listPerpTickers(client())),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -136,13 +129,7 @@ export const useHyperliquidLeverageLimits = () => {
 
   return useQuery(() => ({
     queryKey: [...QUERY_KEYS.leverageLimits, networkMode()],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      const result = await c.getLeverageLimits()
-
-      return result
-    },
+    queryFn: () => Effect.runPromise(Hyperliquid.getLeverageLimits(client())),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -153,11 +140,7 @@ export const useHyperliquidFundingRates = () => {
 
   return useQuery(() => ({
     queryKey: [...QUERY_KEYS.fundingRates, networkMode()],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      return c.getFundingRates()
-    },
+    queryFn: () => Effect.runPromise(Hyperliquid.getFundingRates(client())),
     enabled: isConnected() && client() !== null,
     staleTime: DATA_STALE_TIME_MS,
   }))
@@ -184,10 +167,7 @@ export const useRebalanceHyperliquidPositions = () => {
   const queryClient = useQueryClient()
 
   return useMutation(() => ({
-    mutationFn: async (params: RebalanceParams) => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-
+    mutationFn: (params: RebalanceParams) => {
       const positions: Position[] = params.positions.map(pos => ({
         symbol: pos.symbol,
         percentage: pos.percentage,
@@ -199,26 +179,15 @@ export const useRebalanceHyperliquidPositions = () => {
         status: pos.status === "working" ? "idle" : pos.status,
       }))
 
-      console.table(
-        positions.map(position => ({
-          symbol: position.symbol,
-          percentage: position.percentage,
-          side: position.side,
-          leverage: position.leverage,
-          leverageChanged: position.leverageChanged,
-          currentNotional: position.currentNotional ?? "--",
-          status: position.status,
-        })),
-      )
-
-      const results = await c.rebalancePositions(
-        positions,
-        params.accountValue,
-        params.crossAccountLeverage,
-        params.precise,
-      )
-
-      return { orders: results }
+      return Effect.runPromise(
+        Hyperliquid.rebalancePositions(
+          client(),
+          positions,
+          params.accountValue,
+          params.crossAccountLeverage,
+          params.precise,
+        ),
+      ).then(orders => ({ orders }))
     },
     onSuccess: () => {
       const account = credentials()?.accountAddress

--- a/frontend/src/lib/http.test.ts
+++ b/frontend/src/lib/http.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { Effect } from "effect"
+import * as Effect from "effect/Effect"
 import {
   fetchJson,
   postJson,
   postEmpty,
+  fetchStreamChecked,
   NetworkError,
   HttpStatusError,
   JsonParseError,
+  JsonSerializeError,
 } from "./http"
 
 describe("http", () => {
@@ -73,6 +75,45 @@ describe("http", () => {
         if (error._tag === "Fail") {
           expect(error.error).toBeInstanceOf(HttpStatusError)
           expect((error.error as HttpStatusError).status).toBe(500)
+          expect((error.error as HttpStatusError).detail).toBeUndefined()
+        }
+      }
+    })
+
+    it("returns HttpStatusError without detail when body is non-object JSON", async () => {
+      mockFetch().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve("just a string"),
+      })
+
+      const exit = await Effect.runPromiseExit(fetchJson("/api/test"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(HttpStatusError)
+          expect((error.error as HttpStatusError).status).toBe(400)
+          expect((error.error as HttpStatusError).detail).toBeUndefined()
+        }
+      }
+    })
+
+    it("returns HttpStatusError without detail when body is null JSON", async () => {
+      mockFetch().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve(null),
+      })
+
+      const exit = await Effect.runPromiseExit(fetchJson("/api/test"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(HttpStatusError)
           expect((error.error as HttpStatusError).detail).toBeUndefined()
         }
       }
@@ -150,6 +191,77 @@ describe("http", () => {
           signal: expect.any(AbortSignal),
         }),
       )
+    })
+  })
+
+  describe("fetchStreamChecked", () => {
+    it("returns Response on successful fetch", async () => {
+      const mockResponse = { ok: true, body: "stream" }
+      mockFetch().mockResolvedValue(mockResponse)
+
+      const result = await Effect.runPromise(
+        fetchStreamChecked("/api/stream", { method: "POST" }),
+      )
+
+      expect(result).toBe(mockResponse)
+      expect(mockFetch()).toHaveBeenCalledWith("/api/stream", {
+        method: "POST",
+      })
+    })
+
+    it("returns HttpStatusError on non-ok response", async () => {
+      mockFetch().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: () => Promise.resolve({ detail: "Bad gateway" }),
+      })
+
+      const exit = await Effect.runPromiseExit(
+        fetchStreamChecked("/api/stream"),
+      )
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(HttpStatusError)
+          expect((error.error as HttpStatusError).status).toBe(502)
+          expect((error.error as HttpStatusError).detail).toBe("Bad gateway")
+        }
+      }
+    })
+
+    it("returns NetworkError when fetch fails", async () => {
+      mockFetch().mockRejectedValue(new TypeError("Network error"))
+
+      const exit = await Effect.runPromiseExit(
+        fetchStreamChecked("/api/stream"),
+      )
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(NetworkError)
+        }
+      }
+    })
+  })
+
+  describe("postJson - serialization", () => {
+    it("returns JsonSerializeError when body is not serializable", async () => {
+      const circular: Record<string, unknown> = {}
+      circular.self = circular
+
+      const exit = await Effect.runPromiseExit(postJson("/api/test", circular))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(JsonSerializeError)
+        }
+      }
     })
   })
 

--- a/frontend/src/lib/http.test.ts
+++ b/frontend/src/lib/http.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Effect } from "effect"
+import {
+  fetchJson,
+  postJson,
+  postEmpty,
+  NetworkError,
+  HttpStatusError,
+  JsonParseError,
+} from "./http"
+
+describe("http", () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const mockFetch = () => globalThis.fetch as ReturnType<typeof vi.fn>
+
+  describe("fetchJson", () => {
+    it("returns parsed JSON on 200", async () => {
+      const payload = { id: 1, name: "test" }
+      mockFetch().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      })
+
+      const result = await Effect.runPromise(fetchJson("/api/test"))
+
+      expect(result).toEqual(payload)
+      expect(mockFetch()).toHaveBeenCalledWith("/api/test", undefined)
+    })
+
+    it("returns HttpStatusError with detail on non-ok response", async () => {
+      mockFetch().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: () => Promise.resolve({ detail: "Validation failed" }),
+      })
+
+      const exit = await Effect.runPromiseExit(fetchJson("/api/test"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(HttpStatusError)
+          expect((error.error as HttpStatusError).status).toBe(422)
+          expect((error.error as HttpStatusError).detail).toBe(
+            "Validation failed",
+          )
+        }
+      }
+    })
+
+    it("returns HttpStatusError without detail when body is unparseable", async () => {
+      mockFetch().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error("not json")),
+      })
+
+      const exit = await Effect.runPromiseExit(fetchJson("/api/test"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(HttpStatusError)
+          expect((error.error as HttpStatusError).status).toBe(500)
+          expect((error.error as HttpStatusError).detail).toBeUndefined()
+        }
+      }
+    })
+
+    it("returns NetworkError when fetch throws", async () => {
+      const fetchError = new TypeError("Failed to fetch")
+      mockFetch().mockRejectedValue(fetchError)
+
+      const exit = await Effect.runPromiseExit(fetchJson("/api/test"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(NetworkError)
+          expect((error.error as NetworkError).cause).toBe(fetchError)
+        }
+      }
+    })
+
+    it("returns JsonParseError on invalid JSON body", async () => {
+      const jsonError = new SyntaxError("Unexpected token")
+      mockFetch().mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(jsonError),
+      })
+
+      const exit = await Effect.runPromiseExit(fetchJson("/api/test"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(JsonParseError)
+          expect((error.error as JsonParseError).cause).toBe(jsonError)
+        }
+      }
+    })
+  })
+
+  describe("postJson", () => {
+    it("sends POST with correct method, headers, and body", async () => {
+      const requestBody = { start_date: "2024-01-01" }
+      const responseBody = { data: [] }
+      mockFetch().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(responseBody),
+      })
+
+      const result = await Effect.runPromise(postJson("/api/data", requestBody))
+
+      expect(result).toEqual(responseBody)
+      expect(mockFetch()).toHaveBeenCalledWith("/api/data", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+      })
+    })
+
+    it("merges additional init options", async () => {
+      mockFetch().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      })
+
+      await Effect.runPromise(
+        postJson("/api/data", {}, { signal: AbortSignal.timeout(5000) }),
+      )
+
+      expect(mockFetch()).toHaveBeenCalledWith(
+        "/api/data",
+        expect.objectContaining({
+          method: "POST",
+          signal: expect.any(AbortSignal),
+        }),
+      )
+    })
+  })
+
+  describe("postEmpty", () => {
+    it("sends POST and returns void on success", async () => {
+      mockFetch().mockResolvedValue({ ok: true })
+
+      await Effect.runPromise(postEmpty("/api/stop"))
+      expect(mockFetch()).toHaveBeenCalledWith("/api/stop", { method: "POST" })
+    })
+
+    it("returns HttpStatusError on non-ok response", async () => {
+      mockFetch().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ detail: "Service unavailable" }),
+      })
+
+      const exit = await Effect.runPromiseExit(postEmpty("/api/stop"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(HttpStatusError)
+          expect((error.error as HttpStatusError).status).toBe(503)
+        }
+      }
+    })
+
+    it("returns NetworkError when fetch fails", async () => {
+      mockFetch().mockRejectedValue(new TypeError("Network error"))
+
+      const exit = await Effect.runPromiseExit(postEmpty("/api/stop"))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        const error = exit.cause
+        if (error._tag === "Fail") {
+          expect(error.error).toBeInstanceOf(NetworkError)
+        }
+      }
+    })
+  })
+})

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,4 +1,5 @@
-import { Data, Effect } from "effect"
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
 
 export class NetworkError extends Data.TaggedError("NetworkError")<{
   readonly cause: unknown
@@ -13,6 +14,10 @@ export class JsonParseError extends Data.TaggedError("JsonParseError")<{
   readonly cause: unknown
 }> {}
 
+export class JsonSerializeError extends Data.TaggedError("JsonSerializeError")<{
+  readonly cause: unknown
+}> {}
+
 const request = (
   url: string,
   init?: RequestInit,
@@ -22,21 +27,29 @@ const request = (
     catch: cause => new NetworkError({ cause }),
   })
 
+const extractDetail = (body: unknown): string | undefined => {
+  if (typeof body === "object" && body !== null && "detail" in body) {
+    const raw = (body as Record<string, unknown>).detail
+    return typeof raw === "string" ? raw : undefined
+  }
+  return undefined
+}
+
 const ensureOk = (
   response: Response,
 ): Effect.Effect<Response, HttpStatusError> =>
   response.ok
     ? Effect.succeed(response)
     : Effect.tryPromise({
-        try: () => response.json() as Promise<{ detail?: string }>,
-        catch: () => ({ detail: undefined }),
+        try: () => response.json() as Promise<unknown>,
+        catch: () => undefined as unknown,
       }).pipe(
-        Effect.catchAll(() => Effect.succeed({ detail: undefined })),
+        Effect.catchAll(() => Effect.succeed(undefined as unknown)),
         Effect.flatMap(body =>
           Effect.fail(
             new HttpStatusError({
               status: response.status,
-              detail: body.detail,
+              detail: extractDetail(body),
             }),
           ),
         ),
@@ -58,30 +71,34 @@ export const postJson = <A>(
   url: string,
   body: unknown,
   init?: RequestInit,
-): Effect.Effect<A, NetworkError | HttpStatusError | JsonParseError> => {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  }
+): Effect.Effect<
+  A,
+  NetworkError | HttpStatusError | JsonParseError | JsonSerializeError
+> => {
+  const merged = new Headers(init?.headers)
+  merged.set("Content-Type", "application/json")
+  const headers = Object.fromEntries(merged.entries())
 
-  if (init?.headers) {
-    const entries =
-      init.headers instanceof Headers
-        ? Array.from(init.headers.entries())
-        : Array.isArray(init.headers)
-          ? init.headers
-          : Object.entries(init.headers)
-    for (const [key, value] of entries) {
-      headers[key] = value
-    }
-  }
-
-  return fetchJson(url, {
-    ...init,
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  })
+  return Effect.try({
+    try: () => JSON.stringify(body),
+    catch: cause => new JsonSerializeError({ cause }),
+  }).pipe(
+    Effect.flatMap(serialized =>
+      fetchJson(url, {
+        ...init,
+        method: "POST",
+        headers,
+        body: serialized,
+      }),
+    ),
+  )
 }
+
+export const fetchStreamChecked = (
+  url: string,
+  init?: RequestInit,
+): Effect.Effect<Response, NetworkError | HttpStatusError> =>
+  request(url, init).pipe(Effect.flatMap(ensureOk))
 
 export const postEmpty = (
   url: string,

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,4 +1,5 @@
-import { Data, Effect } from "effect"
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
 
 export class NetworkError extends Data.TaggedError("NetworkError")<{
   readonly cause: unknown
@@ -13,6 +14,10 @@ export class JsonParseError extends Data.TaggedError("JsonParseError")<{
   readonly cause: unknown
 }> {}
 
+export class JsonSerializeError extends Data.TaggedError("JsonSerializeError")<{
+  readonly cause: unknown
+}> {}
+
 const request = (
   url: string,
   init?: RequestInit,
@@ -22,21 +27,27 @@ const request = (
     catch: cause => new NetworkError({ cause }),
   })
 
+const extractDetail = (body: unknown): string | undefined => {
+  if (typeof body === "object" && body !== null && "detail" in body) {
+    const raw = (body as Record<string, unknown>).detail
+    return typeof raw === "string" ? raw : undefined
+  }
+  return undefined
+}
+
 const ensureOk = (
   response: Response,
 ): Effect.Effect<Response, HttpStatusError> =>
   response.ok
     ? Effect.succeed(response)
-    : Effect.tryPromise({
-        try: () => response.json() as Promise<{ detail?: string }>,
-        catch: () => ({ detail: undefined }),
-      }).pipe(
-        Effect.catchAll(() => Effect.succeed({ detail: undefined })),
+    : Effect.promise(() =>
+        response.json().catch(() => undefined as unknown),
+      ).pipe(
         Effect.flatMap(body =>
           Effect.fail(
             new HttpStatusError({
               status: response.status,
-              detail: body.detail,
+              detail: extractDetail(body),
             }),
           ),
         ),
@@ -58,30 +69,34 @@ export const postJson = <A>(
   url: string,
   body: unknown,
   init?: RequestInit,
-): Effect.Effect<A, NetworkError | HttpStatusError | JsonParseError> => {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  }
+): Effect.Effect<
+  A,
+  NetworkError | HttpStatusError | JsonParseError | JsonSerializeError
+> => {
+  const merged = new Headers(init?.headers)
+  merged.set("Content-Type", "application/json")
+  const headers = Object.fromEntries(merged.entries())
 
-  if (init?.headers) {
-    const entries =
-      init.headers instanceof Headers
-        ? Array.from(init.headers.entries())
-        : Array.isArray(init.headers)
-          ? init.headers
-          : Object.entries(init.headers)
-    for (const [key, value] of entries) {
-      headers[key] = value
-    }
-  }
-
-  return fetchJson(url, {
-    ...init,
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  })
+  return Effect.try({
+    try: () => JSON.stringify(body),
+    catch: cause => new JsonSerializeError({ cause }),
+  }).pipe(
+    Effect.flatMap(serialized =>
+      fetchJson(url, {
+        ...init,
+        method: "POST",
+        headers,
+        body: serialized,
+      }),
+    ),
+  )
 }
+
+export const fetchStreamChecked = (
+  url: string,
+  init?: RequestInit,
+): Effect.Effect<Response, NetworkError | HttpStatusError> =>
+  request(url, init).pipe(Effect.flatMap(ensureOk))
 
 export const postEmpty = (
   url: string,

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,0 +1,93 @@
+import { Data, Effect } from "effect"
+
+export class NetworkError extends Data.TaggedError("NetworkError")<{
+  readonly cause: unknown
+}> {}
+
+export class HttpStatusError extends Data.TaggedError("HttpStatusError")<{
+  readonly status: number
+  readonly detail?: string | undefined
+}> {}
+
+export class JsonParseError extends Data.TaggedError("JsonParseError")<{
+  readonly cause: unknown
+}> {}
+
+const request = (
+  url: string,
+  init?: RequestInit,
+): Effect.Effect<Response, NetworkError> =>
+  Effect.tryPromise({
+    try: () => fetch(url, init),
+    catch: cause => new NetworkError({ cause }),
+  })
+
+const ensureOk = (
+  response: Response,
+): Effect.Effect<Response, HttpStatusError> =>
+  response.ok
+    ? Effect.succeed(response)
+    : Effect.tryPromise({
+        try: () => response.json() as Promise<{ detail?: string }>,
+        catch: () => ({ detail: undefined }),
+      }).pipe(
+        Effect.catchAll(() => Effect.succeed({ detail: undefined })),
+        Effect.flatMap(body =>
+          Effect.fail(
+            new HttpStatusError({
+              status: response.status,
+              detail: body.detail,
+            }),
+          ),
+        ),
+      )
+
+const parseJson = <A>(response: Response): Effect.Effect<A, JsonParseError> =>
+  Effect.tryPromise({
+    try: () => response.json() as Promise<A>,
+    catch: cause => new JsonParseError({ cause }),
+  })
+
+export const fetchJson = <A>(
+  url: string,
+  init?: RequestInit,
+): Effect.Effect<A, NetworkError | HttpStatusError | JsonParseError> =>
+  request(url, init).pipe(Effect.flatMap(ensureOk), Effect.flatMap(parseJson))
+
+export const postJson = <A>(
+  url: string,
+  body: unknown,
+  init?: RequestInit,
+): Effect.Effect<A, NetworkError | HttpStatusError | JsonParseError> => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+
+  if (init?.headers) {
+    const entries =
+      init.headers instanceof Headers
+        ? Array.from(init.headers.entries())
+        : Array.isArray(init.headers)
+          ? init.headers
+          : Object.entries(init.headers)
+    for (const [key, value] of entries) {
+      headers[key] = value
+    }
+  }
+
+  return fetchJson(url, {
+    ...init,
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+export const postEmpty = (
+  url: string,
+  init?: RequestInit,
+): Effect.Effect<void, NetworkError | HttpStatusError> =>
+  request(url, { ...init, method: "POST" }).pipe(
+    Effect.flatMap(ensureOk),
+    Effect.asVoid,
+  )

--- a/frontend/src/services/hyperliquid.test.ts
+++ b/frontend/src/services/hyperliquid.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from "vitest"
+import * as Effect from "effect/Effect"
+import {
+  getBalance,
+  getAccountSummary,
+  getCurrentPositions,
+  getFundingRates,
+  rebalancePositions,
+  WalletNotConnected,
+  ExchangeRequestError,
+} from "./hyperliquid"
+import type { HyperliquidClient, OrderResult } from "./hyperliquid-client"
+import type { RebalanceAction } from "@/pages/Portfolio/hooks/portfolioRebalancer"
+
+const createMockClient = (
+  overrides: Partial<HyperliquidClient> = {},
+): HyperliquidClient =>
+  ({
+    getBalance: vi.fn(),
+    getAccountSummary: vi.fn(),
+    getCurrentPositions: vi.fn(),
+    getFundingRates: vi.fn(),
+    rebalancePositions: vi.fn(),
+    getNetworkMode: vi.fn(),
+    getWalletAddress: vi.fn(),
+    ...overrides,
+  }) as unknown as HyperliquidClient
+
+const failureError = async <E>(
+  effect: Effect.Effect<unknown, E>,
+): Promise<E> => {
+  const exit = await Effect.runPromiseExit(effect)
+  if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+    return exit.cause.error
+  }
+  throw new Error(`expected a tagged failure, got: ${JSON.stringify(exit)}`)
+}
+
+describe("hyperliquid Effect service", () => {
+  describe("WalletNotConnected", () => {
+    it("fails with WalletNotConnected when client is null", async () => {
+      const error = await failureError(getBalance(null))
+      expect(error).toBeInstanceOf(WalletNotConnected)
+      expect(error._tag).toBe("WalletNotConnected")
+    })
+
+    it("fails with WalletNotConnected for every operation when client is null", async () => {
+      const nullClientOperations = [
+        getBalance(null),
+        getAccountSummary(null),
+        getCurrentPositions(null),
+        getFundingRates(null),
+        rebalancePositions(null, []),
+      ]
+
+      for (const operation of nullClientOperations) {
+        const error = await failureError(operation)
+        expect(error).toBeInstanceOf(WalletNotConnected)
+      }
+    })
+  })
+
+  describe("delegation to HyperliquidClient", () => {
+    it("getBalance delegates and returns result", async () => {
+      const mockClient = createMockClient({
+        getBalance: vi.fn().mockResolvedValue(1500.5),
+      })
+
+      const result = await Effect.runPromise(getBalance(mockClient))
+
+      expect(result).toBe(1500.5)
+      expect(mockClient.getBalance).toHaveBeenCalled()
+    })
+
+    it("getAccountSummary delegates and returns result", async () => {
+      const summary = {
+        accountValue: 1000,
+        totalNotionalPosition: 2000,
+        withdrawable: 500,
+      }
+      const mockClient = createMockClient({
+        getAccountSummary: vi.fn().mockResolvedValue(summary),
+      })
+
+      const result = await Effect.runPromise(getAccountSummary(mockClient))
+
+      expect(result).toEqual(summary)
+    })
+
+    it("getCurrentPositions delegates and returns result", async () => {
+      const positions = [
+        {
+          symbol: "BTC/USDC:USDC",
+          side: "buy" as const,
+          notional: 500,
+          entryPrice: 45000,
+          unrealizedPnl: 50,
+          leverage: 2,
+        },
+      ]
+      const mockClient = createMockClient({
+        getCurrentPositions: vi.fn().mockResolvedValue(positions),
+      })
+
+      const result = await Effect.runPromise(getCurrentPositions(mockClient))
+
+      expect(result).toEqual(positions)
+    })
+
+    it("getFundingRates delegates and returns result", async () => {
+      const rates = { BTC: 0.0001, ETH: -0.0002 }
+      const mockClient = createMockClient({
+        getFundingRates: vi.fn().mockResolvedValue(rates),
+      })
+
+      const result = await Effect.runPromise(getFundingRates(mockClient))
+
+      expect(result).toEqual(rates)
+    })
+
+    it("rebalancePositions delegates the actions and returns the orders", async () => {
+      const orders: OrderResult[] = [
+        { symbol: "BTC/USDC:USDC", side: "buy", status: "filled" },
+      ]
+      const mockRebalance = vi.fn().mockResolvedValue(orders)
+      const mockClient = createMockClient({
+        rebalancePositions: mockRebalance,
+      })
+
+      const actions: RebalanceAction[] = [
+        {
+          kind: "rebalance",
+          symbol: "BTC/USDC:USDC",
+          signedNotionalDelta: 100,
+          leverage: 2,
+          leverageChanged: false,
+        },
+      ]
+
+      const result = await Effect.runPromise(
+        rebalancePositions(mockClient, actions),
+      )
+
+      expect(result).toEqual(orders)
+      expect(mockRebalance).toHaveBeenCalledWith(actions)
+    })
+  })
+
+  describe("error wrapping", () => {
+    it("wraps exchange exceptions as ExchangeRequestError", async () => {
+      const ccxtError = new Error("Exchange timeout")
+      const mockClient = createMockClient({
+        getBalance: vi.fn().mockRejectedValue(ccxtError),
+      })
+
+      const error = await failureError(getBalance(mockClient))
+
+      expect(error).toBeInstanceOf(ExchangeRequestError)
+      expect((error as ExchangeRequestError).cause).toBe(ccxtError)
+    })
+  })
+})

--- a/frontend/src/services/hyperliquid.test.ts
+++ b/frontend/src/services/hyperliquid.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest"
+import * as Effect from "effect/Effect"
+import {
+  getBalance,
+  getAccountSummary,
+  getCurrentPositions,
+  listPerpTickers,
+  getLeverageLimits,
+  getFundingRates,
+  rebalancePositions,
+  WalletNotConnected,
+  ExchangeRequestError,
+} from "./hyperliquid"
+import type { HyperliquidClient } from "./hyperliquid-client"
+
+const createMockClient = (
+  overrides: Partial<HyperliquidClient> = {},
+): HyperliquidClient =>
+  ({
+    getBalance: vi.fn(),
+    getAccountSummary: vi.fn(),
+    getCurrentPositions: vi.fn(),
+    listPerpTickers: vi.fn(),
+    getLeverageLimits: vi.fn(),
+    getFundingRates: vi.fn(),
+    rebalancePositions: vi.fn(),
+    getNetworkMode: vi.fn(),
+    getWalletAddress: vi.fn(),
+    ...overrides,
+  }) as unknown as HyperliquidClient
+
+describe("hyperliquid Effect service", () => {
+  describe("WalletNotConnected", () => {
+    it("fails with WalletNotConnected when client is null", async () => {
+      const exit = await Effect.runPromiseExit(getBalance(null))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+        expect(exit.cause.error).toBeInstanceOf(WalletNotConnected)
+        expect(exit.cause.error._tag).toBe("WalletNotConnected")
+      }
+    })
+
+    it("fails for all operations when client is null", async () => {
+      const operations = [
+        getBalance(null),
+        getAccountSummary(null),
+        getCurrentPositions(null),
+        listPerpTickers(null),
+        getLeverageLimits(null),
+        getFundingRates(null),
+        rebalancePositions(null, [], 1000, 1, false),
+      ]
+
+      for (const operation of operations) {
+        const exit = await Effect.runPromiseExit(operation)
+        expect(exit._tag).toBe("Failure")
+      }
+    })
+  })
+
+  describe("delegation to HyperliquidClient", () => {
+    it("getBalance delegates and returns result", async () => {
+      const mockClient = createMockClient({
+        getBalance: vi.fn().mockResolvedValue(1500.5),
+      })
+
+      const result = await Effect.runPromise(getBalance(mockClient))
+
+      expect(result).toBe(1500.5)
+      expect(mockClient.getBalance).toHaveBeenCalled()
+    })
+
+    it("getAccountSummary delegates and returns result", async () => {
+      const summary = {
+        accountValue: 1000,
+        totalNotionalPosition: 2000,
+        withdrawable: 500,
+      }
+      const mockClient = createMockClient({
+        getAccountSummary: vi.fn().mockResolvedValue(summary),
+      })
+
+      const result = await Effect.runPromise(getAccountSummary(mockClient))
+
+      expect(result).toEqual(summary)
+    })
+
+    it("getCurrentPositions delegates and returns result", async () => {
+      const positions = [
+        {
+          symbol: "BTC/USDC:USDC",
+          side: "buy" as const,
+          notional: 500,
+          entryPrice: 45000,
+          unrealizedPnl: 50,
+          leverage: 2,
+        },
+      ]
+      const mockClient = createMockClient({
+        getCurrentPositions: vi.fn().mockResolvedValue(positions),
+      })
+
+      const result = await Effect.runPromise(getCurrentPositions(mockClient))
+
+      expect(result).toEqual(positions)
+    })
+
+    it("listPerpTickers delegates and returns result", async () => {
+      const tickers = ["BTC/USDC:USDC", "ETH/USDC:USDC"]
+      const mockClient = createMockClient({
+        listPerpTickers: vi.fn().mockResolvedValue(tickers),
+      })
+
+      const result = await Effect.runPromise(listPerpTickers(mockClient))
+
+      expect(result).toEqual(tickers)
+    })
+
+    it("getLeverageLimits delegates and returns result", async () => {
+      const limits = [{ symbol: "BTC/USDC:USDC", maxLeverage: 50 }]
+      const mockClient = createMockClient({
+        getLeverageLimits: vi.fn().mockResolvedValue(limits),
+      })
+
+      const result = await Effect.runPromise(getLeverageLimits(mockClient))
+
+      expect(result).toEqual(limits)
+    })
+
+    it("getFundingRates delegates and returns result", async () => {
+      const rates = { BTC: 0.0001, ETH: -0.0002 }
+      const mockClient = createMockClient({
+        getFundingRates: vi.fn().mockResolvedValue(rates),
+      })
+
+      const result = await Effect.runPromise(getFundingRates(mockClient))
+
+      expect(result).toEqual(rates)
+    })
+
+    it("rebalancePositions passes all parameters", async () => {
+      const orders = [
+        {
+          symbol: "BTC/USDC:USDC",
+          side: "buy" as const,
+          percentage: 0.5,
+          status: "filled" as const,
+        },
+      ]
+      const mockRebalance = vi.fn().mockResolvedValue(orders)
+      const mockClient = createMockClient({
+        rebalancePositions: mockRebalance,
+      })
+
+      const positions = [
+        {
+          symbol: "BTC/USDC:USDC",
+          percentage: 0.5,
+          side: "buy" as const,
+          leverage: 2,
+          leverageChanged: false,
+          status: "modified" as const,
+        },
+      ]
+
+      const result = await Effect.runPromise(
+        rebalancePositions(mockClient, positions, 1000, 2, true),
+      )
+
+      expect(result).toEqual(orders)
+      expect(mockRebalance).toHaveBeenCalledWith(positions, 1000, 2, true)
+    })
+  })
+
+  describe("error wrapping", () => {
+    it("wraps exchange exceptions as ExchangeRequestError", async () => {
+      const ccxtError = new Error("Exchange timeout")
+      const mockClient = createMockClient({
+        getBalance: vi.fn().mockRejectedValue(ccxtError),
+      })
+
+      const exit = await Effect.runPromiseExit(getBalance(mockClient))
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+        expect(exit.cause.error).toBeInstanceOf(ExchangeRequestError)
+        expect((exit.cause.error as ExchangeRequestError).cause).toBe(ccxtError)
+      }
+    })
+  })
+})

--- a/frontend/src/services/hyperliquid.ts
+++ b/frontend/src/services/hyperliquid.ts
@@ -1,0 +1,121 @@
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import type {
+  HyperliquidClient,
+  CurrentPosition,
+  LeverageLimit,
+  OrderResult,
+  Position,
+} from "./hyperliquid-client"
+
+export class WalletNotConnected extends Data.TaggedError("WalletNotConnected")<
+  Record<string, never>
+> {}
+
+export class ExchangeRequestError extends Data.TaggedError(
+  "ExchangeRequestError",
+)<{
+  readonly cause: unknown
+}> {}
+
+export class PriceFetchError extends Data.TaggedError("PriceFetchError")<{
+  readonly symbol: string
+  readonly cause: unknown
+}> {}
+
+const wrapExchange = <A>(
+  fn: () => Promise<A>,
+): Effect.Effect<A, ExchangeRequestError> =>
+  Effect.tryPromise({
+    try: fn,
+    catch: cause => new ExchangeRequestError({ cause }),
+  })
+
+const requireClient = (
+  client: HyperliquidClient | null,
+): Effect.Effect<HyperliquidClient, WalletNotConnected> =>
+  client ? Effect.succeed(client) : Effect.fail(new WalletNotConnected())
+
+export const getBalance = (
+  client: HyperliquidClient | null,
+): Effect.Effect<number, WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid => wrapExchange(() => hyperliquid.getBalance())),
+  )
+
+export interface AccountSummary {
+  accountValue: number
+  totalNotionalPosition: number
+  withdrawable: number
+}
+
+export const getAccountSummary = (
+  client: HyperliquidClient | null,
+): Effect.Effect<AccountSummary, WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getAccountSummary()),
+    ),
+  )
+
+export const getCurrentPositions = (
+  client: HyperliquidClient | null,
+): Effect.Effect<
+  CurrentPosition[],
+  WalletNotConnected | ExchangeRequestError
+> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getCurrentPositions()),
+    ),
+  )
+
+export const listPerpTickers = (
+  client: HyperliquidClient | null,
+): Effect.Effect<string[], WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.listPerpTickers()),
+    ),
+  )
+
+export const getLeverageLimits = (
+  client: HyperliquidClient | null,
+): Effect.Effect<LeverageLimit[], WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getLeverageLimits()),
+    ),
+  )
+
+export const getFundingRates = (
+  client: HyperliquidClient | null,
+): Effect.Effect<
+  Record<string, number>,
+  WalletNotConnected | ExchangeRequestError
+> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getFundingRates()),
+    ),
+  )
+
+export const rebalancePositions = (
+  client: HyperliquidClient | null,
+  positions: Position[],
+  accountValue: number,
+  crossAccountLeverage: number,
+  precise: boolean,
+): Effect.Effect<OrderResult[], WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() =>
+        hyperliquid.rebalancePositions(
+          positions,
+          accountValue,
+          crossAccountLeverage,
+          precise,
+        ),
+      ),
+    ),
+  )

--- a/frontend/src/services/hyperliquid.ts
+++ b/frontend/src/services/hyperliquid.ts
@@ -1,0 +1,87 @@
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import type {
+  HyperliquidClient,
+  CurrentPosition,
+  OrderResult,
+} from "./hyperliquid-client"
+import type { RebalanceAction } from "@/pages/Portfolio/hooks/portfolioRebalancer"
+
+export class WalletNotConnected extends Data.TaggedError("WalletNotConnected")<
+  Record<string, never>
+> {}
+
+export class ExchangeRequestError extends Data.TaggedError(
+  "ExchangeRequestError",
+)<{
+  readonly cause: unknown
+}> {}
+
+const wrapExchange = <A>(
+  fn: () => Promise<A>,
+): Effect.Effect<A, ExchangeRequestError> =>
+  Effect.tryPromise({
+    try: fn,
+    catch: cause => new ExchangeRequestError({ cause }),
+  })
+
+const requireClient = (
+  client: HyperliquidClient | null,
+): Effect.Effect<HyperliquidClient, WalletNotConnected> =>
+  client ? Effect.succeed(client) : Effect.fail(new WalletNotConnected())
+
+export const getBalance = (
+  client: HyperliquidClient | null,
+): Effect.Effect<number, WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid => wrapExchange(() => hyperliquid.getBalance())),
+  )
+
+export interface AccountSummary {
+  accountValue: number
+  totalNotionalPosition: number
+  withdrawable: number
+}
+
+export const getAccountSummary = (
+  client: HyperliquidClient | null,
+): Effect.Effect<AccountSummary, WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getAccountSummary()),
+    ),
+  )
+
+export const getCurrentPositions = (
+  client: HyperliquidClient | null,
+): Effect.Effect<
+  CurrentPosition[],
+  WalletNotConnected | ExchangeRequestError
+> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getCurrentPositions()),
+    ),
+  )
+
+export const getFundingRates = (
+  client: HyperliquidClient | null,
+): Effect.Effect<
+  Record<string, number>,
+  WalletNotConnected | ExchangeRequestError
+> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.getFundingRates()),
+    ),
+  )
+
+export const rebalancePositions = (
+  client: HyperliquidClient | null,
+  actions: RebalanceAction[],
+): Effect.Effect<OrderResult[], WalletNotConnected | ExchangeRequestError> =>
+  requireClient(client).pipe(
+    Effect.flatMap(hyperliquid =>
+      wrapExchange(() => hyperliquid.rebalancePositions(actions)),
+    ),
+  )

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -23,6 +23,7 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "plugins": [{ "name": "@effect/language-service" }],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Motivation

Raw `throw` and string-based error handling make failure modes
indistinguishable — a disconnected wallet, an exchange API failure, and a network
error all look the same, forcing callers to parse error messages to react.

## Solution

Adopt Effect's typed error channels: each async operation returns `Effect<A, E>`
where `E` is a discriminated union of tagged errors, so callers pattern-match on
`_tag` instead of parsing strings.
