### PR TITLE
docs: point user stories at the factors module

### DIFF
--- a/docs/user-stories/risk-analytics.md
+++ b/docs/user-stories/risk-analytics.md
@@ -48,7 +48,7 @@ Frontend changes:
 - Render the dynamic matrix instead of the hardcoded one. The number of rows and
   columns should match the live asset list.
 
-Backend starting points: `src/beta.rs` (rolling window covariance/variance
+Backend starting points: `src/factors.rs` (rolling window covariance/variance
 pattern to adapt), `src/dataframe.rs` (Polars DataFrame operations).
 
 ### Tasks

--- a/docs/user-stories/screener.md
+++ b/docs/user-stories/screener.md
@@ -46,7 +46,7 @@ funding_rate: f64 | null }>`.
 Volatility: 30-day realized annualized volatility =
 `std(daily_returns) *
 sqrt(252)` over the last 30 days. This is computable from
-existing OHLCV data in Polars — see `src/beta.rs` for the pattern.
+existing OHLCV data in Polars — see `src/factors.rs` for the pattern.
 
 Frontend changes:
 


### PR DESCRIPTION
## Motivation

`src/beta.rs` was consolidated into `src/factors.rs`, but the user-story docs
still tell readers to start at the old path -- the documented backend starting
points lead nowhere.

## Solution

Point the risk-analytics and screener user stories at `src/factors.rs`.

Closes #304
