### PR TITLE
feat: add Sortino ratio factor and MAR config

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,8 +60,10 @@ of them.
 - [x] Factor: Sharpe --
       [#259](https://github.com/data-cartel/moneymentum/issues/259) /
       [#260](https://github.com/data-cartel/moneymentum/pull/260)
-- [ ] Factor: Sortino (adds MAR -- Minimum Acceptable Return -- to
-      TimeframeConfig)
+- [x] Factor: Sortino (adds MAR -- Minimum Acceptable Return -- to
+      TimeframeConfig) --
+      [#261](https://github.com/data-cartel/moneymentum/issues/261) /
+      [#262](https://github.com/data-cartel/moneymentum/pull/262)
 - [ ] Factor: autocorrelation
 - [ ] Factor: information discreteness
 - [ ] Factor: carry (signed funding)

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -17,8 +17,8 @@ const PRICE_STDDEV_EPS: f64 = 1e-8;
 
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
-/// `mean_return`, `price_zscore`, `annualized_return`, and `sharpe`; further
-/// factors are added as columns as they land.
+/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, and `sortino`;
+/// further factors are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -42,6 +42,8 @@ pub(crate) async fn compute_factors_json(
 /// - `annualized_return` = exp(`mean_return` * annualized_factor) - 1
 /// - `sharpe` = `annualized_return` / `annualized_volatility` (risk-free 0);
 ///   null when there is no volatility
+/// - `sortino` = `annualized_return` / downside deviation below the MAR; null
+///   when there is no downside
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -67,6 +69,16 @@ fn per_ticker_factors(
     let with_returns = compute_log_returns(candles)?;
     let lookback = config.lookback_periods;
     let annualization_multiplier = config.annualized_factor.sqrt();
+
+    // Downside deviation inputs for Sortino: sum of squared shortfalls below the
+    // minimum acceptable return, and the observation count to average over.
+    let above_mar = col("log_return").tail(Some(lookback)) - lit(config.min_acceptable_return);
+    let downside_sq_sum = when(above_mar.clone().lt(lit(0.0)))
+        .then(above_mar.pow(lit(2)))
+        .otherwise(lit(0.0))
+        .sum()
+        .alias("downside_sq_sum");
+
     let mut factors = with_returns
         .lazy()
         .group_by([col("ticker")])
@@ -87,6 +99,11 @@ fn per_ticker_factors(
                 .std(1)
                 .alias("price_stddev"),
             col("close").last().alias("last_close"),
+            downside_sq_sum,
+            col("log_return")
+                .tail(Some(lookback))
+                .count()
+                .alias("obs_count"),
         ])
         // price z-score = (latest close - SMA) / price stddev; undefined (null)
         // when there is no price dispersion (constant prices over the window).
@@ -136,11 +153,13 @@ fn per_ticker_factors(
     factors.drop_in_place("price_stddev")?;
     factors.drop_in_place("last_close")?;
 
-    // sharpe = annualized_return / annualized_volatility (risk-free 0); undefined
-    // (null) when there is no volatility to divide by.
-    let factors = factors
+    // sharpe = annualized_return / annualized_volatility (risk-free 0); sortino =
+    // annualized_return / downside deviation below the MAR. Both are undefined
+    // (null) when their risk denominator is zero.
+    let downside_deviation = (col("downside_sq_sum") / col("obs_count")).pow(lit(0.5));
+    let mut factors = factors
         .lazy()
-        .with_column(
+        .with_columns([
             // NaN != 0.0 is true in IEEE 754, so a NaN volatility (e.g. from a
             // corrupt zero close producing a -inf log return) must be rejected
             // explicitly -- mirroring the price_zscore stddev guard.
@@ -152,8 +171,22 @@ fn per_ticker_factors(
             .then(col("annualized_return") / col("annualized_volatility"))
             .otherwise(lit(NULL))
             .alias("sharpe"),
-        )
+            // Same NaN hazard as the sharpe guard: a single-candle ticker
+            // yields sqrt(0/0) = NaN downside deviation, and NaN != 0.0 is
+            // true, so the zero check alone would emit a NaN sortino.
+            when(
+                downside_deviation
+                    .clone()
+                    .is_finite()
+                    .and(downside_deviation.clone().neq(lit(0.0))),
+            )
+            .then(col("annualized_return") / downside_deviation)
+            .otherwise(lit(NULL))
+            .alias("sortino"),
+        ])
         .collect()?;
+    factors.drop_in_place("downside_sq_sum")?;
+    factors.drop_in_place("obs_count")?;
 
     Ok(factors)
 }
@@ -186,7 +219,11 @@ mod tests {
                 "close" => closes,
             }
             .unwrap();
-            let config = TimeframeConfig { lookback_periods: 100, annualized_factor: 365.0 };
+            let config = TimeframeConfig {
+                lookback_periods: 100,
+                annualized_factor: 365.0,
+                min_acceptable_return: 0.0,
+            };
 
             let out = per_ticker_factors(&candles, &config).unwrap();
             let vol = out
@@ -237,6 +274,13 @@ mod tests {
             if let Some(sharpe) = out.column("sharpe").unwrap().f64().unwrap().get(0) {
                 prop_assert!(sharpe.is_finite(), "sharpe must be finite when present, got {sharpe}");
             }
+
+            if let Some(sortino) = out.column("sortino").unwrap().f64().unwrap().get(0) {
+                prop_assert!(
+                    sortino.is_finite(),
+                    "sortino must be finite when present, got {sortino}"
+                );
+            }
         }
 
         /// For a strictly increasing close series the latest close is the maximum,
@@ -263,7 +307,11 @@ mod tests {
                 "close" => closes,
             }
             .unwrap();
-            let config = TimeframeConfig { lookback_periods: 100, annualized_factor: 365.0 };
+            let config = TimeframeConfig {
+                lookback_periods: 100,
+                annualized_factor: 365.0,
+                min_acceptable_return: 0.0,
+            };
 
             let out = per_ticker_factors(&candles, &config).unwrap();
             let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0).unwrap();
@@ -287,6 +335,14 @@ mod tests {
                     "positive return with volatility must give a positive sharpe, got {sharpe}"
                 );
             }
+
+            // Every return is above the MAR (0), so there is no downside and
+            // sortino is undefined -> null.
+            let sortino = out.column("sortino").unwrap().f64().unwrap().get(0);
+            prop_assert!(
+                sortino.is_none(),
+                "increasing closes have no downside, so sortino must be null, got {sortino:?}"
+            );
         }
     }
 
@@ -301,6 +357,7 @@ mod tests {
         let config = TimeframeConfig {
             lookback_periods: 10,
             annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
         };
 
         let out = per_ticker_factors(&candles, &config).unwrap();
@@ -379,6 +436,17 @@ mod tests {
 
         let sharpe = out.column("sharpe").unwrap().f64().unwrap().get(0).unwrap();
         assert!(sharpe.abs() < 1e-12, "sharpe should be ~0, got {sharpe}");
+
+        // There is downside (the -a returns), so sortino is defined; with a zero
+        // annualized_return it is 0 / downside_deviation = 0.
+        let sortino = out
+            .column("sortino")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(sortino.abs() < 1e-12, "sortino should be ~0, got {sortino}");
     }
 
     #[test]
@@ -392,6 +460,7 @@ mod tests {
         let config = TimeframeConfig {
             lookback_periods: 10,
             annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
         };
 
         let out = per_ticker_factors(&candles, &config).unwrap();
@@ -459,6 +528,53 @@ mod tests {
             sharpe.is_none(),
             "constant prices give an undefined (null) sharpe, got {sharpe:?}"
         );
+
+        // No returns fall below the MAR, so downside deviation is zero and
+        // sortino is undefined -> null.
+        let sortino = out.column("sortino").unwrap().f64().unwrap().get(0);
+        assert!(
+            sortino.is_none(),
+            "constant prices give an undefined (null) sortino, got {sortino:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_sortino_matches_manual_downside_deviation() {
+        // closes [100, 99, 101] give log returns [-p, q] with p = ln(100/99)
+        // (a down move below the MAR of 0) and q = ln(101/99) (an up move).
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[100.0, 99.0, 101.0_f64],
+        }
+        .unwrap();
+        // annualized_factor 1 keeps annualized_return = exp(mean_return) - 1.
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 1.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let sortino = out
+            .column("sortino")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+
+        let down_move = (100.0_f64 / 99.0).ln();
+        let up_move = (101.0_f64 / 99.0).ln();
+        let mean_return = f64::midpoint(-down_move, up_move);
+        let annualized_return = mean_return.exp_m1();
+        // Only the down move is below the MAR, so downside variance = p^2 / 2.
+        let downside_deviation = (down_move * down_move / 2.0).sqrt();
+        let expected_sortino = annualized_return / downside_deviation;
+        assert!(
+            (sortino - expected_sortino).abs() < 1e-12,
+            "sortino {sortino} != expected {expected_sortino}"
+        );
     }
 
     #[test]
@@ -473,6 +589,7 @@ mod tests {
         let config = TimeframeConfig {
             lookback_periods: 10,
             annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
         };
 
         let out = per_ticker_factors(&candles, &config).unwrap();
@@ -504,6 +621,7 @@ mod tests {
         assert!(out.column("price_zscore").is_ok());
         assert!(out.column("annualized_return").is_ok());
         assert!(out.column("sharpe").is_ok());
+        assert!(out.column("sortino").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,13 @@ mod tests {
             "every row carries sharpe as a number (the fixture's closes all vary)"
         );
         assert!(
+            rows.iter().all(|row| row
+                .get("sortino")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries sortino as a number (every fixture ticker has downside)"
+        );
+        assert!(
             rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -56,25 +56,29 @@ impl Timeframe {
     }
 
     /// Factor-engine parameters for this timeframe, ported from the legacy
-    /// `util.py` `TIMEFRAME_CONFIGS`. Fields are added as factors that consume
-    /// them land (e.g. `min_acceptable_return` arrives with the Sortino factor).
+    /// `util.py` `TIMEFRAME_CONFIGS`.
     pub(crate) fn config(self) -> TimeframeConfig {
         match self {
             Self::FifteenMin => TimeframeConfig {
                 lookback_periods: 7 * 24 * 4,
                 annualized_factor: 365.0 * 24.0 * 4.0,
+                // The geometric 15m fraction of the hourly MAR.
+                min_acceptable_return: 1.000_012_5_f64.sqrt().sqrt() - 1.0,
             },
             Self::OneHour => TimeframeConfig {
                 lookback_periods: 7 * 24,
                 annualized_factor: 365.0 * 24.0,
+                min_acceptable_return: 0.000_012_5,
             },
             Self::OneDay => TimeframeConfig {
                 lookback_periods: 90,
                 annualized_factor: 365.0,
+                min_acceptable_return: 0.000_3,
             },
             Self::OneWeek => TimeframeConfig {
                 lookback_periods: 52,
                 annualized_factor: 52.0,
+                min_acceptable_return: 0.002_1,
             },
         }
     }
@@ -86,6 +90,14 @@ pub(crate) struct TimeframeConfig {
     pub(crate) lookback_periods: usize,
     /// Scaling factor to annualize per-period returns and volatility.
     pub(crate) annualized_factor: f64,
+    /// Minimum acceptable per-period return below which a return counts as
+    /// downside risk (the MAR in the Sortino ratio). Derived from Hyperliquid's
+    /// neutral funding interest-rate component of 0.01% per 8 hours (0.00125%
+    /// per hour), per
+    /// <https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding>:
+    /// 1h = 1.25e-5, 1d = 24x that, 1w = 7x daily, 15m = the geometric quarter
+    /// of the hourly rate.
+    pub(crate) min_acceptable_return: f64,
 }
 
 #[cfg(test)]
@@ -109,6 +121,45 @@ mod tests {
         let week = Timeframe::OneWeek.config();
         assert_eq!(week.lookback_periods, 52);
         assert!((week.annualized_factor - 52.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mar_constants_derive_from_the_hyperliquid_neutral_funding_rate() {
+        // Asserting the relationships to the documented venue rate (0.01% per
+        // 8 hours, paid hourly) rather than re-typing the source literals, so
+        // a mistyped constant cannot agree with its own copy in the test.
+        let documented_hourly_rate = 0.01 / 100.0 / 8.0;
+
+        let hour = Timeframe::OneHour.config();
+        assert!(
+            (hour.min_acceptable_return - documented_hourly_rate).abs() < 1e-12,
+            "hourly MAR must equal Hyperliquid's 0.00125% hourly neutral rate"
+        );
+
+        let day = Timeframe::OneDay.config();
+        assert!(
+            24.0f64
+                .mul_add(-hour.min_acceptable_return, day.min_acceptable_return)
+                .abs()
+                < 1e-12,
+            "daily MAR must be 24x the hourly rate"
+        );
+
+        let week = Timeframe::OneWeek.config();
+        assert!(
+            7.0f64
+                .mul_add(-day.min_acceptable_return, week.min_acceptable_return)
+                .abs()
+                < 1e-12,
+            "weekly MAR must be 7x the daily rate"
+        );
+
+        let fifteen = Timeframe::FifteenMin.config();
+        let compounded_back_to_hourly = (1.0 + fifteen.min_acceptable_return).powi(4) - 1.0;
+        assert!(
+            (compounded_back_to_hourly - hour.min_acceptable_return).abs() < 1e-12,
+            "four compounded 15m MARs must reproduce the hourly MAR"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Sharpe penalizes all volatility, including upside. Sortino complements it by
dividing return only by downside deviation below a minimum acceptable return,
which better measures assets with asymmetric returns.

## Solution

Add `sortino = annualized_return / downside deviation below the MAR` as a
per-ticker factor (null when the downside denominator is zero), and add the
minimum-acceptable-return (`MAR`) to `TimeframeConfig`.


Closes #261

<!-- GitButler Footer Boundary Top -->
---
This is **part 14 of 17 in a stack** made with GitButler:
- <kbd>&nbsp;17&nbsp;</kbd> #344
- <kbd>&nbsp;16&nbsp;</kbd> #342
- <kbd>&nbsp;15&nbsp;</kbd> #284
- <kbd>&nbsp;14&nbsp;</kbd> #282
- <kbd>&nbsp;13&nbsp;</kbd> #280
- <kbd>&nbsp;12&nbsp;</kbd> #278
- <kbd>&nbsp;11&nbsp;</kbd> #276
- <kbd>&nbsp;10&nbsp;</kbd> #274
- <kbd>&nbsp;9&nbsp;</kbd> #272
- <kbd>&nbsp;8&nbsp;</kbd> #270
- <kbd>&nbsp;7&nbsp;</kbd> #268
- <kbd>&nbsp;6&nbsp;</kbd> #266
- <kbd>&nbsp;5&nbsp;</kbd> #264
- <kbd>&nbsp;4&nbsp;</kbd> #262 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #260
- <kbd>&nbsp;2&nbsp;</kbd> #258
- <kbd>&nbsp;1&nbsp;</kbd> #256
<!-- GitButler Footer Boundary Bottom -->