### PR TITLE
feat: add volatility and cum_return factors with a /factors endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Moneymentum makes those exposures legible and adjustable.
 - **Frontend prototype** at `/prototype`: design reference for the target UI.
 - **Backend** (active development): Rust + Rocket API, Polars analytics,
   SQLite-backed ingestion runs and job queue. Ingests Hyperliquid OHLCV and
-  funding rates; computes rolling beta to BTC.
+  funding rates; computes rolling beta to BTC and serves per-asset factor scores
+  via `GET /factors/<timeframe>`.
 - **Vault program** (planned): Anchor program on Solana for non-custodial
   managed deposits with two-phase withdrawal.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,19 +28,28 @@ user-facing endpoints tick their story items under those themes. This is an
 engineering track that runs in parallel to the product themes below, not ahead
 of them.
 
+- [x] Point user stories at the factors module --
+      [#304](https://github.com/data-cartel/moneymentum/issues/304) /
+      [#250](https://github.com/data-cartel/moneymentum/pull/250)
 - [x] Consolidate beta into a factors module --
       [#249](https://github.com/data-cartel/moneymentum/issues/249) /
-      [#250](https://github.com/data-cartel/moneymentum/pull/250)
-- [ ] Add TimeframeConfig (lookback, annualization, and MAR -- Minimum
-      Acceptable Return)
+      [#252](https://github.com/data-cartel/moneymentum/pull/252)
+- [x] Add TimeframeConfig (lookback + annualization) --
+      [#251](https://github.com/data-cartel/moneymentum/issues/251) /
+      [#254](https://github.com/data-cartel/moneymentum/pull/254)
 - [ ] Factor: returns
-- [ ] Factor: cum_return
-- [ ] Factor: volatility
+- [x] Factor: cum_return --
+      [#253](https://github.com/data-cartel/moneymentum/issues/253) /
+      [#254](https://github.com/data-cartel/moneymentum/pull/254)
+- [x] Factor: volatility --
+      [#251](https://github.com/data-cartel/moneymentum/issues/251) /
+      [#254](https://github.com/data-cartel/moneymentum/pull/254)
 - [ ] Factor: SMA
 - [ ] Factor: mean return
 - [ ] Factor: price z-score
 - [ ] Factor: Sharpe
-- [ ] Factor: Sortino
+- [ ] Factor: Sortino (adds MAR -- Minimum Acceptable Return -- to
+      TimeframeConfig)
 - [ ] Factor: autocorrelation
 - [ ] Factor: information discreteness
 - [ ] Factor: carry (signed funding)

--- a/SPEC.md
+++ b/SPEC.md
@@ -285,11 +285,11 @@ solidify.
 ## Analytics Capabilities
 
 **Factor Engine**: Computes per-asset factor scores (beta, momentum, carry,
-volatility, Sharpe) over the tradable universe. The backend already computes
-rolling beta to BTC; momentum, carry, and volatility follow the same pattern
-(rolling windows over ingested OHLCV and funding-rate data). Outputs feed the
-screener (rank/filter assets by factor) and the rebalancer (target factor
-exposures, not symbols).
+volatility, Sharpe) over the tradable universe. The backend computes rolling
+beta to BTC and serves per-asset factor scores via `GET /factors/<timeframe>`;
+factors land incrementally as columns (rolling windows over ingested OHLCV and
+funding-rate data). Outputs feed the screener (rank/filter assets by factor) and
+the rebalancer (target factor exposures, not symbols).
 
 The portfolio-weighted beta is exposed via `POST /beta`, which accepts a set of
 position weights plus a benchmark symbol and returns a single beta value

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -5,6 +5,7 @@
 //! ownership of data to safely move it across thread boundaries.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use polars::prelude::{
     CsvReader, CsvWriter, DataFrame, IntoLazy, PlSmallStr, PolarsError, Selector, SerReader,
@@ -46,8 +47,23 @@ pub(crate) async fn write_csv(path: PathBuf, mut df: DataFrame) -> Result<(), Da
             std::fs::create_dir_all(parent)?;
         }
 
-        let file = std::fs::File::create(&path)?;
-        CsvWriter::new(file).finish(&mut df)?;
+        // Write to a unique sibling temp file and rename so readers racing this
+        // write (request-time factor/beta computations) never observe a
+        // truncated or half-written file, and overlapping writers to the same
+        // target never share a temp file; same-directory rename is atomic on
+        // POSIX.
+        let tmp_path = unique_sibling_tmp_path(&path);
+        let file = std::fs::File::create(&tmp_path)?;
+        let written = CsvWriter::new(file)
+            .finish(&mut df)
+            .map_err(DataFrameError::from)
+            .and_then(|()| std::fs::rename(&tmp_path, &path).map_err(DataFrameError::from));
+        if let Err(write_error) = written {
+            // Best-effort cleanup: failed writes must not leak uniquely named
+            // temp files into the data directory forever.
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(write_error);
+        }
         debug!(rows = df.height(), "wrote csv");
         Ok(())
     })
@@ -99,6 +115,24 @@ pub(crate) async fn merge_and_deduplicate(
         Ok(deduped)
     })
     .await?
+}
+
+/// A temp path unique to this write, next to the target so the final rename
+/// stays within one filesystem (a cross-device rename is not atomic).
+///
+/// Uniqueness comes from the process id plus a process-wide counter, so
+/// overlapping writers to the same target never truncate each other's temp
+/// file.
+fn unique_sibling_tmp_path(path: &std::path::Path) -> PathBuf {
+    static WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let write_id = WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let process_id = std::process::id();
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    path.with_file_name(format!("{file_name}.{process_id}.{write_id}.tmp"))
 }
 
 #[cfg(test)]
@@ -153,12 +187,32 @@ mod tests {
         let original_width = original.width();
 
         write_csv(path.clone(), original).await.unwrap();
-        let loaded = read_csv(path).await.unwrap().unwrap();
+        let loaded = read_csv(path.clone()).await.unwrap().unwrap();
 
         assert_eq!(loaded.height(), original_height);
         assert_eq!(loaded.width(), original_width);
         assert!(logs_contain_at(Level::DEBUG, &["wrote csv"]));
         assert!(logs_contain_at(Level::DEBUG, &["loaded csv"]));
+
+        // The atomic write publishes via temp-file-plus-rename: after a
+        // successful write only the target may remain, or a dropped rename
+        // would silently serve stale data to racing readers.
+        let leftover_files: Vec<String> = std::fs::read_dir(temp_dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name != "test.csv")
+            .collect();
+        assert!(
+            leftover_files.is_empty(),
+            "write must clean up its temp file, found {leftover_files:?}"
+        );
+
+        // Overwriting an existing file goes through the same rename and must
+        // replace the contents, not append or leave the old data.
+        let replacement = create_test_df(&[1_704_074_400_000_i64], &["SOL"], &[150.0]);
+        write_csv(path.clone(), replacement).await.unwrap();
+        let reloaded = read_csv(path).await.unwrap().unwrap();
+        assert_eq!(reloaded.height(), 1, "overwrite must replace the contents");
     }
 
     #[tokio::test]

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -16,14 +16,15 @@ pub const LOG_RETURNS_LOOKBACK_CANDLES: usize = 366;
 
 use polars::datatypes::AnyValue;
 use polars::prelude::{
-    ChunkApply, DataFrame, DataFrameJoinOps, IntoLazy, IntoSeries, JoinArgs, JoinType, NamedFrom,
-    PolarsError, Series, SortMultipleOptions, SortOptions, col, lit,
+    ChunkApply, DataFrame, DataFrameJoinOps, IntoLazy, IntoSeries, JoinArgs, JoinType, JsonFormat,
+    JsonWriter, NamedFrom, PolarsError, SerWriter, Series, SortMultipleOptions, SortOptions, col,
+    lit,
 };
 use thiserror::Error;
 use tracing::{info, instrument};
 
 use crate::dataframe::DataFrameError;
-use crate::timeframe::Timeframe;
+use crate::timeframe::{Timeframe, TimeframeConfig};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PortfolioBetaReport {
@@ -448,6 +449,81 @@ fn variance(benchmark: &Series) -> Result<f64, ReturnsError> {
     Ok(variance)
 }
 
+/// Per-ticker factor scores from a timeframe's candles.
+///
+/// For each ticker, over the last `lookback_periods` daily log returns:
+/// - `annualized_volatility` = sample stddev (ddof=1) * sqrt(annualized_factor)
+/// - `cum_return` = exp(sum of log returns) - 1 (cumulative / momentum return)
+///
+/// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
+#[instrument(skip_all, fields(data_dir = %data_dir.display()))]
+pub(crate) async fn compute_factors(
+    data_dir: &Path,
+    timeframe: Timeframe,
+) -> Result<DataFrame, ReturnsError> {
+    let path = data_dir.join(timeframe.file_name());
+    let df = crate::dataframe::read_csv(path.clone()).await?;
+    let Some(df) = df else {
+        return Err(ReturnsError::NoData { path });
+    };
+    let config = timeframe.config();
+    let out = tokio::task::spawn_blocking(move || per_ticker_factors(&df, &config)).await??;
+    info!(tickers = out.height(), "factors computed");
+    Ok(out)
+}
+
+/// Synchronous core: log returns per ticker, then per-ticker factor scores over
+/// the last `lookback_periods` returns. Stddev uses ddof=1 to match the legacy
+/// Spark `stddev`; the cumulative return is `exp(sum) - 1`.
+fn per_ticker_factors(
+    candles: &DataFrame,
+    config: &TimeframeConfig,
+) -> Result<DataFrame, PolarsError> {
+    let with_returns = compute_log_returns(candles)?;
+    let lookback = config.lookback_periods;
+    let annualizer = config.annualized_factor.sqrt();
+    let mut factors = with_returns
+        .lazy()
+        .group_by([col("ticker")])
+        .agg([
+            (col("log_return").tail(Some(lookback)).std(1) * lit(annualizer))
+                .alias("annualized_volatility"),
+            col("log_return")
+                .tail(Some(lookback))
+                .sum()
+                .alias("cum_log_return"),
+        ])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()?;
+
+    // cum_return = exp(sum of log returns) - 1. exp is applied on the series
+    // (like compute_log_returns does for ln) to avoid a polars math-expr feature.
+    let cum_return = factors
+        .column("cum_log_return")?
+        .f64()?
+        .apply_values(f64::exp_m1)
+        .into_series()
+        .with_name("cum_return".into());
+    factors.with_column(cum_return)?;
+    factors.drop_in_place("cum_log_return")?;
+    Ok(factors)
+}
+
+/// Per-ticker factor scores serialized as a JSON array, for the `/factors`
+/// endpoint. Currently exposes `annualized_volatility`; further factors are
+/// added as columns here as they land.
+pub(crate) async fn compute_factors_json(
+    data_dir: &Path,
+    timeframe: Timeframe,
+) -> Result<Vec<u8>, ReturnsError> {
+    let mut factors = compute_factors(data_dir, timeframe).await?;
+    let mut buf = Vec::new();
+    JsonWriter::new(&mut buf)
+        .with_json_format(JsonFormat::Json)
+        .finish(&mut factors)?;
+    Ok(buf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,6 +589,148 @@ mod tests {
                 &["portfolio beta calculated", "beta"]
             ));
         }
+    }
+
+    proptest! {
+        /// Volatility is a scaled standard deviation, so it is always finite and
+        /// non-negative for any positive close series.
+        #[test]
+        fn volatility_is_non_negative(
+            closes in prop::collection::vec(1.0_f64..1_000_000.0, 3..50),
+        ) {
+            let n = closes.len();
+            let timestamps: Vec<String> = (0..n).map(|i| format!("{i:04}")).collect();
+            let tickers = vec!["BTC"; n];
+            let candles = df! {
+                "timestamp" => timestamps,
+                "ticker" => tickers,
+                "close" => closes,
+            }
+            .unwrap();
+            let config = TimeframeConfig { lookback_periods: 100, annualized_factor: 365.0 };
+
+            let out = per_ticker_factors(&candles, &config).unwrap();
+            let vol = out
+                .column("annualized_volatility")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            prop_assert!(vol >= 0.0, "volatility must be non-negative, got {vol}");
+            prop_assert!(vol.is_finite());
+
+            let cum = out
+                .column("cum_return")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            prop_assert!(cum.is_finite(), "cum_return must be finite, got {cum}");
+        }
+    }
+
+    #[test]
+    fn per_ticker_factors_match_manual_values() {
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3", "4"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 101.0, 100.0, 101.0, 100.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let vol = out
+            .column("annualized_volatility")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+
+        // log returns are [a, -a, a, -a] with a = ln(1.01), mean 0, so the
+        // sample variance is 4a^2/3 and volatility = sqrt(4a^2/3) * sqrt(365).
+        let a = (101.0_f64 / 100.0).ln();
+        let expected = (4.0 * a * a / 3.0).sqrt() * 365.0_f64.sqrt();
+        assert!(
+            (vol - expected).abs() < 1e-10,
+            "vol {vol} != expected {expected}"
+        );
+
+        // log returns sum to a - a + a - a = 0, so cum_return = exp(0) - 1 = 0.
+        let cum = out
+            .column("cum_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(cum.abs() < 1e-12, "cum_return should be ~0, got {cum}");
+    }
+
+    #[test]
+    fn per_ticker_factors_are_zero_for_constant_prices() {
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 100.0, 100.0, 100.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let vol = out
+            .column("annualized_volatility")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            vol.abs() < 1e-12,
+            "constant prices give zero volatility, got {vol}"
+        );
+
+        let cum = out
+            .column("cum_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            cum.abs() < 1e-12,
+            "constant prices give zero cum_return, got {cum}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn compute_factors_reads_candles_and_logs() {
+        let tmp_dir = TempDir::new().unwrap();
+        let src = Path::new("fixtures/ohlcv_1d_beta.csv");
+        let dst = tmp_dir.path().join("ohlcv_1d.csv");
+        fs::copy(src, &dst).unwrap();
+
+        let out = compute_factors(tmp_dir.path(), Timeframe::OneDay)
+            .await
+            .unwrap();
+
+        assert!(out.height() > 0, "expected a factor row per ticker");
+        assert!(out.column("annualized_volatility").is_ok());
+        assert!(out.column("cum_return").is_ok());
+        assert!(crate::logs_contain_at(
+            tracing::Level::INFO,
+            &["factors computed"]
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,21 @@ async fn get_candles(
         .ok_or(Status::NotFound)
 }
 
+#[get("/factors/<timeframe>")]
+async fn get_factors(
+    config: &State<Config>,
+    timeframe: Timeframe,
+) -> Result<RawJson<Vec<u8>>, Status> {
+    match factors::compute_factors_json(&config.data_dir, timeframe).await {
+        Ok(json) => Ok(RawJson(json)),
+        Err(factors::ReturnsError::NoData { .. }) => Err(Status::NotFound),
+        Err(err) => {
+            error!(error = %err, "failed to compute factors");
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
 #[post("/ingest")]
 async fn start_ingestion(job_queue: &State<IngestionJobQueue>, pool: &State<SqlitePool>) -> Status {
     let run_id = match ingestion::create_run(pool).await {
@@ -429,6 +444,7 @@ pub async fn rocket(
             routes![
                 health,
                 get_candles,
+                get_factors,
                 start_ingestion,
                 get_ingestion_status,
                 post_beta,
@@ -480,7 +496,7 @@ mod tests {
         };
         rocket::build()
             .manage(config)
-            .mount("/", routes![health, get_candles])
+            .mount("/", routes![health, get_candles, get_factors])
     }
 
     proptest! {
@@ -550,6 +566,48 @@ mod tests {
         let response = client.get("/candles/1h").dispatch();
 
         assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[test]
+    fn get_factors_returns_404_when_no_data() {
+        let data_dir = TempDir::new().unwrap();
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client.get("/factors/1d").dispatch();
+
+        assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[test]
+    fn get_factors_returns_per_ticker_factor_scores_json() {
+        let data_dir = TempDir::new().unwrap();
+        std::fs::copy(
+            std::path::Path::new("fixtures/ohlcv_1d_beta.csv"),
+            data_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client.get("/factors/1d").dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        let rows: Vec<serde_json::Value> =
+            serde_json::from_str(&body).expect("factors body is a JSON array");
+        assert!(!rows.is_empty(), "expected a row per ticker");
+        assert!(
+            rows.iter()
+                .all(|row| row.get("annualized_volatility").is_some()),
+            "every row carries annualized_volatility"
+        );
+        assert!(
+            rows.iter().all(|row| row.get("cum_return").is_some()),
+            "every row carries cum_return"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
+            "BTC is present in the factor scores"
+        );
     }
 
     #[test]

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -54,11 +54,62 @@ impl Timeframe {
             Self::OneWeek => "ohlcv_1w.csv",
         }
     }
+
+    /// Factor-engine parameters for this timeframe, ported from the legacy
+    /// `util.py` `TIMEFRAME_CONFIGS`. Fields are added as factors that consume
+    /// them land (e.g. `min_acceptable_return` arrives with the Sortino factor).
+    pub(crate) fn config(self) -> TimeframeConfig {
+        match self {
+            Self::FifteenMin => TimeframeConfig {
+                lookback_periods: 7 * 24 * 4,
+                annualized_factor: 365.0 * 24.0 * 4.0,
+            },
+            Self::OneHour => TimeframeConfig {
+                lookback_periods: 7 * 24,
+                annualized_factor: 365.0 * 24.0,
+            },
+            Self::OneDay => TimeframeConfig {
+                lookback_periods: 90,
+                annualized_factor: 365.0,
+            },
+            Self::OneWeek => TimeframeConfig {
+                lookback_periods: 52,
+                annualized_factor: 52.0,
+            },
+        }
+    }
+}
+
+/// Per-timeframe parameters that drive the factor engine's windowed math.
+pub(crate) struct TimeframeConfig {
+    /// Number of candles in the lookback window for rolling factor math.
+    pub(crate) lookback_periods: usize,
+    /// Scaling factor to annualize per-period returns and volatility.
+    pub(crate) annualized_factor: f64,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn config_matches_legacy_timeframe_constants() {
+        let fifteen = Timeframe::FifteenMin.config();
+        assert_eq!(fifteen.lookback_periods, 672);
+        assert!((fifteen.annualized_factor - 35040.0).abs() < f64::EPSILON);
+
+        let hour = Timeframe::OneHour.config();
+        assert_eq!(hour.lookback_periods, 168);
+        assert!((hour.annualized_factor - 8760.0).abs() < f64::EPSILON);
+
+        let day = Timeframe::OneDay.config();
+        assert_eq!(day.lookback_periods, 90);
+        assert!((day.annualized_factor - 365.0).abs() < f64::EPSILON);
+
+        let week = Timeframe::OneWeek.config();
+        assert_eq!(week.lookback_periods, 52);
+        assert!((week.annualized_factor - 52.0).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn interval_strings_are_valid() {


### PR DESCRIPTION
## Motivation

Users need per-asset risk/return factors to build factor-driven portfolios
instead of hand-picking symbols. There was no endpoint serving per-ticker
factor scores, no volatility factor, and no momentum factor.

## Solution

Add the first two factors and the endpoint that serves them:

- `TimeframeConfig` (lookback period + annualization constants) on `Timeframe`.
- Per-ticker annualized volatility: sample stddev of the lookback window's
  daily log returns, scaled by `sqrt(annualized_factor)`.
- `cum_return = exp(sum of lookback log returns) - 1` as the momentum factor.
- `GET /factors/<timeframe>` returning per-ticker factor scores as JSON; later
  factors add columns here.

Fixture + property tests for the math and an endpoint test for the wiring.

Closes #251
Closes #253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GET /factors/<timeframe>` endpoint exposing per-asset factor scores (beta, momentum, carry, volatility, Sharpe) across the tradable universe.

* **Documentation**
  * Updated README, ROADMAP, and specification to clarify factor engine capabilities and per-asset factor score computation via rolling windows over OHLCV and funding-rate data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->