### PR TITLE
eliminate remaining raw throws and untyped fetch calls

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -87,3 +87,75 @@ Structure code around features and domain concepts, not technical layers.
   metrics code, export it from `metrics/registry.ts`
 
 This keeps related code discoverable and reduces import complexity.
+
+## 7. Effect for Error Handling
+
+All async operations use Effect for typed error channels. Raw `throw`,
+`Promise.reject`, and untyped `catch` blocks are not allowed in production code.
+
+### HTTP layer (`src/lib/http.ts`)
+
+Tagged error types:
+
+- `NetworkError` -- fetch itself failed (offline, DNS, CORS)
+- `HttpStatusError` -- response not ok (carries `status` and optional `detail`)
+- `JsonParseError` -- response body not valid JSON
+- `JsonSerializeError` -- `JSON.stringify` failed (e.g. circular references)
+
+Programs:
+
+- `fetchJson<A>(url, init?)` -- GET/generic request returning parsed JSON
+- `postJson<A>(url, body, init?)` -- POST with JSON body
+- `postEmpty(url, init?)` -- POST expecting no response body
+- `fetchStreamChecked(url, init?)` -- fetch with status check, returns raw
+  `Response` for streaming
+
+### Bridge to TanStack Query
+
+`Effect.runPromise(program)` inside `queryFn`. When the Effect fails,
+`runPromise` rejects with a typed error that has `_tag` -- components can
+pattern-match on `error._tag` instead of parsing strings.
+
+```ts
+queryFn: (({ signal }) => Effect.runPromise(fetchJson<T>(url, { signal })));
+```
+
+Always forward the `signal` from TanStack Query's context into the HTTP helpers.
+
+### Hyperliquid service (`src/services/hyperliquid.ts`)
+
+Wraps `HyperliquidClient` methods in Effect programs with typed errors:
+
+- `WalletNotConnected` -- no client available
+- `ExchangeRequestError` -- exchange API call failed
+
+Each function takes `client: HyperliquidClient | null` and returns an Effect.
+The null check is handled by `requireClient` which fails with
+`WalletNotConnected`.
+
+### Rules
+
+- **Import from submodules**: `import * as Effect from "effect/Effect"`, never
+  from the barrel `"effect"` (enforced by `@effect/eslint-plugin`)
+- **No raw fetch**: All HTTP calls go through `src/lib/http.ts`
+- **No throw/Promise.reject**: Use `Effect.fail` with a tagged error
+- **No try/catch**: Use `Effect.tryPromise` or `Effect.try`
+
+### Zero exceptions policy
+
+No new `throw`, `Promise.reject`, or `try/catch` in any code. Every failure must
+flow through Effect's typed error channel. The only permitted exceptions are:
+
+- **SolidJS context hooks** (`useWallet`, `useNetwork`, `useTheme`) -- the
+  framework requires a synchronous throw when a hook is called outside its
+  Provider. These are programmer errors, not runtime failures.
+- **App bootstrap** (`main.tsx`) -- throwing when the root DOM element is
+  missing is a fatal startup error.
+- **Imperative DOM library callbacks** (e.g. lightweight-charts in
+  `ChartComponent`) -- third-party libraries that don't support Effect. Catch at
+  the boundary and log; do not propagate.
+
+`HyperliquidClient` internals still use `throw` and `try/catch`, but these are
+fully contained by `wrapExchange` in the Effect service layer. New code inside
+`HyperliquidClient` must follow the same pattern -- any throw will be caught by
+`Effect.tryPromise` and surfaced as `ExchangeRequestError`.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -15,7 +15,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "decimal.js": "^10.6.0",
-        "effect": "^3.19.19",
+        "effect": "^3.21.4",
         "lightweight-charts": "^5.1.0",
         "lucide-solid": "^0.577.0",
         "multicoin-address-validator": "^0.5.26",
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@effect/eslint-plugin": "^0.3.2",
-        "@effect/language-service": "^0.79.0",
+        "@effect/language-service": "^0.86.2",
         "@eslint/js": "^9.25.0",
         "@solidjs/testing-library": "^0.8.10",
         "@tailwindcss/vite": "^4.1.8",
@@ -102,7 +102,7 @@
 
     "@effect/eslint-plugin": ["@effect/eslint-plugin@0.3.2", "", { "dependencies": { "@dprint/formatter": "^0.4.1", "@dprint/typescript": "^0.91.3", "prettier-linter-helpers": "^1.0.0" } }, "sha512-c4Vs9t3r54A4Zpl+wo8+PGzZz3JWYsip41H+UrebRLjQ2Hk/ap63IeCgN/HWcYtxtyhRopjp7gW9nOQ2Snbl+g=="],
 
-    "@effect/language-service": ["@effect/language-service@0.79.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-DEmIOsg1GjjP6s9HXH1oJrW+gDmzkhVv9WOZl6to5eNyyCrjz1S2PDqQ7aYrW/HuifhfwI5Bik1pK4pj7Z+lrg=="],
+    "@effect/language-service": ["@effect/language-service@0.86.2", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -572,7 +572,7 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "effect": ["effect@3.19.19", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg=="],
+    "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 

--- a/frontend/bun.nix
+++ b/frontend/bun.nix
@@ -117,9 +117,9 @@
     url = "https://registry.npmjs.org/@effect/eslint-plugin/-/eslint-plugin-0.3.2.tgz";
     hash = "sha512-c4Vs9t3r54A4Zpl+wo8+PGzZz3JWYsip41H+UrebRLjQ2Hk/ap63IeCgN/HWcYtxtyhRopjp7gW9nOQ2Snbl+g==";
   };
-  "@effect/language-service@0.79.0" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/language-service/-/language-service-0.79.0.tgz";
-    hash = "sha512-DEmIOsg1GjjP6s9HXH1oJrW+gDmzkhVv9WOZl6to5eNyyCrjz1S2PDqQ7aYrW/HuifhfwI5Bik1pK4pj7Z+lrg==";
+  "@effect/language-service@0.86.2" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/language-service/-/language-service-0.86.2.tgz";
+    hash = "sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg==";
   };
   "@emnapi/core@1.8.1" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz";
@@ -1105,9 +1105,9 @@
     url = "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz";
     hash = "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==";
   };
-  "effect@3.19.19" = fetchurl {
-    url = "https://registry.npmjs.org/effect/-/effect-3.19.19.tgz";
-    hash = "sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==";
+  "effect@3.21.4" = fetchurl {
+    url = "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz";
+    hash = "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==";
   };
   "electron-to-chromium@1.5.307" = fetchurl {
     url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "decimal.js": "^10.6.0",
-    "effect": "^3.19.19",
+    "effect": "^3.21.4",
     "lightweight-charts": "^5.1.0",
     "lucide-solid": "^0.577.0",
     "multicoin-address-validator": "^0.5.26",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@effect/eslint-plugin": "^0.3.2",
-    "@effect/language-service": "^0.79.0",
+    "@effect/language-service": "^0.86.2",
     "@eslint/js": "^9.25.0",
     "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/vite": "^4.1.8",

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,7 +1,16 @@
+import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/solid-query"
 import type { Timeframe } from "@/components/ui/timeframe-select"
 import { fetchJson, postJson, postEmpty, fetchStreamChecked } from "@/lib/http"
+
+export class MissingTickerError extends Data.TaggedError("MissingTickerError")<
+  Record<string, never>
+> {}
+
+export class EmptyStreamError extends Data.TaggedError("EmptyStreamError")<
+  Record<string, never>
+> {}
 
 export type TradingData = {
   timestamp: string
@@ -39,101 +48,125 @@ export interface AnalysisDataParams {
   timeframe: Timeframe
 }
 
-export const useDateRange = (timeframe: () => Timeframe) => {
-  return useQuery<DateRange>(() => ({
+const fetchDateRange = (timeframe: Timeframe, signal: AbortSignal) =>
+  fetchJson<DateRange>(`/api/date-range?timeframe=${timeframe}`, { signal })
+
+const fetchAnalysisData = (
+  timeframe: Timeframe,
+  startDate: string,
+  endDate: string,
+  signal: AbortSignal,
+) =>
+  postJson<{ data: TradingData[]; message: string | null }>(
+    `/api/data?timeframe=${timeframe}`,
+    {
+      start_date: `${startDate}T00:00:00Z`,
+      end_date: `${endDate}T23:59:59Z`,
+    },
+    { signal },
+  )
+
+const fetchTokenData = (
+  ticker: string | undefined,
+  timeframe: Timeframe,
+  signal: AbortSignal,
+) =>
+  Effect.Do.pipe(
+    Effect.bind("tickerValue", () =>
+      ticker ? Effect.succeed(ticker) : Effect.fail(new MissingTickerError()),
+    ),
+    Effect.flatMap(({ tickerValue }) =>
+      fetchJson<{ data: TradingData[]; message?: string }>(
+        `/api/token/${encodeURIComponent(tickerValue)}?timeframe=${timeframe}`,
+        { signal },
+      ),
+    ),
+    Effect.flatMap(tokenResponse =>
+      tokenResponse.message
+        ? Effect.fail(new Error(tokenResponse.message))
+        : Effect.succeed(tokenResponse),
+    ),
+  )
+
+const streamReload = (mode: string) =>
+  fetchStreamChecked("/api/reload_data/stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode }),
+  }).pipe(
+    Effect.flatMap(response =>
+      response.body
+        ? Effect.succeed(response.body)
+        : Effect.fail(new EmptyStreamError()),
+    ),
+    Effect.flatMap(body =>
+      Effect.tryPromise({
+        try: async () => {
+          const reader = body.getReader()
+          const decoder = new TextDecoder("utf-8")
+          try {
+            let done = false
+            while (!done) {
+              const readResult = await reader.read()
+              done = readResult.done
+              if (readResult.value) {
+                console.log(decoder.decode(readResult.value, { stream: true }))
+              }
+            }
+          } finally {
+            reader.releaseLock()
+          }
+        },
+        catch: cause => new Error(String(cause)),
+      }),
+    ),
+  )
+
+const fetchBudgetPreference = (signal: AbortSignal) =>
+  fetchJson<{ budget: number }>("/api/hyperliquid/budget-preference", {
+    signal,
+  })
+
+const saveBudgetPreference = (payload: { budget: number }) =>
+  postJson("/api/hyperliquid/budget-preference", payload).pipe(Effect.asVoid)
+
+export const useDateRange = (timeframe: () => Timeframe) =>
+  useQuery<DateRange>(() => ({
     queryKey: ["dateRange", timeframe()],
     queryFn: ({ signal }) =>
-      Effect.runPromise(
-        fetchJson<DateRange>(`/api/date-range?timeframe=${timeframe()}`, {
-          signal,
-        }),
-      ),
+      Effect.runPromise(fetchDateRange(timeframe(), signal)),
   }))
-}
 
-export const useAnalysisData = (params: () => AnalysisDataParams) => {
-  return useQuery<{ data: TradingData[]; message: string | null }>(() => {
+export const useAnalysisData = (params: () => AnalysisDataParams) =>
+  useQuery<{ data: TradingData[]; message: string | null }>(() => {
     const { startDate, endDate, timeframe } = params()
     return {
       queryKey: ["analysisData", timeframe, startDate, endDate],
       queryFn: ({ signal }) =>
         Effect.runPromise(
-          postJson<{ data: TradingData[]; message: string | null }>(
-            `/api/data?timeframe=${timeframe}`,
-            {
-              start_date: `${startDate}T00:00:00Z`,
-              end_date: `${endDate}T23:59:59Z`,
-            },
-            { signal },
-          ),
+          fetchAnalysisData(timeframe, startDate, endDate, signal),
         ),
       enabled: !!startDate && !!endDate,
     }
   })
-}
 
 export const useTokenData = (
   ticker: () => string | undefined,
   timeframe: () => Timeframe,
-) => {
-  return useQuery<{ data: TradingData[]; message?: string }>(() => ({
+) =>
+  useQuery<{ data: TradingData[]; message?: string }>(() => ({
     queryKey: ["tokenData", ticker(), timeframe()],
-    queryFn: ({ signal }) => {
-      const tickerValue = ticker()
-      if (!tickerValue) {
-        return Promise.reject(new Error("Ticker is required"))
-      }
-
-      return Effect.runPromise(
-        fetchJson<{ data: TradingData[]; message?: string }>(
-          `/api/token/${encodeURIComponent(tickerValue)}?timeframe=${timeframe()}`,
-          { signal },
-        ).pipe(
-          Effect.flatMap(tokenResponse =>
-            tokenResponse.message
-              ? Effect.fail(new Error(tokenResponse.message))
-              : Effect.succeed(tokenResponse),
-          ),
-        ),
-      )
-    },
+    queryFn: ({ signal }) =>
+      Effect.runPromise(fetchTokenData(ticker(), timeframe(), signal)),
     enabled: !!ticker(),
   }))
-}
 
 export const useReloadData = () => {
   const queryClient = useQueryClient()
 
   return useMutation(() => ({
-    mutationFn: async ({ mode }: { mode: string }) => {
-      const response = await Effect.runPromise(
-        fetchStreamChecked("/api/reload_data/stream", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ mode }),
-        }),
-      )
-
-      if (!response.body) {
-        throw new Error("No response body received")
-      }
-
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder("utf-8")
-
-      try {
-        let done = false
-        while (!done) {
-          const readResult = await reader.read()
-          done = readResult.done
-          if (readResult.value) {
-            console.log(decoder.decode(readResult.value, { stream: true }))
-          }
-        }
-      } finally {
-        reader.releaseLock()
-      }
-    },
+    mutationFn: ({ mode }: { mode: string }) =>
+      Effect.runPromise(streamReload(mode)),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["analysisData"] })
       void queryClient.invalidateQueries({ queryKey: ["tokenData"] })
@@ -142,34 +175,23 @@ export const useReloadData = () => {
   }))
 }
 
-export const useStopReload = () => {
-  return useMutation(() => ({
+export const useStopReload = () =>
+  useMutation(() => ({
     mutationFn: () => Effect.runPromise(postEmpty("/api/stop_reload")),
   }))
-}
 
-export const useBudgetPreference = () => {
-  return useQuery<{ budget: number }>(() => ({
+export const useBudgetPreference = () =>
+  useQuery<{ budget: number }>(() => ({
     queryKey: ["hyperliquid", "budget-preference"],
-    queryFn: ({ signal }) =>
-      Effect.runPromise(
-        fetchJson<{ budget: number }>("/api/hyperliquid/budget-preference", {
-          signal,
-        }),
-      ),
+    queryFn: ({ signal }) => Effect.runPromise(fetchBudgetPreference(signal)),
   }))
-}
 
 export const useSaveBudgetPreference = () => {
   const queryClient = useQueryClient()
 
   return useMutation(() => ({
     mutationFn: (payload: { budget: number }) =>
-      Effect.runPromise(
-        postJson("/api/hyperliquid/budget-preference", payload).pipe(
-          Effect.asVoid,
-        ),
-      ),
+      Effect.runPromise(saveBudgetPreference(payload)),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: ["hyperliquid", "budget-preference"],

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -12,6 +12,14 @@ export class EmptyStreamError extends Data.TaggedError("EmptyStreamError")<
   Record<string, never>
 > {}
 
+export class StreamReadError extends Data.TaggedError("StreamReadError")<{
+  readonly cause: unknown
+}> {}
+
+export class ApiMessageError extends Data.TaggedError("ApiMessageError")<{
+  readonly message: string
+}> {}
+
 export type TradingData = {
   timestamp: string
   close: number
@@ -83,7 +91,7 @@ const fetchTokenData = (
     ),
     Effect.flatMap(tokenResponse =>
       tokenResponse.message
-        ? Effect.fail(new Error(tokenResponse.message))
+        ? Effect.fail(new ApiMessageError({ message: tokenResponse.message }))
         : Effect.succeed(tokenResponse),
     ),
   )
@@ -117,7 +125,7 @@ const streamReload = (mode: string) =>
             reader.releaseLock()
           }
         },
-        catch: cause => new Error(String(cause)),
+        catch: cause => new StreamReadError({ cause }),
       }),
     ),
   )

--- a/frontend/src/pages/Portfolio/hooks/useBeta.ts
+++ b/frontend/src/pages/Portfolio/hooks/useBeta.ts
@@ -1,5 +1,7 @@
+import * as Effect from "effect/Effect"
 import { useQuery } from "@tanstack/solid-query"
 import { createMemo } from "solid-js"
+import { postJson } from "@/lib/http"
 import type { PortfolioInterface } from "./usePortfolioState"
 import type { ReadonlyBetaPosition } from "./useReadonlyPortfolioState"
 
@@ -72,22 +74,20 @@ interface BetaResponse {
   data_age_hours: number
 }
 
-const fetchBeta = async (
+const fetchBeta = (
   weights: Record<string, number>,
   benchmark: string,
   signal?: AbortSignal,
-): Promise<BetaResponse> => {
-  const res = await fetch(`${import.meta.env.BASE_URL}api/beta`, {
-    method: "POST",
-    signal: signal
-      ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
-      : AbortSignal.timeout(10_000),
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ weights, benchmark }),
-  })
-  if (!res.ok) throw new Error(`beta request failed: ${res.status}`)
-  return res.json() as Promise<BetaResponse>
-}
+) =>
+  postJson<BetaResponse>(
+    `${import.meta.env.BASE_URL}api/beta`,
+    { weights, benchmark },
+    {
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
+        : AbortSignal.timeout(10_000),
+    },
+  )
 
 export const useBeta = (
   portfolio: () => Record<string, PortfolioInterface | undefined>,
@@ -123,7 +123,9 @@ export const useBeta = (
     return {
       queryKey: ["beta", currentBenchmark.symbol, currentWeightsKey] as const,
       queryFn: (ctx: { signal: AbortSignal }) =>
-        fetchBeta(currentWeights, currentBenchmark.symbol, ctx.signal),
+        Effect.runPromise(
+          fetchBeta(currentWeights, currentBenchmark.symbol, ctx.signal),
+        ),
       enabled: hasData,
       retry: 2,
     }


### PR DESCRIPTION
## Motivation

After the Hyperliquid Effect migration, a few async paths still used raw `throw`,
`Promise.reject`, and untyped `fetch`, bypassing the typed error channel and
making those failures opaque to callers.

## Solution

Convert the remaining exception-based code to Effect programs — `Promise.reject`
becomes `Effect.fail` with a tagged `MissingTickerError`, a streaming `throw`
becomes `EmptyStreamError`, and the raw `fetch` is replaced with the typed
client.
