### PR TITLE
rename single-letter variables to descriptive names

### DIFF
--- a/frontend/src/pages/Prototype/components/FactorsTab.tsx
+++ b/frontend/src/pages/Prototype/components/FactorsTab.tsx
@@ -78,7 +78,7 @@ export const FactorsTab = (props: FactorsTabProps) => {
 
     for (const factor of factors) {
       const factorData = props.factorHistoricalReturns.filter(
-        r => r.factor === factor,
+        record => record.factor === factor,
       )
       const series = chart.addSeries(LineSeries, {
         color: FACTOR_CHART_COLORS[factor] ?? "#888",

--- a/frontend/src/pages/Prototype/components/MetricSelector.tsx
+++ b/frontend/src/pages/Prototype/components/MetricSelector.tsx
@@ -67,7 +67,7 @@ export const MetricSelector = (props: MetricSelectorProps) => {
 
       if (!props.isOpen && needsWindow()) {
         const currentIndex = WINDOW_OPTIONS.findIndex(
-          w => w.id === props.selectedWindowId,
+          windowOption => windowOption.id === props.selectedWindowId,
         )
         if (event.key === "ArrowLeft" || event.key === "h") {
           event.preventDefault()

--- a/frontend/src/pages/Prototype/components/RiskTab.tsx
+++ b/frontend/src/pages/Prototype/components/RiskTab.tsx
@@ -38,9 +38,9 @@ export const RiskTab = (props: RiskTabProps) => {
 
   const getCorrelation = (a1: string, a2: string): number => {
     const entry = props.correlationMatrix.find(
-      e =>
-        (e.asset1 === a1 && e.asset2 === a2) ||
-        (e.asset1 === a2 && e.asset2 === a1),
+      correlationEntry =>
+        (correlationEntry.asset1 === a1 && correlationEntry.asset2 === a2) ||
+        (correlationEntry.asset1 === a2 && correlationEntry.asset2 === a1),
     )
     return entry?.correlation ?? 0
   }

--- a/frontend/src/pages/Prototype/index.tsx
+++ b/frontend/src/pages/Prototype/index.tsx
@@ -232,10 +232,10 @@ const PrototypePage = () => {
     })
 
     const hexToRgba = (hex: string, alpha: number) => {
-      const r = parseInt(hex.slice(1, 3), 16)
-      const g = parseInt(hex.slice(3, 5), 16)
-      const b = parseInt(hex.slice(5, 7), 16)
-      return `rgba(${r}, ${g}, ${b}, ${alpha})`
+      const red = parseInt(hex.slice(1, 3), 16)
+      const green = parseInt(hex.slice(3, 5), 16)
+      const blue = parseInt(hex.slice(5, 7), 16)
+      return `rgba(${red}, ${green}, ${blue}, ${alpha})`
     }
 
     for (const metric of metrics) {
@@ -301,7 +301,7 @@ const PrototypePage = () => {
 
   const greeksMap = createMemo(() => {
     const map = new Map<string, (typeof greeks)[0]>()
-    for (const g of greeks) map.set(g.symbol, g)
+    for (const greek of greeks) map.set(greek.symbol, greek)
     return map
   })
 

--- a/frontend/src/pages/Prototype/metrics/computations.ts
+++ b/frontend/src/pages/Prototype/metrics/computations.ts
@@ -60,13 +60,15 @@ export const computeRollingSharpe = (
   const annualizationFactor = Math.sqrt(252)
   const result: TimeSeriesPoint[] = []
 
-  for (let i = windowDays - 1; i < returns.length; i++) {
-    const window = returns.slice(i - windowDays + 1, i + 1).map(p => p.value)
+  for (let index = windowDays - 1; index < returns.length; index++) {
+    const window = returns
+      .slice(index - windowDays + 1, index + 1)
+      .map(point => point.value)
     const mean = computeRollingMean(window)
     const std = computeRollingStd(window, mean)
     const sharpe = std > 0 ? (mean / std) * annualizationFactor : 0
 
-    result.push({ time: returns[i].time, value: sharpe })
+    result.push({ time: returns[index].time, value: sharpe })
   }
 
   return result
@@ -82,14 +84,16 @@ export const computeRollingSortino = (
   const annualizationFactor = Math.sqrt(252)
   const result: TimeSeriesPoint[] = []
 
-  for (let i = windowDays - 1; i < returns.length; i++) {
-    const window = returns.slice(i - windowDays + 1, i + 1).map(p => p.value)
+  for (let index = windowDays - 1; index < returns.length; index++) {
+    const window = returns
+      .slice(index - windowDays + 1, index + 1)
+      .map(point => point.value)
     const mean = computeRollingMean(window)
     const downsideStd = computeRollingDownsideStd(window, 0)
     const sortino =
       downsideStd > 0 ? (mean / downsideStd) * annualizationFactor : 0
 
-    result.push({ time: returns[i].time, value: sortino })
+    result.push({ time: returns[index].time, value: sortino })
   }
 
   return result
@@ -105,12 +109,14 @@ export const computeRollingVolatility = (
   const annualizationFactor = Math.sqrt(252)
   const result: TimeSeriesPoint[] = []
 
-  for (let i = windowDays - 1; i < returns.length; i++) {
-    const window = returns.slice(i - windowDays + 1, i + 1).map(p => p.value)
+  for (let index = windowDays - 1; index < returns.length; index++) {
+    const window = returns
+      .slice(index - windowDays + 1, index + 1)
+      .map(point => point.value)
     const mean = computeRollingMean(window)
     const std = computeRollingStd(window, mean)
 
-    result.push({ time: returns[i].time, value: std * annualizationFactor })
+    result.push({ time: returns[index].time, value: std * annualizationFactor })
   }
 
   return result

--- a/frontend/src/pages/Prototype/mockData.ts
+++ b/frontend/src/pages/Prototype/mockData.ts
@@ -323,9 +323,9 @@ const generateBacktestData = (): BacktestPoint[] => {
   const points: BacktestPoint[] = []
   let value = 10000
 
-  for (let i = 365; i >= 0; i--) {
+  for (let dayOffset = 365; dayOffset >= 0; dayOffset--) {
     const dayMs = 24 * 60 * 60 * 1000
-    const time = Math.floor((now - i * dayMs) / 1000)
+    const time = Math.floor((now - dayOffset * dayMs) / 1000)
     const dailyReturn = (Math.random() - 0.48) * 0.03
     value = value * (1 + dailyReturn)
     points.push({ time, value })
@@ -771,8 +771,8 @@ const generateFactorHistoricalReturns = (): FactorHistoricalReturn[] => {
 
   for (const factor of factors) {
     let cumulativeReturn = 1
-    for (let i = 365; i >= 0; i--) {
-      const time = Math.floor((now - i * dayMs) / 1000)
+    for (let dayOffset = 365; dayOffset >= 0; dayOffset--) {
+      const time = Math.floor((now - dayOffset * dayMs) / 1000)
       const dailyReturn =
         factorDrifts[factor] +
         (Math.random() - 0.5) * factorVolatilities[factor]
@@ -833,10 +833,10 @@ const generateReturnDistribution = (): ReturnDistributionBucket[] => {
   const buckets: Map<number, number> = new Map()
   const bucketSize = 0.005
 
-  for (let i = 1; i < MOCK_BACKTEST_DATA.length; i++) {
+  for (let index = 1; index < MOCK_BACKTEST_DATA.length; index++) {
     const dailyReturn =
-      (MOCK_BACKTEST_DATA[i].value - MOCK_BACKTEST_DATA[i - 1].value) /
-      MOCK_BACKTEST_DATA[i - 1].value
+      (MOCK_BACKTEST_DATA[index].value - MOCK_BACKTEST_DATA[index - 1].value) /
+      MOCK_BACKTEST_DATA[index - 1].value
     const bucket = Math.round(dailyReturn / bucketSize) * bucketSize
     buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1)
   }

--- a/frontend/src/pages/Prototype/utils/keyboard.ts
+++ b/frontend/src/pages/Prototype/utils/keyboard.ts
@@ -9,7 +9,9 @@ type KeyBinding = {
 const createKeyboardHandler =
   (bindings: KeyBinding[]) => (event: KeyboardEvent) => {
     const binding = bindings.find(
-      b => b.key === event.key && (b.when === undefined || b.when()),
+      candidate =>
+        candidate.key === event.key &&
+        (candidate.when === undefined || candidate.when()),
     )
     if (binding) {
       if (binding.preventDefault !== false) {

--- a/frontend/src/pages/Prototype/utils/portfolio.ts
+++ b/frontend/src/pages/Prototype/utils/portfolio.ts
@@ -76,8 +76,8 @@ export const filterAssetsByQuery = <T extends AssetWithSharpe>(
   query: string,
 ): T[] => {
   if (!query) return assets
-  const q = query.toLowerCase()
-  return assets.filter(a => a.ticker.toLowerCase().includes(q))
+  const lowerQuery = query.toLowerCase()
+  return assets.filter(asset => asset.ticker.toLowerCase().includes(lowerQuery))
 }
 
 export const sortAssetsBySharpe = <T extends AssetWithSharpe>(
@@ -90,9 +90,9 @@ export const lookupCorrelation = (
   asset2: string,
 ): number => {
   const entry = matrix.find(
-    e =>
-      (e.asset1 === asset1 && e.asset2 === asset2) ||
-      (e.asset1 === asset2 && e.asset2 === asset1),
+    candidate =>
+      (candidate.asset1 === asset1 && candidate.asset2 === asset2) ||
+      (candidate.asset1 === asset2 && candidate.asset2 === asset1),
   )
   return entry?.correlation ?? 0
 }
@@ -308,10 +308,10 @@ export const rebalanceWeights = (
   result.set(changedSymbol, newWeight)
 
   const otherSymbols = Array.from(currentWeights.keys()).filter(
-    s => s !== changedSymbol,
+    symbol => symbol !== changedSymbol,
   )
   const otherWeightsTotal = otherSymbols.reduce(
-    (sum, s) => sum + (currentWeights.get(s) ?? 0),
+    (sum, symbol) => sum + (currentWeights.get(symbol) ?? 0),
     0,
   )
 

--- a/frontend/src/pages/TokenPage/index.tsx
+++ b/frontend/src/pages/TokenPage/index.tsx
@@ -107,7 +107,7 @@ const TokenPage = (props: { timeframe: Timeframe }) => {
                     optionValue="value"
                     optionTextValue="label"
                     value={AVAILABLE_METRICS.find(
-                      m => m.value === selectedMetric(),
+                      metric => metric.value === selectedMetric(),
                     )}
                     onChange={option => {
                       if (option) {

--- a/frontend/src/pages/TokenPage/utils.ts
+++ b/frontend/src/pages/TokenPage/utils.ts
@@ -48,8 +48,8 @@ export const transformToLineData = (
   const uniqueData: { time: string; value: number }[] = []
   const timeSet = new Set<string>()
 
-  for (let i = processedData.length - 1; i >= 0; i--) {
-    const item = processedData[i]
+  for (let index = processedData.length - 1; index >= 0; index--) {
+    const item = processedData[index]
     if (!timeSet.has(item.time)) {
       timeSet.add(item.time)
       uniqueData.unshift(item)


### PR DESCRIPTION
## Motivation

Single-letter variable names (`t`, `r`, `p`, `e`, `m`, `i`) hide intent and make
code hard to read at a glance; the codebase enforces descriptive naming.

## Solution

Rename 28 single-letter variables across 12 files to descriptive names (arrow-fn
params, loop indices, local bindings) and codify the rule in AGENTS.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cleaned up several prototype and token page internals for clearer readability.
  * Improved variable naming in chart, metric selection, risk, keyboard, portfolio, and token data logic.
  * Updated rolling metric, mock data, and line-data calculations without changing results or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->