### PR TITLE
refactor: consolidate beta into a factors module

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,10 +18,41 @@ the order within each theme.
 
 ---
 
+## Dev: finish the Python -> Rust analytics migration
+
+Port the deleted Python quant analytics to Rust as the factor and risk engine
+that powers the "Screener and staged simulation" and "Risk analytics" themes
+below. The autonomous trader's auto-pick/execute loop is out of scope --
+execution stays in the frontend. Delivered as a stack of small PRs; the
+user-facing endpoints tick their story items under those themes. This is an
+engineering track that runs in parallel to the product themes below, not ahead
+of them.
+
+- [x] Consolidate beta into a factors module --
+      [#249](https://github.com/data-cartel/moneymentum/issues/249) /
+      [#250](https://github.com/data-cartel/moneymentum/pull/250)
+- [ ] Add TimeframeConfig (lookback, annualization, and MAR -- Minimum
+      Acceptable Return)
+- [ ] Factor: returns
+- [ ] Factor: cum_return
+- [ ] Factor: volatility
+- [ ] Factor: SMA
+- [ ] Factor: mean return
+- [ ] Factor: price z-score
+- [ ] Factor: Sharpe
+- [ ] Factor: Sortino
+- [ ] Factor: autocorrelation
+- [ ] Factor: information discreteness
+- [ ] Factor: carry (signed funding)
+- [ ] Markets metadata + persisted disable flag
+- [ ] Tradable filter wired into ingestion
+
+---
+
 ## Usable production deployment
 
 Users need to reach the app before any portfolio feature matters. Deployment is
-the next implementation priority.
+the next user-facing priority; it runs in parallel to the Dev track above.
 
 - [ ] [Keep The App Deployed And Reachable](./stories/0x008.keep-app-deployed-and-reachable.md)
 - [ ] [Verify Deployed Hyperliquid Long-Short Rebalancing](./stories/0x00a.verify-deployed-hyperliquid-long-short-rebalancing.md)

--- a/docs/user-stories/risk-analytics.md
+++ b/docs/user-stories/risk-analytics.md
@@ -48,7 +48,7 @@ Frontend changes:
 - Render the dynamic matrix instead of the hardcoded one. The number of rows and
   columns should match the live asset list.
 
-Backend starting points: `src/beta.rs` (rolling window covariance/variance
+Backend starting points: `src/factors.rs` (rolling window covariance/variance
 pattern to adapt), `src/dataframe.rs` (Polars DataFrame operations).
 
 ### Tasks

--- a/docs/user-stories/screener.md
+++ b/docs/user-stories/screener.md
@@ -46,7 +46,7 @@ funding_rate: f64 | null }>`.
 Volatility: 30-day realized annualized volatility =
 `std(daily_returns) *
 sqrt(252)` over the last 30 days. This is computable from
-existing OHLCV data in Polars — see `src/beta.rs` for the pattern.
+existing OHLCV data in Polars — see `src/factors.rs` for the pattern.
 
 Frontend changes:
 

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -1,7 +1,10 @@
-//! Log returns from daily OHLCV candles.
+//! Factor engine: per-asset factor math over ingested OHLCV/funding data.
 //!
-//! Reads `ohlcv_1d.csv` from a data directory and computes per-ticker log returns:
-//! `log_return = ln(close_t / close_{t-1})` within each ticker's time series.
+//! Currently computes per-ticker log returns
+//! (`log_return = ln(close_t / close_{t-1})`) and portfolio beta
+//! (`Cov(portfolio, benchmark) / Var(benchmark)`) from `ohlcv_1d.csv`.
+//! Additional factors (volatility, Sharpe, ...) are added in this module so
+//! they share the same returns/covariance primitives.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
@@ -38,7 +41,7 @@ pub enum ReturnsError {
     Polars(#[from] PolarsError),
     #[error(transparent)]
     Join(#[from] tokio::task::JoinError),
-    #[error("no daily candle data at {path}")]
+    #[error("no candle data at {path}")]
     NoData { path: std::path::PathBuf },
     #[error("daily candle data has no timestamps")]
     NoTimestamps,
@@ -449,9 +452,68 @@ fn variance(benchmark: &Series) -> Result<f64, ReturnsError> {
 mod tests {
     use super::*;
     use polars::prelude::df;
+    use proptest::prelude::*;
     use std::fs;
     use tempfile::TempDir;
     use tracing_test::traced_test;
+
+    proptest! {
+        /// `log_return` equals `ln(close_t / close_{t-1})` for any positive close series.
+        #[test]
+        fn log_returns_are_ln_of_close_ratio(
+            closes in prop::collection::vec(1.0_f64..1_000_000.0, 2..30),
+        ) {
+            let n = closes.len();
+            let timestamps: Vec<String> = (0..n).map(|i| format!("{i:04}")).collect();
+            let tickers = vec!["BTC"; n];
+            let frame = df! {
+                "timestamp" => timestamps,
+                "ticker" => tickers,
+                "close" => closes.clone(),
+            }
+            .unwrap();
+
+            let out = compute_log_returns(&frame).unwrap();
+            let log_return = out.column("log_return").unwrap();
+
+            prop_assert!(log_return.get(0).unwrap().is_null());
+            for (idx, pair) in closes.windows(2).enumerate() {
+                let expected = (pair[1] / pair[0]).ln();
+                let actual = log_return.get(idx + 1).unwrap().try_extract::<f64>().unwrap();
+                prop_assert!((actual - expected).abs() < 1e-9);
+            }
+        }
+
+        /// For a single-ticker portfolio measured against that same ticker,
+        /// `beta = Cov(w*r, r) / Var(r) = w` whenever `Var(r) > 0`.
+        #[traced_test]
+        #[test]
+        fn single_ticker_beta_equals_weight(
+            returns in prop::collection::vec(-0.5_f64..0.5, 3..40),
+            weight in -5.0_f64..5.0,
+        ) {
+            prop_assume!(returns.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+            let n = returns.len();
+            let timestamps: Vec<String> = (0..n).map(|i| format!("{i:04}")).collect();
+            let tickers = vec!["BTC"; n];
+            let frame = df! {
+                "timestamp" => timestamps,
+                "ticker" => tickers,
+                "log_return" => returns,
+            }
+            .unwrap();
+
+            let weights = [("BTC".to_string(), weight)];
+            let beta = compute_beta_from_log_returns(&frame, &weights, "BTC")
+                .unwrap()
+                .unwrap();
+            prop_assert!((beta - weight).abs() < 1e-9, "beta {beta} != weight {weight}");
+            prop_assert!(crate::logs_contain_at(
+                tracing::Level::INFO,
+                &["portfolio beta calculated", "beta"]
+            ));
+        }
+    }
 
     #[test]
     fn daily_candles_path_uses_ohlcv_1d() {
@@ -609,9 +671,17 @@ mod tests {
         assert_eq!(report.excluded_tickers, vec!["DOGE"]);
         assert!(report.effective_weights.is_empty());
         assert_eq!(report.data_age_hours, 2);
+
+        // The log buffer is process-global, so other tests legitimately logging
+        // "portfolio beta calculated" would trip a bare negative assertion.
+        // Scope it to this test's own span (traced_test prefixes every line
+        // emitted here with the test name).
         assert!(!crate::logs_contain_at(
             tracing::Level::INFO,
-            &["portfolio beta calculated"]
+            &[
+                "beta_report_returns_none_when_all_portfolio_assets_are_excluded",
+                "portfolio beta calculated",
+            ]
         ));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-mod beta;
 mod candle;
 mod dataframe;
+mod factors;
 mod finance;
 mod funding;
 mod hyperliquid;
@@ -325,7 +325,8 @@ async fn post_beta(
         sorted_weights
     };
 
-    match beta::compute_portfolio_beta_report(&config.data_dir, &weights, &body.benchmark).await {
+    match factors::compute_portfolio_beta_report(&config.data_dir, &weights, &body.benchmark).await
+    {
         Ok(report) => Ok(Json(BetaResponse {
             beta: report.beta,
             excluded_symbols: report.excluded_tickers,


### PR DESCRIPTION
## Motivation

The factor engine (volatility, Sharpe, autocorrelation, beta-to-benchmark, ...)
all needs the same returns / covariance / variance math that previously lived
only in the standalone `beta` module. Without a shared home, each new factor
would duplicate those helpers or awkwardly cross-import them.

## Solution

Rename `beta.rs` to `factors.rs` to establish the factor-engine module, making
beta the first factor and promoting its log-return / covariance / variance
helpers to the shared basis the other factors build on. Adds property tests for
the primitives (log return == ln(close ratio); single-ticker portfolio beta ==
weight) and scopes the flaky negative log assertion to its own test span.
`POST /beta` and its regression value are unchanged.

Closes #249
