### PR TITLE
update project docs for current architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,9 +119,31 @@ Fix immediately. The user never sends messages just for the sake of it.
 
 Never add "Generated with [Tool Name]" to commits, PRs, or code.
 
-### PR descriptions
+### PR titles and descriptions
 
-Explain WHY the PR exists, not what changed.
+**Titles**: Lowercase, imperative, concise. Describe the outcome, not the
+mechanism. No prefixes like `feat:` or `fix:`.
+
+- Good: `migrate frontend from React to SolidJS`
+- Good: `replace exceptions with typed Effect errors`
+- Bad: `Add Effect library for functional HTTP error handling`
+- Bad: `Refactor API hooks to use Effect-based error handling`
+
+**Descriptions**: Two sections -- `## Why` and `## How`.
+
+- **Why**: The problem or motivation. Why does this PR exist?
+- **How**: High-level approach. Explain the solution, not the file changes --
+  the diff tab handles that. No file paths, no bullet lists of changes.
+
+```
+## Why
+
+<1-3 sentences explaining the problem or motivation>
+
+## How
+
+<1-3 sentences explaining the approach and key decisions>
+```
 
 ### Every PR is tracked by an issue and the roadmap
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,8 @@
 # Moneymentum Architecture Specification
 
+> **Where we're going.** For the practical path to get there, see
+> [ROADMAP.md](./ROADMAP.md).
+
 ## Terminology Standard
 
 Use proper financial terminology throughout--docs, code, UI. It's precise,
@@ -34,7 +37,7 @@ sizes. This matters because:
   action.
 - **Scaling is trivial**: Double your capital? Same weights, same risk profile.
   No need to recalculate position sizes.
-- **Leverage is explicit**: Total exposure = NAV (net asset value) × leverage. A
+- **Leverage is explicit**: Total exposure = NAV (net asset value) * leverage. A
   2x leveraged portfolio at 40/30/30 weights is immediately understandable.
 
 The alternative--thinking in position sizes ("2.5 BTC, 10 ETH")--obscures risk.
@@ -43,7 +46,7 @@ This tool enforces proportion-based thinking.
 
 ## Core Workflow
 
-**Monitor → Screen → Stage → Simulate → Execute → Repeat**
+**Monitor -> Screen -> Stage -> Simulate -> Execute -> Repeat**
 
 1. **Monitor**: Check how your portfolio is doing--performance, factor
    exposures, risk metrics
@@ -95,7 +98,7 @@ flowchart LR
     subgraph Turnkey["Turnkey (Policy Enforcement)"]
         direction TB
         POL[Policy Engine]
-        WALLET[Server Wallets]
+        WALLET[Enclave Wallets]
         POL --> WALLET
     end
 
@@ -125,7 +128,8 @@ plans). The frontend is a monitoring and control dashboard.
 
 **Turnkey server wallets** provide the custody layer with policy enforcement at
 the signing layer. The backend routes orders to venues but cannot withdraw funds
-or interact with non-whitelisted contracts.
+or interact with non-whitelisted contracts. Signing latency is 50-100ms with
+native Rust SDK support and explicit Hyperliquid EIP-712 compatibility.
 
 **Solana vault program** (Anchor) handles investor deposits/withdrawals, share
 token accounting, and fee deductions. Capital flows from the vault to Turnkey
@@ -139,7 +143,7 @@ total NAV, and posts signed attestations to the vault program.
 title: "Flow of Funds: Deposits, Rebalancing & Withdrawals"
 ---
 graph TB
-    subgraph Solana["── Solana ──"]
+    subgraph Solana["Solana"]
         Investor["Investor"]
         Vault["Vault Program<br/>─────────────<br/>share tokens<br/>fee accounting<br/>NAV attestations"]
         SOLWallet["Turnkey SOL Wallet<br/>(vault custody)"]
@@ -157,8 +161,8 @@ graph TB
         Vault -. "mgmt + perf fee" .-> PMFee
     end
 
-    subgraph Bridge["── deBridge ──"]
-        deBridge["Solana ↔ Hyperliquid<br/>direct USDC"]
+    subgraph Bridge["deBridge"]
+        deBridge["Solana <-> Hyperliquid<br/>direct USDC"]
     end
 
     subgraph Hyperliquid["── Hyperliquid L1 ──"]
@@ -169,7 +173,7 @@ graph TB
         HyperCore -- "withdraw USDC" --> EVMWallet
     end
 
-    subgraph DeriveChain["── Derive Chain ──"]
+    subgraph DeriveChain["Derive Chain"]
         DeriveDeposit["Derive Native Deposit<br/>from HyperEVM"]
         DeriveProtocol["Derive Protocol<br/>options"]
 

--- a/frontend/src/pages/Prototype/KEYBOARD_WORKFLOW_PLAN.md
+++ b/frontend/src/pages/Prototype/KEYBOARD_WORKFLOW_PLAN.md
@@ -4,14 +4,14 @@
 
 A user should be able to complete this ENTIRE flow using ONLY keyboard:
 
-1. **Open app** → Screener focused by default
-2. **Press `2`** → Focus positions panel
-3. **Press `j`/`k`** → Navigate to an underlying (BTC, ETH, etc.)
-4. **Press `o`** → Expand the underlying to see instruments
-5. **Press `j`/`k`** → Navigate to specific instrument (perp, spot, option)
-6. **Press `w`** → Start editing weight, type value, press Enter
-7. **Press `[` or `]`** → Adjust leverage (GLOBALLY, from any panel)
-8. **Press `x`** → Execute all staged trades
+1. **Open app** -> Screener focused by default
+2. **Press `2`** -> Focus positions panel
+3. **Press `j`/`k`** -> Navigate to an underlying (BTC, ETH, etc.)
+4. **Press `o`** -> Expand the underlying to see instruments
+5. **Press `j`/`k`** -> Navigate to specific instrument (perp, spot, option)
+6. **Press `w`** -> Start editing weight, type value, press Enter
+7. **Press `[` or `]`** -> Adjust leverage (GLOBALLY, from any panel)
+8. **Press `x`** -> Execute all staged trades
 
 NO MOUSE CLICKS ALLOWED.
 
@@ -54,11 +54,11 @@ NO MOUSE CLICKS ALLOWED.
 
 ## Implementation Order (TDD)
 
-1. ✅ Write failing test describing exact workflow
-2. ⏳ Add global `[`/`]` handlers for leverage
-3. ⏳ Add `x` handler for execute
-4. ⏳ Verify weight editing works with `w` key
-5. ⏳ Make test pass
+1. [x] Write failing test describing exact workflow
+2. [ ] Add global `[`/`]` handlers for leverage
+3. [ ] Add `x` handler for execute
+4. [ ] Verify weight editing works with `w` key
+5. [ ] Make test pass
 
 ## Progress Checkpoint
 


### PR DESCRIPTION
## Motivation

Project docs were stale and contradicted each other and the code — SPEC.md still
referenced Privy (replaced by Turnkey), README.md listed Python as the active
backend, and ROADMAP.md was a flat checklist instead of priority-ordered epics.

## Solution

Rewrite ROADMAP.md in epic format (WHY paragraphs, mermaid dependency graphs),
update SPEC.md for the Privy->Turnkey and React->SolidJS transitions, and update
the AGENTS.md/CLAUDE.md project direction.
