### PR TITLE
fix: allow close all positions

### DIFF
--- a/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanelAlerts.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanelAlerts.tsx
@@ -23,8 +23,19 @@ const ALLOCATION_FULL_MIN_PERCENT = 99.95
 export const PositionsPanelAlerts = (
   props: PositionsPanelAlertsProps,
 ): JSX.Element => {
+  const isClosingAllPositions = createMemo(
+    () =>
+      Object.values(props.currentPortfolio).some(
+        position => position !== undefined,
+      ) &&
+      Object.values(props.targetPortfolio).every(
+        position => position === undefined || position.notional <= 0.01,
+      ),
+  )
+
   const hasUnderAllocation = createMemo(
     () =>
+      !isClosingAllPositions() &&
       !props.hasTotalWeightExceeded &&
       props.targetAllocationPercent < ALLOCATION_FULL_MIN_PERCENT,
   )

--- a/frontend/src/pages/Portfolio/hooks/usePortfolioState.test.tsx
+++ b/frontend/src/pages/Portfolio/hooks/usePortfolioState.test.tsx
@@ -217,6 +217,29 @@ describe("usePortfolioState", () => {
     expect(result.canSubmit).toBe(true)
   })
 
+  it("allows submitting a full close to cash", async () => {
+    const { result } = renderHook(() => usePortfolioState(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(Object.keys(result.targetPortfolio)).toHaveLength(2)
+    })
+
+    result.setManualWeightEntry(true)
+    result.handleWeightChange("BTC/USDC:USDC", 0)
+    result.handleWeightChange("ETH/USDC:USDC", 0)
+
+    expect(result.targetAllocationPercent).toBe(0)
+    expect(result.symbolsBelowMinimum).toEqual([])
+    expect(result.symbolsDeltaBelowMinimum).toEqual([])
+    expect(result.canSubmit).toBe(true)
+
+    result.handleRebalancePositions()
+
+    expect(mutate).toHaveBeenCalled()
+  })
+
   it("redistributes other positions when weight redistribution is enabled", async () => {
     const { result } = renderHook(() => usePortfolioState(), {
       wrapper: createWrapper(),

--- a/frontend/src/pages/Portfolio/hooks/usePortfolioState.test.tsx
+++ b/frontend/src/pages/Portfolio/hooks/usePortfolioState.test.tsx
@@ -237,7 +237,29 @@ describe("usePortfolioState", () => {
 
     result.handleRebalancePositions()
 
-    expect(mutate).toHaveBeenCalled()
+    expect(mutate).toHaveBeenCalledWith({
+      actions: [
+        { kind: "close", symbol: "BTC/USDC:USDC", side: "buy" },
+        { kind: "close", symbol: "ETH/USDC:USDC", side: "buy" },
+      ],
+    })
+  })
+
+  it("allows full close when every target position is dust", async () => {
+    const { result } = renderHook(() => usePortfolioState(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(Object.keys(result.targetPortfolio)).toHaveLength(2)
+    })
+
+    result.handleNotionalChange("BTC/USDC:USDC", 0.006)
+    result.handleNotionalChange("ETH/USDC:USDC", 0.006)
+
+    expect(result.symbolsBelowMinimum).toEqual([])
+    expect(result.symbolsDeltaBelowMinimum).toEqual([])
+    expect(result.canSubmit).toBe(true)
   })
 
   it("redistributes other positions when weight redistribution is enabled", async () => {

--- a/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
+++ b/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
@@ -41,6 +41,7 @@ const initialManualWeightEntryFromStorage = (): boolean =>
 
 const MAX_CROSS_ACCOUNT_LEVERAGE = 5
 const DEFAULT_CROSS_ACCOUNT_LEVERAGE = 1
+const POSITION_CLOSE_EPSILON = 0.01
 
 export interface PortfolioInterface {
   symbol: string
@@ -182,9 +183,22 @@ export const usePortfolioState = () => {
     Object.values(currentPortfolio).some(position => position !== undefined),
   )
 
-  const isClosingAllPositions = createMemo(
-    () => hasCurrentPositions() && effectiveTotalNotional() <= 0.01,
-  )
+  const isClosingAllPositions = createMemo(() => {
+    if (!hasCurrentPositions()) return false
+
+    const symbols = new Set([
+      ...Object.keys(currentPortfolio),
+      ...Object.keys(targetPortfolio),
+    ])
+
+    return [...symbols].every(symbol => {
+      const targetPosition = targetPortfolio[symbol]
+      return (
+        targetPosition === undefined ||
+        targetPosition.notional <= POSITION_CLOSE_EPSILON
+      )
+    })
+  })
 
   const symbolsBelowMinimum = createMemo(() => {
     if (isClosingAllPositions()) return []

--- a/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
+++ b/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
@@ -171,8 +171,25 @@ export const usePortfolioState = () => {
     })
   }
 
-  const symbolsBelowMinimum = createMemo(() =>
-    Object.keys(targetPortfolio).filter(symbol => {
+  const effectiveTotalNotional = createMemo(() => {
+    return Object.values(targetPortfolio).reduce(
+      (sum, pos) => sum + (pos?.notional ?? 0),
+      0,
+    )
+  })
+
+  const hasCurrentPositions = createMemo(() =>
+    Object.values(currentPortfolio).some(position => position !== undefined),
+  )
+
+  const isClosingAllPositions = createMemo(
+    () => hasCurrentPositions() && effectiveTotalNotional() <= 0.01,
+  )
+
+  const symbolsBelowMinimum = createMemo(() => {
+    if (isClosingAllPositions()) return []
+
+    return Object.keys(targetPortfolio).filter(symbol => {
       const targetPosition = targetPortfolio[symbol]
       const currentNotional = currentPortfolio[symbol]?.notional ?? 0
 
@@ -183,11 +200,13 @@ export const usePortfolioState = () => {
         Math.abs(targetPosition.notional - currentNotional) < 0.01
 
       return !unchanged
-    }),
-  )
+    })
+  })
 
-  const symbolsDeltaBelowMinimum = createMemo(() =>
-    Object.keys(targetPortfolio).filter(symbol => {
+  const symbolsDeltaBelowMinimum = createMemo(() => {
+    if (isClosingAllPositions()) return []
+
+    return Object.keys(targetPortfolio).filter(symbol => {
       const target = targetPortfolio[symbol]
       if (!target) return false
 
@@ -203,8 +222,8 @@ export const usePortfolioState = () => {
       const delta = Math.abs(targetSignedNotional - currentSignedNotional)
 
       return delta < MIN_USD && delta !== 0
-    }),
-  )
+    })
+  })
 
   // Keep displayed target leverage in sync with planned target notional.
   createEffect(() => {
@@ -369,13 +388,6 @@ export const usePortfolioState = () => {
   })
 
   const hasPositionsBelowMinimum = () => symbolsBelowMinimum().length > 0
-  const effectiveTotalNotional = createMemo(() => {
-    return Object.values(targetPortfolio).reduce(
-      (sum, pos) => sum + (pos?.notional ?? 0),
-      0,
-    )
-  })
-
   const targetAllocationPercent = createMemo(() => {
     const total = targetTotalNotional()
     if (total <= 0) return 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Allocation under 100%" warning that appeared when closing all portfolio positions, reducing confusion during full liquidation scenarios.
  * Improved portfolio state calculations to correctly handle transitions to zero positions.

* **Tests**
  * Added test coverage for manual portfolio closing workflows to ensure rebalancing submission succeeds when moving to cash.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-cartel/moneymentum/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->