### PR TITLE
docs: pr tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,33 @@ Never add "Generated with [Tool Name]" to commits, PRs, or code.
 
 Explain WHY the PR exists, not what changed.
 
+### Every PR is tracked by an issue and the roadmap
+
+Every PR `Closes` a problem-only GitHub issue, and that issue is a checklist
+item in the relevant [ROADMAP.md](./ROADMAP.md) section linking the issue and
+the PR. Keep the roadmap in lockstep: the entry and its tick land on the feature
+PR itself, so the roadmap always matches what merged. The `pr-tracking` skill
+makes a whole stack conform.
+
+### Every stacked PR carries the GitButler stack footer
+
+Every PR that belongs to a multi-branch stack must carry the GitButler
+stack-navigation footer -- the
+`This is part X of N in a stack made with
+GitButler:` block (between the
+`<!-- GitButler Footer Boundary -->` markers) listing the stack's PRs
+top-to-bottom with the current one marked. It orients reviewers in the stack and
+links the sibling PRs.
+
+GitButler writes this footer when it opens or pushes a PR, but it **drifts**: a
+no-op push does not rewrite it, so after a rebase, a branch add/remove, or a
+merge it goes stale (lists merged PRs, wrong `N`, wrong position) or is missing
+entirely on PRs that were not opened through GitButler. There is no `but`
+command to refresh it. Keep every stacked PR's footer current by running
+`nix run .#pr-stack-footer` (`scripts/pr-stack-footer.nu`), which rebuilds each
+stack's footer from the live workspace and splices it into the PR bodies. Run it
+after any operation that reshapes the stack.
+
 ### Documentation stays in lockstep with the code
 
 Every PR must leave the documentation in a true state. Before handing off work

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -211,3 +211,29 @@ to DigitalOcean via NixOS + deploy-rs.
 - [x] Rolling beta calculation (`POST /beta`)
 - [x] Candle API (`GET /candles/<timeframe>`)
 - [x] Ingestion status API (`GET /ingestion/status`)
+
+---
+
+## Completed: GitButler CLI for stacked PRs
+
+- [x] Package the GitButler CLI via Nix --
+      [#243](https://github.com/data-cartel/moneymentum/issues/243) /
+      [#238](https://github.com/data-cartel/moneymentum/pull/238)
+- [x] Add a GitButler skill for coding agents --
+      [#244](https://github.com/data-cartel/moneymentum/issues/244) /
+      [#240](https://github.com/data-cartel/moneymentum/pull/240)
+
+## Completed: Finish Python/Spark removal
+
+- [x] Remove dead Python linter tooling --
+      [#245](https://github.com/data-cartel/moneymentum/issues/245) /
+      [#241](https://github.com/data-cartel/moneymentum/pull/241)
+- [x] Strip unused JVM/Spark deps from the dev shell --
+      [#246](https://github.com/data-cartel/moneymentum/issues/246) /
+      [#242](https://github.com/data-cartel/moneymentum/pull/242)
+
+## Completed: Per-PR issue and roadmap tracking
+
+- [x] Document and automate the issue-and-roadmap-per-PR rule --
+      [#247](https://github.com/data-cartel/moneymentum/issues/247) /
+      [#248](https://github.com/data-cartel/moneymentum/pull/248)

--- a/ai/skills/pr-tracking/SKILL.md
+++ b/ai/skills/pr-tracking/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pr-tracking
+description: "Make a stack of PRs fully tracked: every branch has a PR, every PR Closes a problem-only GitHub issue, every issue is a ticked roadmap item, all cross-linked. Use for: make sure each PR has an issue, track the stack, link issues to PRs, add these PRs to the roadmap."
+---
+
+# PR Tracking Skill
+
+The executable procedure for the `AGENTS.md` rule "Every PR is tracked by an
+issue and the roadmap". Use `gh` for GitHub and the
+[gitbutler](../gitbutler/SKILL.md) skill (`but`) for branch/PR/push operations.
+
+For every branch in the stack, make all of this true:
+
+1. A PR exists (open a **draft** if not: `but pr new --draft`; never
+   `gh pr create`, which bypasses GitButler's stack metadata, and never create
+   non-draft and flip afterwards -- the initial non-draft ping to reviewers
+   cannot be retracted; `but pr set-draft` is only remediation for a PR that
+   already exists non-draft). Its base is its downstack parent, or the stack's
+   integration branch (`main`/`master`) for the bottom PR.
+2. An issue describes the **problem** it solves (`gh issue create`) -- problem
+   only, no proposed solution, one per PR.
+3. The PR body explains **why** and ends with `Closes #<issue>`
+   (`gh pr edit <pr> --body-file <file>`; write the body with Write, never a
+   heredoc). GitHub only honors closing keywords on the PR that merges into the
+   default branch, so a stacked child PR's `Closes` line is informational --
+   when a child PR's commits reach the default branch without auto-closing its
+   issue, close the issue explicitly (`gh issue close <issue>`).
+4. The PR is assigned to the author (`gh pr edit <pr> --add-assignee @me` --
+   `gh`/`but` do not auto-assign).
+5. The issue is a checklist item in the right `ROADMAP.md` section, with real
+   markdown links to the issue and PR:
+   `- [ ] <desc> -- [#<issue>](url) / [#<pr>](url)`. Tick `- [x]` once the work
+   is done. Do not group unrelated work into one section; bare `#123` is not a
+   link.
+
+The roadmap entry and its tick land on the feature PR itself (step 5), so the
+roadmap always matches what merged; only standalone policy or process-doc
+changes get their own PR. Re-run whenever the stack changes (new branch, rebased
+scope, merge); keep links and ticks current. Never post issue/PR comments or
+flip PR state without an explicit instruction.


### PR DESCRIPTION
## Motivation

Every PR should close a problem-only issue that is tracked as a checklist item in
the roadmap, and a stack of PRs should be made to conform to that without manual
bookkeeping. Nothing documented or automated the convention.

## Solution

Document the issue-and-roadmap-per-PR rule in `AGENTS.md`, and add the
`pr-tracking` skill that walks a whole stack into compliance (a PR per branch,
each closing a problem-only issue, each a ticked roadmap item, all cross-linked).


Closes #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated PR submission guidelines to require issue tracking and roadmap synchronization
  * Added completed milestones: GitButler CLI for stacked PRs, Python/Spark removal, and PR-issue tracking

* **New Features**
  * Introduced automated PR tracking to keep roadmap synchronized with pull request merges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 1 in a stack** made with GitButler:
- <kbd>&nbsp;1&nbsp;</kbd> #248 👈
<!-- GitButler Footer Boundary Bottom -->
