### PR TITLE
feat: add SMA, mean return, and price z-score factors

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,9 +44,15 @@ of them.
 - [x] Factor: volatility --
       [#251](https://github.com/data-cartel/moneymentum/issues/251) /
       [#254](https://github.com/data-cartel/moneymentum/pull/254)
-- [ ] Factor: SMA
-- [ ] Factor: mean return
-- [ ] Factor: price z-score
+- [x] Factor: SMA --
+      [#255](https://github.com/data-cartel/moneymentum/issues/255) /
+      [#256](https://github.com/data-cartel/moneymentum/pull/256)
+- [x] Factor: mean return --
+      [#255](https://github.com/data-cartel/moneymentum/issues/255) /
+      [#256](https://github.com/data-cartel/moneymentum/pull/256)
+- [x] Factor: price z-score --
+      [#255](https://github.com/data-cartel/moneymentum/issues/255) /
+      [#256](https://github.com/data-cartel/moneymentum/pull/256)
 - [ ] Factor: Sharpe
 - [ ] Factor: Sortino (adds MAR -- Minimum Acceptable Return -- to
       TimeframeConfig)

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -1,10 +1,11 @@
 //! Factor engine: per-asset factor math over ingested OHLCV/funding data.
 //!
-//! Currently computes per-ticker log returns
-//! (`log_return = ln(close_t / close_{t-1})`) and portfolio beta
-//! (`Cov(portfolio, benchmark) / Var(benchmark)`) from `ohlcv_1d.csv`.
-//! Additional factors (volatility, Sharpe, ...) are added in this module so
-//! they share the same returns/covariance primitives.
+//! Computes per-ticker log returns (`log_return = ln(close_t / close_{t-1})`)
+//! and portfolio beta (`Cov(portfolio, benchmark) / Var(benchmark)`) from
+//! `ohlcv_1d.csv`, plus per-ticker factor scores (volatility, cumulative
+//! return, SMA, mean return, price z-score) served by the `/factors` endpoint.
+//! Factors live in this module so they share the same returns/covariance
+//! primitives.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
@@ -17,8 +18,8 @@ pub const LOG_RETURNS_LOOKBACK_CANDLES: usize = 366;
 use polars::datatypes::AnyValue;
 use polars::prelude::{
     ChunkApply, DataFrame, DataFrameJoinOps, IntoLazy, IntoSeries, JoinArgs, JoinType, JsonFormat,
-    JsonWriter, NamedFrom, PolarsError, SerWriter, Series, SortMultipleOptions, SortOptions, col,
-    lit,
+    JsonWriter, NULL, NamedFrom, PolarsError, SerWriter, Series, SortMultipleOptions, SortOptions,
+    col, lit, when,
 };
 use thiserror::Error;
 use tracing::{info, instrument};
@@ -451,9 +452,12 @@ fn variance(benchmark: &Series) -> Result<f64, ReturnsError> {
 
 /// Per-ticker factor scores from a timeframe's candles.
 ///
-/// For each ticker, over the last `lookback_periods` daily log returns:
-/// - `annualized_volatility` = sample stddev (ddof=1) * sqrt(annualized_factor)
+/// For each ticker, over the last `lookback_periods` candles:
+/// - `annualized_volatility` = sample stddev (ddof=1) of log returns * sqrt(annualized_factor)
 /// - `cum_return` = exp(sum of log returns) - 1 (cumulative / momentum return)
+/// - `sma` = simple moving average of close prices
+/// - `mean_return` = mean log return
+/// - `price_zscore` = (latest close - `sma`) / sample stddev of close prices
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -473,7 +477,7 @@ pub(crate) async fn compute_factors(
 }
 
 /// Synchronous core: log returns per ticker, then per-ticker factor scores over
-/// the last `lookback_periods` returns. Stddev uses ddof=1 to match the legacy
+/// the last `lookback_periods` candles. Stddev uses ddof=1 to match the legacy
 /// Spark `stddev`; the cumulative return is `exp(sum) - 1`.
 fn per_ticker_factors(
     candles: &DataFrame,
@@ -492,7 +496,25 @@ fn per_ticker_factors(
                 .tail(Some(lookback))
                 .sum()
                 .alias("cum_log_return"),
+            col("close").tail(Some(lookback)).mean().alias("sma"),
+            col("log_return")
+                .tail(Some(lookback))
+                .mean()
+                .alias("mean_return"),
+            col("close")
+                .tail(Some(lookback))
+                .std(1)
+                .alias("price_stddev"),
+            col("close").last().alias("last_close"),
         ])
+        // price z-score = (latest close - SMA) / price stddev; undefined (null)
+        // when there is no price dispersion (constant prices over the window).
+        .with_column(
+            when(col("price_stddev").neq(lit(0.0)))
+                .then((col("last_close") - col("sma")) / col("price_stddev"))
+                .otherwise(lit(NULL))
+                .alias("price_zscore"),
+        )
         .sort(["ticker"], SortMultipleOptions::default())
         .collect()?;
 
@@ -506,12 +528,15 @@ fn per_ticker_factors(
         .with_name("cum_return".into());
     factors.with_column(cum_return)?;
     factors.drop_in_place("cum_log_return")?;
+    factors.drop_in_place("price_stddev")?;
+    factors.drop_in_place("last_close")?;
     Ok(factors)
 }
 
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
-/// endpoint. Currently exposes `annualized_volatility`; further factors are
-/// added as columns here as they land.
+/// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
+/// `mean_return`, and `price_zscore`; further factors are added as columns as
+/// they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -593,12 +618,15 @@ mod tests {
 
     proptest! {
         /// Volatility is a scaled standard deviation, so it is always finite and
-        /// non-negative for any positive close series.
+        /// non-negative for any positive close series; the SMA stays within the
+        /// price range, mean return is finite, and a present z-score is finite.
         #[test]
         fn volatility_is_non_negative(
             closes in prop::collection::vec(1.0_f64..1_000_000.0, 3..50),
         ) {
             let n = closes.len();
+            let min_close = closes.iter().copied().fold(f64::INFINITY, f64::min);
+            let max_close = closes.iter().copied().fold(f64::NEG_INFINITY, f64::max);
             let timestamps: Vec<String> = (0..n).map(|i| format!("{i:04}")).collect();
             let tickers = vec!["BTC"; n];
             let candles = df! {
@@ -628,6 +656,52 @@ mod tests {
                 .get(0)
                 .unwrap();
             prop_assert!(cum.is_finite(), "cum_return must be finite, got {cum}");
+
+            let sma = out.column("sma").unwrap().f64().unwrap().get(0).unwrap();
+            prop_assert!(sma.is_finite());
+            prop_assert!(
+                sma >= min_close - 1e-6 && sma <= max_close + 1e-6,
+                "sma {sma} outside price range [{min_close}, {max_close}]"
+            );
+
+            let mean_return = out.column("mean_return").unwrap().f64().unwrap().get(0).unwrap();
+            prop_assert!(mean_return.is_finite(), "mean_return must be finite, got {mean_return}");
+
+            if let Some(zscore) = out.column("price_zscore").unwrap().f64().unwrap().get(0) {
+                prop_assert!(
+                    zscore.is_finite(),
+                    "price_zscore must be finite when present, got {zscore}"
+                );
+            }
+        }
+
+        /// For a strictly increasing close series the latest close is the maximum,
+        /// so it sits above the moving average and the price z-score is positive.
+        #[test]
+        fn price_zscore_positive_for_strictly_increasing_closes(
+            base in 1.0_f64..1000.0,
+            increments in prop::collection::vec(0.01_f64..100.0, 3..40),
+        ) {
+            let closes: Vec<f64> = std::iter::once(base)
+                .chain(increments.iter().scan(base, |price, increment| {
+                    *price += increment;
+                    Some(*price)
+                }))
+                .collect();
+            let n = closes.len();
+            let timestamps: Vec<String> = (0..n).map(|i| format!("{i:04}")).collect();
+            let tickers = vec!["BTC"; n];
+            let candles = df! {
+                "timestamp" => timestamps,
+                "ticker" => tickers,
+                "close" => closes,
+            }
+            .unwrap();
+            let config = TimeframeConfig { lookback_periods: 100, annualized_factor: 365.0 };
+
+            let out = per_ticker_factors(&candles, &config).unwrap();
+            let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0).unwrap();
+            prop_assert!(zscore > 0.0, "increasing closes must give a positive z-score, got {zscore}");
         }
     }
 
@@ -671,6 +745,38 @@ mod tests {
             .get(0)
             .unwrap();
         assert!(cum.abs() < 1e-12, "cum_return should be ~0, got {cum}");
+
+        // sma = mean([100, 101, 100, 101, 100]) = 502 / 5 = 100.4.
+        let sma = out.column("sma").unwrap().f64().unwrap().get(0).unwrap();
+        assert!((sma - 100.4).abs() < 1e-10, "sma {sma} != 100.4");
+
+        // mean of the non-null log returns [a, -a, a, -a] is 0.
+        let mean_return = out
+            .column("mean_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            mean_return.abs() < 1e-12,
+            "mean_return should be ~0, got {mean_return}"
+        );
+
+        // price stddev (ddof=1) of the closes is sqrt(1.2 / 4) = sqrt(0.3), so
+        // the z-score of the latest close (100) is (100 - 100.4) / sqrt(0.3).
+        let zscore = out
+            .column("price_zscore")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        let expected_zscore = -0.4 / 0.3_f64.sqrt();
+        assert!(
+            (zscore - expected_zscore).abs() < 1e-10,
+            "zscore {zscore} != {expected_zscore}"
+        );
     }
 
     #[test]
@@ -710,6 +816,28 @@ mod tests {
             cum.abs() < 1e-12,
             "constant prices give zero cum_return, got {cum}"
         );
+
+        let sma = out.column("sma").unwrap().f64().unwrap().get(0).unwrap();
+        assert!((sma - 100.0).abs() < 1e-12, "sma should be 100, got {sma}");
+
+        let mean_return = out
+            .column("mean_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            mean_return.abs() < 1e-12,
+            "constant prices give zero mean_return, got {mean_return}"
+        );
+
+        // No price dispersion means the z-score is undefined -> null.
+        let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0);
+        assert!(
+            zscore.is_none(),
+            "constant prices give an undefined (null) z-score, got {zscore:?}"
+        );
     }
 
     #[traced_test]
@@ -727,6 +855,9 @@ mod tests {
         assert!(out.height() > 0, "expected a factor row per ticker");
         assert!(out.column("annualized_volatility").is_ok());
         assert!(out.column("cum_return").is_ok());
+        assert!(out.column("sma").is_ok());
+        assert!(out.column("mean_return").is_ok());
+        assert!(out.column("price_zscore").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,25 @@ mod tests {
         );
         assert!(
             rows.iter()
+                .all(|row| row.get("sma").and_then(serde_json::Value::as_f64).is_some()),
+            "every row carries sma as a number"
+        );
+        assert!(
+            rows.iter().all(|row| row
+                .get("mean_return")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries mean_return as a number"
+        );
+        assert!(
+            rows.iter().all(|row| row
+                .get("price_zscore")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries price_zscore as a number (the fixture's prices all vary)"
+        );
+        assert!(
+            rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"
         );


### PR DESCRIPTION
## Motivation

Mean-reversion signals — where the current price sits relative to its recent
average — need a simple moving average, a mean return, and a normalized price
z-score.

## Solution

Add `sma`, `mean_return`, and `price_zscore` per-ticker factors to the factor
table served by `/factors`.


Closes #255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The /factors endpoint now returns three additional analytics: SMA (simple moving average), mean return (average log returns), and price z-score (normalized deviation).

* **Tests**
  * Added and updated tests to verify the new factor metrics are computed and present in endpoint responses.

* **Documentation**
  * Roadmap updated to mark SMA, mean return, and price z-score tasks as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 17 of 17 in a stack** made with GitButler:
- <kbd>&nbsp;17&nbsp;</kbd> #344
- <kbd>&nbsp;16&nbsp;</kbd> #342
- <kbd>&nbsp;15&nbsp;</kbd> #284
- <kbd>&nbsp;14&nbsp;</kbd> #282
- <kbd>&nbsp;13&nbsp;</kbd> #280
- <kbd>&nbsp;12&nbsp;</kbd> #278
- <kbd>&nbsp;11&nbsp;</kbd> #276
- <kbd>&nbsp;10&nbsp;</kbd> #274
- <kbd>&nbsp;9&nbsp;</kbd> #272
- <kbd>&nbsp;8&nbsp;</kbd> #270
- <kbd>&nbsp;7&nbsp;</kbd> #268
- <kbd>&nbsp;6&nbsp;</kbd> #266
- <kbd>&nbsp;5&nbsp;</kbd> #264
- <kbd>&nbsp;4&nbsp;</kbd> #262
- <kbd>&nbsp;3&nbsp;</kbd> #260
- <kbd>&nbsp;2&nbsp;</kbd> #258
- <kbd>&nbsp;1&nbsp;</kbd> #256 👈 
<!-- GitButler Footer Boundary Bottom -->