### PR TITLE
feat: add lag-1 autocorrelation factor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,9 @@ of them.
 - [x] Factor: beta (per-asset, to benchmark) --
       [#269](https://github.com/data-cartel/moneymentum/issues/269) /
       [#270](https://github.com/data-cartel/moneymentum/pull/270)
+- [x] Factor: 24h volume (screener tie-break) --
+      [#271](https://github.com/data-cartel/moneymentum/issues/271) /
+      [#272](https://github.com/data-cartel/moneymentum/pull/272)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,9 @@ of them.
 - [x] Factor: carry (signed funding) --
       [#267](https://github.com/data-cartel/moneymentum/issues/267) /
       [#268](https://github.com/data-cartel/moneymentum/pull/268)
+- [x] Factor: beta (per-asset, to benchmark) --
+      [#269](https://github.com/data-cartel/moneymentum/issues/269) /
+      [#270](https://github.com/data-cartel/moneymentum/pull/270)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,9 @@ of them.
 - [x] Markets metadata + persisted disable flag --
       [#275](https://github.com/data-cartel/moneymentum/issues/275) /
       [#276](https://github.com/data-cartel/moneymentum/pull/276)
-- [ ] Tradable filter wired into ingestion
+- [x] Tradable filter wired into ingestion --
+      [#277](https://github.com/data-cartel/moneymentum/issues/277) /
+      [#278](https://github.com/data-cartel/moneymentum/pull/278)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,9 @@ of them.
 - [x] Factor: autocorrelation --
       [#263](https://github.com/data-cartel/moneymentum/issues/263) /
       [#264](https://github.com/data-cartel/moneymentum/pull/264)
-- [ ] Factor: information discreteness
+- [x] Factor: information discreteness --
+      [#265](https://github.com/data-cartel/moneymentum/issues/265) /
+      [#266](https://github.com/data-cartel/moneymentum/pull/266)
 - [ ] Factor: carry (signed funding)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,9 @@ of them.
 - [x] Factor: 24h volume (screener tie-break) --
       [#271](https://github.com/data-cartel/moneymentum/issues/271) /
       [#272](https://github.com/data-cartel/moneymentum/pull/272)
-- [ ] Markets metadata + persisted disable flag
+- [x] Markets metadata + persisted disable flag --
+      [#275](https://github.com/data-cartel/moneymentum/issues/275) /
+      [#276](https://github.com/data-cartel/moneymentum/pull/276)
 - [ ] Tradable filter wired into ingestion
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,9 @@ of them.
       TimeframeConfig) --
       [#261](https://github.com/data-cartel/moneymentum/issues/261) /
       [#262](https://github.com/data-cartel/moneymentum/pull/262)
-- [ ] Factor: autocorrelation
+- [x] Factor: autocorrelation --
+      [#263](https://github.com/data-cartel/moneymentum/issues/263) /
+      [#264](https://github.com/data-cartel/moneymentum/pull/264)
 - [ ] Factor: information discreteness
 - [ ] Factor: carry (signed funding)
 - [ ] Markets metadata + persisted disable flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -152,7 +152,11 @@ Find assets by factor characteristics, stage portfolio changes, and simulate the
 result before sending trades.
 
 - [ ] [Compare Target vs Current Portfolio](./stories/0x01a.compare-target-vs-current-portfolio.md)
-- [ ] [Screen Perps By Factor](./stories/0x01c.screen-perps-by-factor.md)
+- [ ] [Screen Perps By Factor](./stories/0x01c.screen-perps-by-factor.md) --
+      backend rank API shipped
+      ([#273](https://github.com/data-cartel/moneymentum/issues/273) /
+      [#274](https://github.com/data-cartel/moneymentum/pull/274)); frontend
+      filter integration pending
 - [ ] [Simulate Staged Portfolio Metrics](./stories/0x01d.simulate-staged-portfolio-metrics.md)
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,9 @@ of them.
 - [x] Factor: information discreteness --
       [#265](https://github.com/data-cartel/moneymentum/issues/265) /
       [#266](https://github.com/data-cartel/moneymentum/pull/266)
-- [ ] Factor: carry (signed funding)
+- [x] Factor: carry (signed funding) --
+      [#267](https://github.com/data-cartel/moneymentum/issues/267) /
+      [#268](https://github.com/data-cartel/moneymentum/pull/268)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion
 

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -17,6 +17,7 @@
 //!   scores.
 //! - [`carry`]: latest signed funding rate, joined into the scores.
 //! - [`asset_beta`]: per-asset beta to the benchmark, joined into the scores.
+//! - [`volume`]: trailing 24h volume, joined into the scores.
 
 mod asset_beta;
 mod autocorrelation;
@@ -24,6 +25,7 @@ mod beta;
 mod carry;
 mod returns;
 mod scores;
+mod volume;
 
 pub(crate) use beta::compute_portfolio_beta_report;
 pub(crate) use scores::compute_factors_json;

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -13,7 +13,10 @@
 //!   served by `POST /beta`.
 //! - [`scores`]: per-ticker factor scores (volatility, cumulative return, SMA,
 //!   mean return, price z-score), served by `GET /factors`.
+//! - [`autocorrelation`]: lag-1 autocorrelation of returns, joined into the
+//!   scores.
 
+mod autocorrelation;
 mod beta;
 mod returns;
 mod scores;

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -15,9 +15,11 @@
 //!   mean return, price z-score), served by `GET /factors`.
 //! - [`autocorrelation`]: lag-1 autocorrelation of returns, joined into the
 //!   scores.
+//! - [`carry`]: latest signed funding rate, joined into the scores.
 
 mod autocorrelation;
 mod beta;
+mod carry;
 mod returns;
 mod scores;
 

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -28,7 +28,7 @@ mod scores;
 mod volume;
 
 pub(crate) use beta::compute_portfolio_beta_report;
-pub(crate) use scores::compute_factors_json;
+pub(crate) use scores::{compute_factors, compute_factors_json};
 
 use thiserror::Error;
 

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -16,7 +16,9 @@
 //! - [`autocorrelation`]: lag-1 autocorrelation of returns, joined into the
 //!   scores.
 //! - [`carry`]: latest signed funding rate, joined into the scores.
+//! - [`asset_beta`]: per-asset beta to the benchmark, joined into the scores.
 
+mod asset_beta;
 mod autocorrelation;
 mod beta;
 mod carry;

--- a/src/factors/asset_beta.rs
+++ b/src/factors/asset_beta.rs
@@ -1,0 +1,167 @@
+//! Per-asset beta to a benchmark: how strongly each asset's returns move with
+//! the benchmark's. This is a per-ticker screener factor, distinct from the
+//! portfolio beta in [`super::beta`].
+
+use polars::prelude::{
+    DataFrame, Expr, IntoLazy, JoinArgs, JoinType, NULL, PolarsError, SortMultipleOptions, col,
+    lit, when,
+};
+
+use super::returns::chronological;
+
+/// Per-ticker beta to `benchmark_ticker` over the last `lookback` paired returns:
+/// `Cov(asset, benchmark) / Var(benchmark)` (population moments).
+///
+/// Returns a `DataFrame` with columns `ticker` and `beta`. Beta is null when the
+/// benchmark has no return variance in the window. The benchmark's beta to
+/// itself is 1.
+pub(super) fn asset_beta_by_ticker(
+    with_returns: &DataFrame,
+    benchmark_ticker: &str,
+    lookback: usize,
+) -> Result<DataFrame, PolarsError> {
+    let benchmark = with_returns
+        .clone()
+        .lazy()
+        .filter(col("ticker").eq(lit(benchmark_ticker)))
+        .select([
+            col("timestamp"),
+            col("log_return").alias("benchmark_return"),
+        ]);
+
+    with_returns
+        .clone()
+        .lazy()
+        // Pair each asset return with the benchmark's return at the same time;
+        // covariance and variance are then measured over the same observations.
+        // Inner join by intent: an asset row without a benchmark row at that
+        // timestamp cannot form a pair and must not survive.
+        .join(
+            benchmark,
+            [col("timestamp")],
+            [col("timestamp")],
+            JoinArgs::new(JoinType::Inner),
+        )
+        // Drop incomplete pairs where either side's return is null (e.g. each
+        // ticker's first candle has no previous close).
+        .filter(
+            col("log_return")
+                .is_not_null()
+                .and(col("benchmark_return").is_not_null()),
+        )
+        .group_by([col("ticker")])
+        .agg([
+            {
+                let asset = chronological("log_return").tail(Some(lookback));
+                let asset_dev = asset.clone() - asset.mean();
+                (asset_dev * benchmark_deviation(lookback))
+                    .sum()
+                    .alias("beta_cov_sum")
+            },
+            (benchmark_deviation(lookback) * benchmark_deviation(lookback))
+                .sum()
+                .alias("beta_var_sum"),
+        ])
+        .with_column(
+            when(col("beta_var_sum").gt(lit(0.0)))
+                .then(col("beta_cov_sum") / col("beta_var_sum"))
+                .otherwise(lit(NULL))
+                .alias("beta"),
+        )
+        .select([col("ticker"), col("beta")])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()
+}
+
+/// Deviation of the benchmark's trailing returns from their window mean, the
+/// term shared by the covariance and variance aggregations above.
+fn benchmark_deviation(lookback: usize) -> Expr {
+    let benchmark_returns = chronological("benchmark_return").tail(Some(lookback));
+    benchmark_returns.clone() - benchmark_returns.mean()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+    use proptest::prelude::*;
+
+    fn returns_frame(btc: &[f64], eth: &[f64]) -> DataFrame {
+        let count = btc.len();
+        let timestamps: Vec<String> = (0..count)
+            .chain(0..count)
+            .map(|index| format!("{index:04}"))
+            .collect();
+        let tickers: Vec<&str> = std::iter::repeat_n("BTC", count)
+            .chain(std::iter::repeat_n("ETH", count))
+            .collect();
+        let log_returns: Vec<f64> = btc.iter().chain(eth.iter()).copied().collect();
+        df! {
+            "timestamp" => timestamps,
+            "ticker" => tickers,
+            "log_return" => log_returns,
+        }
+        .unwrap()
+    }
+
+    #[test]
+    fn beta_to_self_is_one_and_doubled_returns_give_two() {
+        let btc = [0.01, -0.02, 0.03, -0.01, 0.02];
+        let eth: Vec<f64> = btc.iter().map(|value| value * 2.0).collect();
+        let with_returns = returns_frame(&btc, &eth);
+
+        let out = asset_beta_by_ticker(&with_returns, "BTC", 100).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let beta = out.column("beta").unwrap().f64().unwrap();
+
+        assert_eq!(tickers.get(0), Some("BTC"));
+        assert!(
+            (beta.get(0).unwrap() - 1.0).abs() < 1e-12,
+            "the benchmark's beta to itself must be 1"
+        );
+        assert_eq!(tickers.get(1), Some("ETH"));
+        assert!(
+            (beta.get(1).unwrap() - 2.0).abs() < 1e-12,
+            "doubled returns must give beta 2"
+        );
+    }
+
+    #[test]
+    fn beta_is_null_when_benchmark_has_no_variance() {
+        let btc = [0.0, 0.0, 0.0, 0.0];
+        let eth = [0.01, -0.02, 0.03, -0.01];
+        let with_returns = returns_frame(&btc, &eth);
+
+        let out = asset_beta_by_ticker(&with_returns, "BTC", 100).unwrap();
+        let beta = out.column("beta").unwrap().f64().unwrap();
+
+        assert!(
+            beta.iter().all(|beta_value| beta_value.is_none()),
+            "a benchmark with no variance gives undefined (null) beta"
+        );
+    }
+
+    proptest! {
+        /// When an asset's returns are an exact multiple of the benchmark's, beta
+        /// recovers that multiple.
+        #[test]
+        fn beta_recovers_a_linear_coefficient(
+            btc in prop::collection::vec(-0.2_f64..0.2, 4..30),
+            coefficient in -3.0_f64..3.0,
+        ) {
+            prop_assume!(btc.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+            let eth: Vec<f64> = btc.iter().map(|value| value * coefficient).collect();
+            let with_returns = returns_frame(&btc, &eth);
+
+            let out = asset_beta_by_ticker(&with_returns, "BTC", 100).unwrap();
+            let tickers = out.column("ticker").unwrap().str().unwrap();
+            let beta = out.column("beta").unwrap().f64().unwrap();
+            let eth_index = tickers.iter().position(|ticker| ticker == Some("ETH")).unwrap();
+
+            prop_assert!(
+                (beta.get(eth_index).unwrap() - coefficient).abs() < 1e-9,
+                "beta should recover the coefficient {coefficient}"
+            );
+        }
+    }
+}

--- a/src/factors/autocorrelation.rs
+++ b/src/factors/autocorrelation.rs
@@ -1,0 +1,238 @@
+//! Lag-1 autocorrelation of log returns: the Pearson correlation between each
+//! return and the previous one, over the last `corr_lookback` complete pairs.
+
+use polars::prelude::{
+    DataFrame, IntoLazy, NULL, PolarsError, SortMultipleOptions, col, lit, when,
+};
+
+use super::returns::chronological;
+
+/// Per-ticker lag-1 autocorrelation of `log_return` over the last
+/// `corr_lookback` complete `(return, previous return)` pairs.
+///
+/// Returns a `DataFrame` with columns `ticker` and `autocorrelation`. The score
+/// is null when a ticker has no return variation in the window (correlation
+/// undefined) or too few pairs to measure. Uses a consistent-normalization
+/// Pearson correlation, so it always lies in `[-1, 1]`.
+pub(super) fn autocorrelation_by_ticker(
+    with_returns: &DataFrame,
+    corr_lookback: usize,
+) -> Result<DataFrame, PolarsError> {
+    // The lag pairing below relies on row order, so sort here instead of
+    // assuming the caller's frame still carries compute_log_returns ordering.
+    let lag_pairing = col("log_return")
+        .shift(lit(1))
+        .over([col("ticker")])
+        .alias("lag_log_return");
+
+    // Built once and cloned into each aggregation: the covariance and both
+    // variances must share the same window and centering byte-for-byte, or the
+    // output silently stops being a Pearson correlation in [-1, 1].
+    let returns = chronological("log_return").tail(Some(corr_lookback));
+    let lagged = chronological("lag_log_return").tail(Some(corr_lookback));
+    let returns_dev = returns.clone() - returns.mean();
+    let lagged_dev = lagged.clone() - lagged.mean();
+
+    with_returns
+        .clone()
+        .lazy()
+        .sort(["ticker", "timestamp"], SortMultipleOptions::default())
+        .with_column(lag_pairing)
+        // Keep only complete pairs so covariance and both variances are measured
+        // over the same observations (a true Pearson correlation in [-1, 1]).
+        .filter(
+            col("log_return")
+                .is_not_null()
+                .and(col("lag_log_return").is_not_null()),
+        )
+        .group_by([col("ticker")])
+        .agg([
+            (returns_dev.clone() * lagged_dev.clone())
+                .sum()
+                .alias("autocorr_cov_sum"),
+            (returns_dev.clone() * returns_dev)
+                .sum()
+                .alias("autocorr_var_returns"),
+            (lagged_dev.clone() * lagged_dev)
+                .sum()
+                .alias("autocorr_var_lagged"),
+        ])
+        .with_column(
+            when(
+                col("autocorr_var_returns")
+                    .gt(lit(0.0))
+                    .and(col("autocorr_var_lagged").gt(lit(0.0))),
+            )
+            .then(
+                col("autocorr_cov_sum")
+                    / (col("autocorr_var_returns") * col("autocorr_var_lagged")).pow(lit(0.5)),
+            )
+            .otherwise(lit(NULL))
+            .alias("autocorrelation"),
+        )
+        .select([col("ticker"), col("autocorrelation")])
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+    use proptest::prelude::*;
+
+    fn log_returns_frame(closes: &[f64]) -> DataFrame {
+        let count = closes.len();
+        let timestamps: Vec<String> = (0..count).map(|index| format!("{index:04}")).collect();
+        let tickers = vec!["BTC"; count];
+        let candles = df! {
+            "timestamp" => timestamps,
+            "ticker" => tickers,
+            "close" => closes.to_vec(),
+        }
+        .unwrap();
+        super::super::returns::compute_log_returns(&candles).unwrap()
+    }
+
+    #[test]
+    fn autocorrelation_is_minus_one_for_alternating_returns() {
+        // Alternating closes give log returns [+u, -u, +u, ...]; each return is
+        // the negative of the previous one, so the lag-1 correlation is -1.
+        let with_returns =
+            log_returns_frame(&[100.0, 110.0, 100.0, 110.0, 100.0, 110.0, 100.0, 110.0]);
+
+        let out = autocorrelation_by_ticker(&with_returns, 2).unwrap();
+        let autocorrelation = out
+            .column("autocorrelation")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            (autocorrelation - (-1.0)).abs() < 1e-12,
+            "alternating returns must give autocorrelation -1, got {autocorrelation}"
+        );
+    }
+
+    #[test]
+    fn autocorrelation_keeps_tickers_independent() {
+        // BTC alternates (every return is the negative of the previous one,
+        // autocorrelation -1) while ETH's returns grow linearly (each return
+        // is a linear function of the previous one, autocorrelation +1). If
+        // the group_by leaked one ticker's value into the other, at least one
+        // of the two opposite-sign assertions would fail.
+        let btc_closes = [100.0, 110.0, 100.0, 110.0, 100.0, 110.0_f64];
+        let eth_returns = [0.01, 0.02, 0.03, 0.04, 0.05_f64];
+        let eth_closes: Vec<f64> = std::iter::once(100.0)
+            .chain(eth_returns.iter().scan(100.0, |close, log_return| {
+                *close *= log_return.exp();
+                Some(*close)
+            }))
+            .collect();
+
+        let timestamps: Vec<String> = (0..btc_closes.len())
+            .chain(0..eth_closes.len())
+            .map(|index| format!("{index:04}"))
+            .collect();
+        let tickers: Vec<&str> = std::iter::repeat_n("BTC", btc_closes.len())
+            .chain(std::iter::repeat_n("ETH", eth_closes.len()))
+            .collect();
+        let closes: Vec<f64> = btc_closes
+            .iter()
+            .chain(eth_closes.iter())
+            .copied()
+            .collect();
+        let candles = df! {
+            "timestamp" => timestamps,
+            "ticker" => tickers,
+            "close" => closes,
+        }
+        .unwrap();
+        let with_returns = super::super::returns::compute_log_returns(&candles).unwrap();
+
+        let out = autocorrelation_by_ticker(&with_returns, 10).unwrap();
+        let by_ticker = |ticker: &str| -> f64 {
+            let index = out
+                .column("ticker")
+                .unwrap()
+                .str()
+                .unwrap()
+                .iter()
+                .position(|value| value == Some(ticker))
+                .expect("ticker present");
+            out.column("autocorrelation")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(index)
+                .expect("autocorrelation present")
+        };
+
+        let btc = by_ticker("BTC");
+        let eth = by_ticker("ETH");
+        assert!(
+            (btc - (-1.0)).abs() < 1e-9,
+            "BTC alternating returns must give -1, got {btc}"
+        );
+        assert!(
+            (eth - 1.0).abs() < 1e-9,
+            "ETH linearly growing returns must give +1, got {eth}"
+        );
+    }
+
+    #[test]
+    fn autocorrelation_windows_only_the_trailing_pairs() {
+        // The early closes alternate (lag-1 autocorrelation -1); only the
+        // last stretch grows linearly (+1). With a pair window covering just
+        // the trailing stretch, the alternating prefix must not leak in --
+        // a full-window computation would land far below +1.
+        let closes = [
+            100.0, 110.0, 100.0, 110.0, 100.0, // alternating prefix
+            101.0, 103.0, 106.0, 110.0, 115.0, 121.0_f64, // linear-return tail
+        ];
+        let with_returns = log_returns_frame(&closes);
+
+        let out = autocorrelation_by_ticker(&with_returns, 4).unwrap();
+        let autocorrelation = out
+            .column("autocorrelation")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            autocorrelation > 0.9,
+            "the trailing window holds only the trend, so the alternating \
+             prefix must not drag the score down, got {autocorrelation}"
+        );
+    }
+
+    #[test]
+    fn autocorrelation_is_null_for_constant_prices() {
+        let with_returns = log_returns_frame(&[100.0, 100.0, 100.0, 100.0, 100.0]);
+
+        let out = autocorrelation_by_ticker(&with_returns, 10).unwrap();
+        let autocorrelation = out.column("autocorrelation").unwrap().f64().unwrap().get(0);
+        assert!(
+            autocorrelation.is_none(),
+            "constant prices have no return variation, so autocorrelation must be null, got {autocorrelation:?}"
+        );
+    }
+
+    proptest! {
+        /// A correlation coefficient always lies in [-1, 1] whenever it is defined.
+        #[test]
+        fn autocorrelation_is_within_unit_interval(
+            closes in prop::collection::vec(1.0_f64..1_000_000.0, 5..60),
+        ) {
+            let with_returns = log_returns_frame(&closes);
+            let out = autocorrelation_by_ticker(&with_returns, 10).unwrap();
+            if let Some(autocorrelation) = out.column("autocorrelation").unwrap().f64().unwrap().get(0) {
+                prop_assert!(
+                    (-1.0 - 1e-9..=1.0 + 1e-9).contains(&autocorrelation),
+                    "autocorrelation {autocorrelation} outside [-1, 1]"
+                );
+            }
+        }
+    }
+}

--- a/src/factors/carry.rs
+++ b/src/factors/carry.rs
@@ -1,0 +1,138 @@
+//! Carry factor: the latest signed funding rate per asset, joined into the
+//! per-ticker factor scores from `funding_rate1h.csv`.
+
+use polars::prelude::{
+    DataFrame, DataFrameJoinOps, DataType, IntoLazy, JoinArgs, JoinType, NULL, PolarsError,
+    SortMultipleOptions, col, lit,
+};
+
+use super::returns::chronological;
+
+/// Joins the carry factor (latest signed funding rate per ticker) into `factors`.
+///
+/// When funding data is absent, adds a null `carry` column so the factor table
+/// keeps a stable schema.
+pub(super) fn with_carry(
+    factors: DataFrame,
+    funding: Option<&DataFrame>,
+) -> Result<DataFrame, PolarsError> {
+    match funding {
+        Some(funding) => {
+            let carry = carry_by_ticker(funding)?;
+            Ok(factors.join(
+                &carry,
+                ["ticker"],
+                ["ticker"],
+                JoinArgs::new(JoinType::Left),
+                None,
+            )?)
+        }
+        None => Ok(factors
+            .lazy()
+            .with_column(lit(NULL).cast(DataType::Float64).alias("carry"))
+            .collect()?),
+    }
+}
+
+/// Latest funding rate per symbol, as a `DataFrame` keyed by `ticker`.
+///
+/// Funding rates are signed: positive means longs pay shorts, so a positive
+/// carry is a cost of being long and a yield for being short.
+fn carry_by_ticker(funding: &DataFrame) -> Result<DataFrame, PolarsError> {
+    funding
+        .clone()
+        .lazy()
+        .group_by([col("symbol")])
+        .agg([chronological("funding_rate").last().alias("carry")])
+        .select([col("symbol").alias("ticker"), col("carry")])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+
+    fn sample_funding() -> DataFrame {
+        // BTC's latest rate comes first so "latest" must win by timestamp,
+        // not by row order surviving into the group.
+        df! {
+            "timestamp" => &[
+                "2024-01-01T01:00:00Z",
+                "2024-01-01T00:00:00Z",
+                "2024-01-01T00:00:00Z",
+            ],
+            "funding_rate" => &[0.0003, 0.0001, -0.0002_f64],
+            "symbol" => &["BTC", "BTC", "ETH"],
+        }
+        .unwrap()
+    }
+
+    #[test]
+    fn carry_is_latest_funding_rate_per_symbol() {
+        let out = carry_by_ticker(&sample_funding()).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let carry = out.column("carry").unwrap().f64().unwrap();
+
+        assert_eq!(tickers.get(0), Some("BTC"));
+        assert!(
+            (carry.get(0).unwrap() - 0.0003).abs() < 1e-12,
+            "BTC carry should be the latest funding rate 0.0003"
+        );
+        assert_eq!(tickers.get(1), Some("ETH"));
+        assert!(
+            (carry.get(1).unwrap() - (-0.0002)).abs() < 1e-12,
+            "ETH carry should be its only funding rate -0.0002"
+        );
+    }
+
+    #[test]
+    fn with_carry_joins_latest_funding_onto_factors() {
+        // SOL has candles but no funding entry -- the most common real-world
+        // case. The left join must keep it with a null carry; an accidental
+        // inner join would silently drop every asset without a perp listing.
+        let factors = df! {
+            "ticker" => &["BTC", "ETH", "SOL"],
+            "sma" => &[1.0, 2.0, 3.0_f64],
+        }
+        .unwrap();
+
+        let out = with_carry(factors, Some(&sample_funding())).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let carry = out.column("carry").unwrap().f64().unwrap();
+        let carry_for = |ticker: &str| {
+            let index = (0..tickers.len())
+                .find(|&index| tickers.get(index) == Some(ticker))
+                .expect("every factors ticker survives the join");
+
+            carry.get(index)
+        };
+
+        assert!((carry_for("BTC").unwrap() - 0.0003).abs() < 1e-12);
+        assert!((carry_for("ETH").unwrap() - (-0.0002)).abs() < 1e-12);
+        assert!(
+            carry_for("SOL").is_none(),
+            "a ticker without funding data must keep a null carry, not vanish"
+        );
+    }
+
+    #[test]
+    fn with_carry_adds_null_column_when_funding_absent() {
+        let factors = df! {
+            "ticker" => &["BTC"],
+            "sma" => &[1.0_f64],
+        }
+        .unwrap();
+
+        let out = with_carry(factors, None).unwrap();
+        assert!(
+            out.column("carry").is_ok(),
+            "carry column is always present"
+        );
+        assert!(
+            out.column("carry").unwrap().f64().unwrap().get(0).is_none(),
+            "carry is null when there is no funding data"
+        );
+    }
+}

--- a/src/factors/returns.rs
+++ b/src/factors/returns.rs
@@ -3,13 +3,23 @@
 //! `log_return = ln(close_t / close_{t-1})`, computed per ticker.
 
 use polars::prelude::{
-    ChunkApply, DataFrame, IntoLazy, IntoSeries, NULL, PolarsError, SortMultipleOptions, col, lit,
-    when,
+    ChunkApply, DataFrame, Expr, IntoLazy, IntoSeries, NULL, PolarsError, SortMultipleOptions, col,
+    lit, when,
 };
 use tracing::debug;
 
 /// Daily candles needed for a 365-calendar-day log-return window.
 pub(super) const LOG_RETURNS_LOOKBACK_CANDLES: usize = 366;
+
+/// A column's values sorted by candle timestamp, for use inside `group_by`
+/// aggregations.
+///
+/// Polars does not document the order of values gathered per group, so any
+/// trailing-window selection (`tail`, `last`) must sort explicitly instead of
+/// relying on the input frame's row order surviving the grouping.
+pub(super) fn chronological(column: &str) -> Expr {
+    col(column).sort_by([col("timestamp")], SortMultipleOptions::default())
+}
 
 /// Sort by ticker and timestamp, then add a per-ticker `log_return` column.
 ///

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -12,6 +12,7 @@ use tracing::{info, instrument};
 
 use super::ReturnsError;
 use super::autocorrelation::autocorrelation_by_ticker;
+use super::carry::with_carry;
 use super::returns::compute_log_returns;
 use crate::timeframe::{Timeframe, TimeframeConfig};
 
@@ -20,8 +21,8 @@ const PRICE_STDDEV_EPS: f64 = 1e-8;
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
 /// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
-/// `autocorrelation`, and `information_discreteness`; further factors are added
-/// as columns as they land.
+/// `autocorrelation`, `information_discreteness`, and `carry`; further factors
+/// are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -51,6 +52,8 @@ pub(crate) async fn compute_factors_json(
 ///   `lookback_periods` / 4 pairs; null when returns have no variation
 /// - `information_discreteness` = sign(`cum_return`) * (fraction of negative
 ///   returns - fraction of positive returns); -1 for a smooth trend
+/// - `carry` = latest signed funding rate from `funding_rate1h.csv`; null when
+///   no funding data is available
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -60,8 +63,13 @@ async fn compute_factors(data_dir: &Path, timeframe: Timeframe) -> Result<DataFr
     let Some(df) = df else {
         return Err(ReturnsError::NoData { path });
     };
+    let funding = crate::dataframe::read_csv(data_dir.join(crate::funding::file_name())).await?;
     let config = timeframe.config();
-    let out = tokio::task::spawn_blocking(move || per_ticker_factors(&df, &config)).await??;
+    let out = tokio::task::spawn_blocking(move || {
+        let factors = per_ticker_factors(&df, &config)?;
+        with_carry(factors, funding.as_ref())
+    })
+    .await??;
     info!(tickers = out.height(), "factors computed");
     Ok(out)
 }
@@ -820,8 +828,46 @@ mod tests {
         assert!(out.column("sortino").is_ok());
         assert!(out.column("autocorrelation").is_ok());
         assert!(out.column("information_discreteness").is_ok());
+        assert!(out.column("carry").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
+            &["factors computed"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn compute_factors_joins_latest_carry_from_funding_file() {
+        let tmp_dir = TempDir::new().unwrap();
+        fs::copy(
+            "fixtures/ohlcv_1d_beta.csv",
+            tmp_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+        fs::write(
+            tmp_dir.path().join("funding_rate1h.csv"),
+            "timestamp,funding_rate,symbol\n\
+             2024-01-01T00:00:00Z,0.0001,BTC\n\
+             2024-01-02T00:00:00Z,0.0005,BTC\n",
+        )
+        .unwrap();
+
+        let out = compute_factors(tmp_dir.path(), Timeframe::OneDay)
+            .await
+            .unwrap();
+
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let carry = out.column("carry").unwrap().f64().unwrap();
+        let btc_index = (0..tickers.len())
+            .find(|&index| tickers.get(index) == Some("BTC"))
+            .expect("BTC present");
+        assert!(
+            (carry.get(btc_index).unwrap() - 0.0005).abs() < 1e-12,
+            "BTC carry should be the latest funding rate 0.0005"
+        );
+
+        assert!(crate::logs_contain_at(
+            tracing::Level::DEBUG,
             &["factors computed"]
         ));
     }

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -4,12 +4,13 @@
 use std::path::Path;
 
 use polars::prelude::{
-    ChunkApply, DataFrame, IntoLazy, IntoSeries, JsonFormat, JsonWriter, NULL, PolarsError,
-    SerWriter, SortMultipleOptions, col, lit, when,
+    ChunkApply, DataFrame, DataFrameJoinOps, IntoLazy, IntoSeries, JoinArgs, JoinType, JsonFormat,
+    JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit, when,
 };
 use tracing::{info, instrument};
 
 use super::ReturnsError;
+use super::autocorrelation::autocorrelation_by_ticker;
 use super::returns::compute_log_returns;
 use crate::timeframe::{Timeframe, TimeframeConfig};
 
@@ -17,8 +18,8 @@ const PRICE_STDDEV_EPS: f64 = 1e-8;
 
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
-/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, and `sortino`;
-/// further factors are added as columns as they land.
+/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`, and
+/// `autocorrelation`; further factors are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -44,6 +45,8 @@ pub(crate) async fn compute_factors_json(
 ///   null when there is no volatility
 /// - `sortino` = `annualized_return` / downside deviation below the MAR; null
 ///   when there is no downside
+/// - `autocorrelation` = lag-1 autocorrelation of returns over the last
+///   `lookback_periods` / 4 pairs; null when returns have no variation
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -70,6 +73,17 @@ fn per_ticker_factors(
     let lookback = config.lookback_periods;
     let annualization_multiplier = config.annualized_factor.sqrt();
 
+    // Lag-1 autocorrelation needs its own complete-pairs pass over a shorter
+    // window, computed separately and joined back in by ticker below.
+    //
+    // The pair window is a quarter of the factor lookback (e.g. 22 pairs on
+    // the 90-period daily window): a shorter window makes the score track the
+    // recent regime instead of averaging lag-1 persistence over the whole
+    // lookback.
+    const AUTOCORRELATION_WINDOW_DIVISOR: usize = 4;
+    let autocorrelation =
+        autocorrelation_by_ticker(&with_returns, lookback / AUTOCORRELATION_WINDOW_DIVISOR)?;
+
     // Downside deviation inputs for Sortino: sum of squared shortfalls below the
     // minimum acceptable return, and the observation count to average over.
     let above_mar = col("log_return").tail(Some(lookback)) - lit(config.min_acceptable_return);
@@ -79,7 +93,7 @@ fn per_ticker_factors(
         .sum()
         .alias("downside_sq_sum");
 
-    let mut factors = with_returns
+    let factors = with_returns
         .lazy()
         .group_by([col("ticker")])
         .agg([
@@ -116,6 +130,28 @@ fn per_ticker_factors(
         .sort(["ticker"], SortMultipleOptions::default())
         .collect()?;
 
+    let factors = add_return_and_risk_factors(factors, config.annualized_factor)?;
+
+    let factors = factors.join(
+        &autocorrelation,
+        ["ticker"],
+        ["ticker"],
+        JoinArgs::new(JoinType::Left),
+        None,
+    )?;
+
+    Ok(factors)
+}
+
+/// Derives the return and risk-adjusted factors from the aggregated columns and
+/// drops the intermediate sums/counts they were computed from.
+///
+/// Adds `cum_return`, `annualized_return`, `sharpe`, and `sortino`.
+/// `sharpe`/`sortino` are null when their risk denominator is zero.
+fn add_return_and_risk_factors(
+    mut factors: DataFrame,
+    annualized_factor: f64,
+) -> Result<DataFrame, PolarsError> {
     // cum_return = exp(sum of log returns) - 1, and annualized_return =
     // exp(mean_return * annualized_factor) - 1. exp is applied on the series
     // (like compute_log_returns does for ln) to avoid a polars math-expr feature.
@@ -127,7 +163,6 @@ fn per_ticker_factors(
         .with_name("cum_return".into());
     factors.with_column(cum_return)?;
 
-    let annualized_factor = config.annualized_factor;
     let annualized_return = factors
         .column("mean_return")?
         .f64()?
@@ -157,7 +192,7 @@ fn per_ticker_factors(
     // annualized_return / downside deviation below the MAR. Both are undefined
     // (null) when their risk denominator is zero.
     let downside_deviation = (col("downside_sq_sum") / col("obs_count")).pow(lit(0.5));
-    let mut factors = factors
+    let factors = factors
         .lazy()
         .with_columns([
             // NaN != 0.0 is true in IEEE 754, so a NaN volatility (e.g. from a
@@ -184,9 +219,8 @@ fn per_ticker_factors(
             .otherwise(lit(NULL))
             .alias("sortino"),
         ])
+        .drop(cols(["downside_sq_sum", "obs_count"]))
         .collect()?;
-    factors.drop_in_place("downside_sq_sum")?;
-    factors.drop_in_place("obs_count")?;
 
     Ok(factors)
 }
@@ -536,6 +570,13 @@ mod tests {
             sortino.is_none(),
             "constant prices give an undefined (null) sortino, got {sortino:?}"
         );
+
+        // No return variation means autocorrelation is undefined -> null.
+        let autocorrelation = out.column("autocorrelation").unwrap().f64().unwrap().get(0);
+        assert!(
+            autocorrelation.is_none(),
+            "constant prices give an undefined (null) autocorrelation, got {autocorrelation:?}"
+        );
     }
 
     #[test]
@@ -622,6 +663,7 @@ mod tests {
         assert!(out.column("annualized_return").is_ok());
         assert!(out.column("sharpe").is_ok());
         assert!(out.column("sortino").is_ok());
+        assert!(out.column("autocorrelation").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -8,13 +8,14 @@ use polars::prelude::{
     JsonFormat, JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit,
     when,
 };
-use tracing::{info, instrument};
+use tracing::{debug, instrument};
 
 use super::ReturnsError;
 use super::asset_beta::asset_beta_by_ticker;
 use super::autocorrelation::autocorrelation_by_ticker;
 use super::carry::with_carry;
-use super::returns::compute_log_returns;
+use super::returns::{chronological, compute_log_returns};
+use super::volume::with_volume_24h;
 use crate::timeframe::{Timeframe, TimeframeConfig};
 
 const PRICE_STDDEV_EPS: f64 = 1e-8;
@@ -26,8 +27,8 @@ const BENCHMARK_TICKER: &str = "BTC";
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
 /// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
-/// `autocorrelation`, `information_discreteness`, `carry`, and `beta`; further
-/// factors are added as columns as they land.
+/// `autocorrelation`, `information_discreteness`, `carry`, `beta`, and
+/// `volume_24h`; further factors are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -61,6 +62,9 @@ pub(crate) async fn compute_factors_json(
 ///   no funding data is available
 /// - `beta` = per-asset beta to the benchmark (BTC) over the lookback; null when
 ///   the benchmark has no return variance
+/// - `volume_24h` = quote notional (`volume * close`) summed over the
+///   dataset's trailing day of candles; null for a ticker with no candles in
+///   that window. On 1w this is the latest weekly candle -- a week's notional
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -72,12 +76,14 @@ async fn compute_factors(data_dir: &Path, timeframe: Timeframe) -> Result<DataFr
     };
     let funding = crate::dataframe::read_csv(data_dir.join(crate::funding::file_name())).await?;
     let config = timeframe.config();
+    let candles_per_day = timeframe.candles_per_day();
     let out = tokio::task::spawn_blocking(move || {
         let factors = per_ticker_factors(&df, &config)?;
+        let factors = with_volume_24h(&factors, &df, candles_per_day)?;
         with_carry(factors, funding.as_ref())
     })
     .await??;
-    info!(tickers = out.height(), "factors computed");
+    debug!(tickers = out.height(), "factors computed");
     Ok(out)
 }
 
@@ -105,9 +111,14 @@ fn per_ticker_factors(
         autocorrelation_by_ticker(&with_returns, lookback / AUTOCORRELATION_WINDOW_DIVISOR)?;
     let asset_beta = asset_beta_by_ticker(&with_returns, BENCHMARK_TICKER, lookback)?;
 
+    // Every factor must window the same trailing rows: single-source the two
+    // window expressions so one factor cannot silently diverge from the rest.
+    let trailing_returns = || chronological("log_return").tail(Some(lookback));
+    let trailing_closes = || chronological("close").tail(Some(lookback));
+
     // Downside deviation inputs for Sortino: sum of squared shortfalls below the
     // minimum acceptable return, and the observation count to average over.
-    let above_mar = col("log_return").tail(Some(lookback)) - lit(config.min_acceptable_return);
+    let above_mar = trailing_returns() - lit(config.min_acceptable_return);
     let downside_sq_sum = when(above_mar.clone().lt(lit(0.0)))
         .then(above_mar.pow(lit(2)))
         .otherwise(lit(0.0))
@@ -118,42 +129,33 @@ fn per_ticker_factors(
         .lazy()
         .group_by([col("ticker")])
         .agg([
-            (col("log_return").tail(Some(lookback)).std(1) * lit(annualization_multiplier))
+            (trailing_returns().std(1) * lit(annualization_multiplier))
                 .alias("annualized_volatility"),
-            col("log_return")
-                .tail(Some(lookback))
-                .sum()
-                .alias("cum_log_return"),
-            col("close").tail(Some(lookback)).mean().alias("sma"),
-            col("log_return")
-                .tail(Some(lookback))
-                .mean()
-                .alias("mean_return"),
-            col("close")
-                .tail(Some(lookback))
-                .std(1)
-                .alias("price_stddev"),
-            col("close").last().alias("last_close"),
+            trailing_returns().sum().alias("cum_log_return"),
+            trailing_closes().mean().alias("sma"),
+            trailing_returns().mean().alias("mean_return"),
+            trailing_closes().std(1).alias("price_stddev"),
+            chronological("close").last().alias("last_close"),
             downside_sq_sum,
-            col("log_return")
-                .tail(Some(lookback))
-                .count()
-                .alias("obs_count"),
-            (col("log_return").tail(Some(lookback)).gt(lit(0.0)))
-                .sum()
-                .alias("pos_count"),
-            (col("log_return").tail(Some(lookback)).lt(lit(0.0)))
-                .sum()
-                .alias("neg_count"),
+            trailing_returns().count().alias("obs_count"),
+            (trailing_returns().gt(lit(0.0))).sum().alias("pos_count"),
+            (trailing_returns().lt(lit(0.0))).sum().alias("neg_count"),
         ])
         // price z-score = (latest close - SMA) / price stddev; undefined (null)
-        // when there is no price dispersion (constant prices over the window).
+        // when there is no price dispersion (constant prices over the window)
+        // or no measurable dispersion at all (a NaN stddev must never pass the
+        // guard, mirroring the annualized_return finiteness guard).
         .with_column(
-            when(col("price_stddev").gt(lit(PRICE_STDDEV_EPS)))
-                .then((col("last_close") - col("sma")) / col("price_stddev"))
-                .otherwise(lit(NULL))
-                .alias("price_zscore"),
+            when(
+                col("price_stddev")
+                    .is_finite()
+                    .and(col("price_stddev").gt(lit(PRICE_STDDEV_EPS))),
+            )
+            .then((col("last_close") - col("sma")) / col("price_stddev"))
+            .otherwise(lit(NULL))
+            .alias("price_zscore"),
         )
+        .drop(cols(["price_stddev", "last_close"]))
         .sort(["ticker"], SortMultipleOptions::default())
         .collect()?;
 
@@ -222,8 +224,6 @@ fn add_return_and_risk_factors(
         .collect()?;
 
     factors.drop_in_place("cum_log_return")?;
-    factors.drop_in_place("price_stddev")?;
-    factors.drop_in_place("last_close")?;
 
     let downside_deviation = (col("downside_sq_sum") / col("obs_count")).pow(lit(0.5));
 
@@ -473,6 +473,230 @@ mod tests {
                 "a smooth uptrend must give information_discreteness -1, got {information_discreteness}"
             );
         }
+    }
+
+    #[test]
+    fn factor_windows_select_the_chronologically_latest_returns() {
+        // 8 candles per ticker with a lookback of 3: the first five closes are
+        // flat (zero returns), the last three returns are ln(1.1), ln(1/1.1),
+        // ln(1.1). A stale window of zeros gives cum_return 0 instead of 0.1,
+        // and while one other window ([0, 0, ln(1.1)]) also sums to ln(1.1),
+        // the sma assertion below discriminates it (its closes average lower
+        // than the trailing window's).
+        let candles = df! {
+            "timestamp" => &[
+                "0", "1", "2", "3", "4", "5", "6", "7",
+                "0", "1", "2", "3", "4", "5", "6", "7",
+            ],
+            "ticker" => &["BTC"; 8].iter().chain(&["ETH"; 8]).copied().collect::<Vec<_>>(),
+            "close" => &[
+                100.0, 100.0, 100.0, 100.0, 100.0, 110.0, 100.0, 110.0,
+                200.0, 200.0, 200.0, 200.0, 200.0, 220.0, 200.0, 220.0_f64,
+            ],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 3,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let ticker_column = out.column("ticker").unwrap().str().unwrap();
+        for (ticker, expected_sma) in [
+            ("BTC", (110.0 + 100.0 + 110.0) / 3.0),
+            ("ETH", (220.0 + 200.0 + 220.0) / 3.0),
+        ] {
+            let row_index = (0..out.height())
+                .find(|row| ticker_column.get(*row) == Some(ticker))
+                .expect("ticker row present in the factor output");
+
+            let cum_return = out
+                .column("cum_return")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(row_index)
+                .unwrap();
+            assert!(
+                (cum_return - 0.1).abs() < 1e-12,
+                "{ticker}: trailing-window cum_return must be 0.1, got {cum_return}"
+            );
+
+            let sma = out
+                .column("sma")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(row_index)
+                .unwrap();
+            assert!(
+                (sma - expected_sma).abs() < 1e-9,
+                "{ticker}: sma over the trailing window must be {expected_sma}, got {sma}"
+            );
+        }
+    }
+
+    #[test]
+    fn per_ticker_factors_sharpe_is_null_when_a_zero_close_poisons_volatility() {
+        // A zero close produces a -inf log return: std over the window goes
+        // NaN while annualized_return collapses to a finite -1, so only the
+        // is_finite() denominator guard stands between this input and a NaN
+        // sharpe in the /factors JSON.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[100.0, 0.0, 101.0],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let sharpe = out.column("sharpe").unwrap().f64().unwrap().get(0);
+        assert!(
+            sharpe.is_none_or(|value| !value.is_nan()),
+            "a NaN volatility must never produce a NaN sharpe, got {sharpe:?}"
+        );
+
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0);
+        assert!(
+            information_discreteness.is_none(),
+            "a NaN cum_return is unmeasurable, not \"perfectly choppy\": \
+             information_discreteness must be null, got {information_discreteness:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_sharpe_is_negative_for_a_downtrend() {
+        // Every other sharpe test uses a non-negative return, so a sign error
+        // in the formula (e.g. an accidental abs on the numerator) would pass
+        // the whole suite while misranking every asset in a drawdown.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 99.0, 97.5, 95.0],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let sharpe = out
+            .column("sharpe")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .expect("a varying downtrend has non-zero volatility");
+        assert!(
+            sharpe < 0.0,
+            "a losing asset must have a negative sharpe, got {sharpe}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_nulls_annualized_return_when_exp_overflows() {
+        // exp(mean_return * annualized_factor) overflows f64 for an extreme
+        // mean return; the guard must surface null, never inf, which would
+        // corrupt screener rankings and is unrepresentable in JSON. Two
+        // distinct returns keep the volatility finite and non-zero, so the
+        // sharpe assertion below genuinely tests null propagation from
+        // annualized_return rather than a null-volatility shortcut.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[1.0, 1e100, 1e150_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let annualized_return = out
+            .column("annualized_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0);
+        assert!(
+            annualized_return.is_none(),
+            "an overflowing annualized return must be null, got {annualized_return:?}"
+        );
+        let sharpe = out.column("sharpe").unwrap().f64().unwrap().get(0);
+        assert!(
+            sharpe.is_none(),
+            "sharpe derives from annualized_return and must be null too, got {sharpe:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_zscore_is_null_when_a_close_is_nan() {
+        // A NaN close poisons the window's stddev to NaN, and NaN != 0.0 is
+        // true in IEEE 754 - without the is_finite() guard the z-score would
+        // serialize as NaN and silently dominate any z-score-ranked output.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[100.0, f64::NAN, 101.0],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0);
+        assert!(
+            zscore.is_none(),
+            "a NaN close gives no measurable dispersion, so price_zscore must be null, got {zscore:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_zscore_is_null_for_a_single_candle_ticker() {
+        // A single observation yields a null (not NaN) stddev from std(ddof=1);
+        // pin the documented null so the edge stays covered.
+        let candles = df! {
+            "timestamp" => &["0"],
+            "ticker" => &["BTC"],
+            "close" => &[100.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0);
+        assert!(
+            zscore.is_none(),
+            "a single candle has no price dispersion, so price_zscore must be null, got {zscore:?}"
+        );
     }
 
     #[test]
@@ -847,20 +1071,75 @@ mod tests {
             .unwrap();
 
         assert!(out.height() > 0, "expected a factor row per ticker");
-        assert!(out.column("annualized_volatility").is_ok());
-        assert!(out.column("cum_return").is_ok());
-        assert!(out.column("sma").is_ok());
-        assert!(out.column("mean_return").is_ok());
-        assert!(out.column("price_zscore").is_ok());
-        assert!(out.column("annualized_return").is_ok());
-        assert!(out.column("sharpe").is_ok());
-        assert!(out.column("sortino").is_ok());
-        assert!(out.column("autocorrelation").is_ok());
-        assert!(out.column("information_discreteness").is_ok());
-        assert!(out.column("carry").is_ok());
-        assert!(out.column("beta").is_ok());
+
+        // Pin real values for a known fixture ticker (the value lookups also
+        // prove every column exists); schema presence alone would pass on
+        // all-NaN output.
+        let ticker_column = out.column("ticker").unwrap().str().unwrap();
+        let btc_row = (0..out.height())
+            .find(|row| ticker_column.get(*row) == Some("BTC"))
+            .expect("BTC present in the fixture");
+        let btc_volatility = out
+            .column("annualized_volatility")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(btc_row)
+            .expect("BTC volatility computed");
+        assert!(
+            btc_volatility.is_finite() && btc_volatility > 0.0,
+            "BTC volatility must be a positive finite number, got {btc_volatility}"
+        );
+        let btc_cum_return = out
+            .column("cum_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(btc_row)
+            .expect("BTC cum_return computed");
+        assert!(
+            btc_cum_return.is_finite() && btc_cum_return > 0.0,
+            "the fixture's BTC closes rise over the lookback window, so \
+             cum_return must be positive, got {btc_cum_return}"
+        );
+
+        // The fixture's BTC series varies, so every series-derived factor must
+        // be a real number for BTC, not null.
+        for factor_column in [
+            "sma",
+            "mean_return",
+            "price_zscore",
+            "annualized_return",
+            "sharpe",
+            "sortino",
+            "autocorrelation",
+            "information_discreteness",
+            "beta",
+            "volume_24h",
+        ] {
+            let value = out
+                .column(factor_column)
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(btc_row);
+            assert!(
+                value.is_some_and(f64::is_finite),
+                "BTC {factor_column} must be a finite number, got {value:?}"
+            );
+        }
+
+        // No funding file was written, so carry must be null - the documented
+        // no-funding-data behavior (the carry join is covered with real data by
+        // compute_factors_joins_latest_carry_from_funding_file).
+        let btc_carry = out.column("carry").unwrap().f64().unwrap().get(btc_row);
+        assert!(
+            btc_carry.is_none(),
+            "carry must be null without funding data, got {btc_carry:?}"
+        );
+
         assert!(crate::logs_contain_at(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["factors computed"]
         ));
     }

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -4,8 +4,9 @@
 use std::path::Path;
 
 use polars::prelude::{
-    ChunkApply, DataFrame, DataFrameJoinOps, IntoLazy, IntoSeries, JoinArgs, JoinType, JsonFormat,
-    JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit, when,
+    ChunkApply, DataFrame, DataFrameJoinOps, DataType, IntoLazy, IntoSeries, JoinArgs, JoinType,
+    JsonFormat, JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit,
+    when,
 };
 use tracing::{info, instrument};
 
@@ -18,8 +19,9 @@ const PRICE_STDDEV_EPS: f64 = 1e-8;
 
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
-/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`, and
-/// `autocorrelation`; further factors are added as columns as they land.
+/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
+/// `autocorrelation`, and `information_discreteness`; further factors are added
+/// as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -47,6 +49,8 @@ pub(crate) async fn compute_factors_json(
 ///   when there is no downside
 /// - `autocorrelation` = lag-1 autocorrelation of returns over the last
 ///   `lookback_periods` / 4 pairs; null when returns have no variation
+/// - `information_discreteness` = sign(`cum_return`) * (fraction of negative
+///   returns - fraction of positive returns); -1 for a smooth trend
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -118,6 +122,12 @@ fn per_ticker_factors(
                 .tail(Some(lookback))
                 .count()
                 .alias("obs_count"),
+            (col("log_return").tail(Some(lookback)).gt(lit(0.0)))
+                .sum()
+                .alias("pos_count"),
+            (col("log_return").tail(Some(lookback)).lt(lit(0.0)))
+                .sum()
+                .alias("neg_count"),
         ])
         // price z-score = (latest close - SMA) / price stddev; undefined (null)
         // when there is no price dispersion (constant prices over the window).
@@ -146,8 +156,10 @@ fn per_ticker_factors(
 /// Derives the return and risk-adjusted factors from the aggregated columns and
 /// drops the intermediate sums/counts they were computed from.
 ///
-/// Adds `cum_return`, `annualized_return`, `sharpe`, and `sortino`.
-/// `sharpe`/`sortino` are null when their risk denominator is zero.
+/// Adds `cum_return`, `annualized_return`, `sharpe`, `sortino`, and
+/// `information_discreteness`. `sharpe`/`sortino` are null when their risk
+/// denominator is zero; `information_discreteness` is `sign(cum_return)` times
+/// the negative-minus-positive return fraction.
 fn add_return_and_risk_factors(
     mut factors: DataFrame,
     annualized_factor: f64,
@@ -188,10 +200,21 @@ fn add_return_and_risk_factors(
     factors.drop_in_place("price_stddev")?;
     factors.drop_in_place("last_close")?;
 
-    // sharpe = annualized_return / annualized_volatility (risk-free 0); sortino =
-    // annualized_return / downside deviation below the MAR. Both are undefined
-    // (null) when their risk denominator is zero.
     let downside_deviation = (col("downside_sq_sum") / col("obs_count")).pow(lit(0.5));
+
+    // information discreteness = sign(cum_return) * (pct_negative - pct_positive):
+    // -1 for a smooth one-directional trend, near 0 for choppy or flat returns.
+    let return_sign = when(col("cum_return").gt(lit(0.0)))
+        .then(lit(1.0))
+        .otherwise(
+            when(col("cum_return").lt(lit(0.0)))
+                .then(lit(-1.0))
+                .otherwise(lit(0.0)),
+        );
+    let pct_difference = (col("neg_count").cast(DataType::Float64)
+        - col("pos_count").cast(DataType::Float64))
+        / col("obs_count").cast(DataType::Float64);
+
     let factors = factors
         .lazy()
         .with_columns([
@@ -218,8 +241,25 @@ fn add_return_and_risk_factors(
             .then(col("annualized_return") / downside_deviation)
             .otherwise(lit(NULL))
             .alias("sortino"),
+            // NaN > 0.0 and NaN < 0.0 are both false, so a NaN-poisoned
+            // cum_return would slip through return_sign as a legitimate-looking
+            // 0.0 ("perfectly choppy") without the explicit finiteness guard
+            // its sibling factors all carry.
+            when(
+                col("obs_count")
+                    .gt(lit(0))
+                    .and(col("cum_return").is_finite()),
+            )
+            .then(return_sign * pct_difference)
+            .otherwise(lit(NULL))
+            .alias("information_discreteness"),
         ])
-        .drop(cols(["downside_sq_sum", "obs_count"]))
+        .drop(cols([
+            "downside_sq_sum",
+            "obs_count",
+            "pos_count",
+            "neg_count",
+        ]))
         .collect()?;
 
     Ok(factors)
@@ -315,6 +355,18 @@ mod tests {
                     "sortino must be finite when present, got {sortino}"
                 );
             }
+
+            let information_discreteness = out
+                .column("information_discreteness")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            prop_assert!(
+                (-1.0 - 1e-9..=1.0 + 1e-9).contains(&information_discreteness),
+                "information_discreteness {information_discreteness} outside [-1, 1]"
+            );
         }
 
         /// For a strictly increasing close series the latest close is the maximum,
@@ -376,6 +428,20 @@ mod tests {
             prop_assert!(
                 sortino.is_none(),
                 "increasing closes have no downside, so sortino must be null, got {sortino:?}"
+            );
+
+            // A smooth uptrend is fully positive returns, so information
+            // discreteness is sign(+) * (0 - 1) = -1.
+            let information_discreteness = out
+                .column("information_discreteness")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            prop_assert!(
+                (information_discreteness - (-1.0)).abs() < 1e-12,
+                "a smooth uptrend must give information_discreteness -1, got {information_discreteness}"
             );
         }
     }
@@ -481,6 +547,20 @@ mod tests {
             .get(0)
             .unwrap();
         assert!(sortino.abs() < 1e-12, "sortino should be ~0, got {sortino}");
+
+        // cum_return is 0, so sign(cum_return) is 0 and information discreteness
+        // is 0 regardless of the positive/negative return split.
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            information_discreteness.abs() < 1e-12,
+            "information_discreteness should be ~0, got {information_discreteness}"
+        );
     }
 
     #[test]
@@ -577,6 +657,20 @@ mod tests {
             autocorrelation.is_none(),
             "constant prices give an undefined (null) autocorrelation, got {autocorrelation:?}"
         );
+
+        // cum_return is 0 (sign 0) with no positive or negative returns, so
+        // information discreteness is exactly 0.
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            information_discreteness.abs() < 1e-12,
+            "constant prices give zero information_discreteness, got {information_discreteness}"
+        );
     }
 
     #[test]
@@ -642,6 +736,67 @@ mod tests {
         );
     }
 
+    #[test]
+    fn information_discreteness_matches_manual_value_for_mixed_signs() {
+        // Three up moves and one down move with a net-positive cum_return:
+        // sign(+) * (pct_negative - pct_positive) = 1 * (1/4 - 3/4) = -0.5.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3", "4"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 102.0, 101.0, 103.0, 105.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+
+        assert!(
+            (information_discreteness - (-0.5)).abs() < 1e-12,
+            "1 down of 4 returns on a net uptrend must give -0.5, got {information_discreteness}"
+        );
+    }
+
+    #[test]
+    fn information_discreteness_is_minus_one_for_smooth_downtrend() {
+        // A smooth downtrend is fully negative returns, so information
+        // discreteness is sign(-) * (1 - 0) = -1, mirroring the uptrend case.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 99.0, 98.0, 97.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            (information_discreteness - (-1.0)).abs() < 1e-12,
+            "a smooth downtrend must give information_discreteness -1, got {information_discreteness}"
+        );
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn compute_factors_reads_candles_and_logs() {
@@ -664,6 +819,7 @@ mod tests {
         assert!(out.column("sharpe").is_ok());
         assert!(out.column("sortino").is_ok());
         assert!(out.column("autocorrelation").is_ok());
+        assert!(out.column("information_discreteness").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -68,7 +68,10 @@ pub(crate) async fn compute_factors_json(
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
-async fn compute_factors(data_dir: &Path, timeframe: Timeframe) -> Result<DataFrame, ReturnsError> {
+pub(crate) async fn compute_factors(
+    data_dir: &Path,
+    timeframe: Timeframe,
+) -> Result<DataFrame, ReturnsError> {
     let path = data_dir.join(timeframe.file_name());
     let df = crate::dataframe::read_csv(path.clone()).await?;
     let Some(df) = df else {

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -11,6 +11,7 @@ use polars::prelude::{
 use tracing::{info, instrument};
 
 use super::ReturnsError;
+use super::asset_beta::asset_beta_by_ticker;
 use super::autocorrelation::autocorrelation_by_ticker;
 use super::carry::with_carry;
 use super::returns::compute_log_returns;
@@ -18,11 +19,15 @@ use crate::timeframe::{Timeframe, TimeframeConfig};
 
 const PRICE_STDDEV_EPS: f64 = 1e-8;
 
+/// Benchmark asset for the per-ticker beta factor. Bitcoin beta is the SPEC's
+/// core risk metric, so the factor table's `beta` column is always beta to BTC.
+const BENCHMARK_TICKER: &str = "BTC";
+
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
 /// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
-/// `autocorrelation`, `information_discreteness`, and `carry`; further factors
-/// are added as columns as they land.
+/// `autocorrelation`, `information_discreteness`, `carry`, and `beta`; further
+/// factors are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -54,6 +59,8 @@ pub(crate) async fn compute_factors_json(
 ///   returns - fraction of positive returns); -1 for a smooth trend
 /// - `carry` = latest signed funding rate from `funding_rate1h.csv`; null when
 ///   no funding data is available
+/// - `beta` = per-asset beta to the benchmark (BTC) over the lookback; null when
+///   the benchmark has no return variance
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -85,8 +92,9 @@ fn per_ticker_factors(
     let lookback = config.lookback_periods;
     let annualization_multiplier = config.annualized_factor.sqrt();
 
-    // Lag-1 autocorrelation needs its own complete-pairs pass over a shorter
-    // window, computed separately and joined back in by ticker below.
+    // Lag-1 autocorrelation and per-asset beta each need their own pass (a
+    // shorter complete-pairs window, and a benchmark join), computed separately
+    // and joined back in by ticker below.
     //
     // The pair window is a quarter of the factor lookback (e.g. 22 pairs on
     // the 90-period daily window): a shorter window makes the score track the
@@ -95,6 +103,7 @@ fn per_ticker_factors(
     const AUTOCORRELATION_WINDOW_DIVISOR: usize = 4;
     let autocorrelation =
         autocorrelation_by_ticker(&with_returns, lookback / AUTOCORRELATION_WINDOW_DIVISOR)?;
+    let asset_beta = asset_beta_by_ticker(&with_returns, BENCHMARK_TICKER, lookback)?;
 
     // Downside deviation inputs for Sortino: sum of squared shortfalls below the
     // minimum acceptable return, and the observation count to average over.
@@ -152,6 +161,14 @@ fn per_ticker_factors(
 
     let factors = factors.join(
         &autocorrelation,
+        ["ticker"],
+        ["ticker"],
+        JoinArgs::new(JoinType::Left),
+        None,
+    )?;
+
+    let factors = factors.join(
+        &asset_beta,
         ["ticker"],
         ["ticker"],
         JoinArgs::new(JoinType::Left),
@@ -375,6 +392,10 @@ mod tests {
                 (-1.0 - 1e-9..=1.0 + 1e-9).contains(&information_discreteness),
                 "information_discreteness {information_discreteness} outside [-1, 1]"
             );
+
+            if let Some(beta) = out.column("beta").unwrap().f64().unwrap().get(0) {
+                prop_assert!(beta.is_finite(), "beta must be finite when present, got {beta}");
+            }
         }
 
         /// For a strictly increasing close series the latest close is the maximum,
@@ -679,6 +700,14 @@ mod tests {
             information_discreteness.abs() < 1e-12,
             "constant prices give zero information_discreteness, got {information_discreteness}"
         );
+
+        // BTC is the benchmark, so constant prices mean zero benchmark
+        // variance and the beta guard must fire through the full pipeline.
+        let beta = out.column("beta").unwrap().f64().unwrap().get(0);
+        assert!(
+            beta.is_none(),
+            "constant benchmark prices give undefined (null) beta, got {beta:?}"
+        );
     }
 
     #[test]
@@ -829,6 +858,7 @@ mod tests {
         assert!(out.column("autocorrelation").is_ok());
         assert!(out.column("information_discreteness").is_ok());
         assert!(out.column("carry").is_ok());
+        assert!(out.column("beta").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/factors/volume.rs
+++ b/src/factors/volume.rs
@@ -1,0 +1,187 @@
+//! Trailing 24h traded notional per asset, a liquidity measure the screener
+//! uses as its tie-break.
+
+use polars::prelude::{
+    DataFrame, DataFrameJoinOps, IntoLazy, JoinArgs, JoinType, PolarsError, SortMultipleOptions,
+    col, lit,
+};
+
+/// Joins per-ticker trailing-24h notional volume into `factors`.
+///
+/// Hyperliquid's candleSnapshot `v` field is denominated in the base asset
+/// (the recorded fixtures show BTC hourly volumes of ~200 against $65k closes,
+/// and the API docs' example value is 0.98639), so raw sums are not comparable
+/// across assets. Each candle's volume is converted to quote notional
+/// (`volume * close`) before summing, making `volume_24h` a real cross-asset
+/// liquidity measure.
+///
+/// The window is the dataset's trailing `candles_per_day` distinct timestamps,
+/// anchored to the most liquid market's clock rather than each ticker's own
+/// last rows: a stale (halted/delisted) ticker has no candles at recent
+/// timestamps and gets a null instead of re-counting its old tail, and a thin
+/// market contributes only the intervals it actually traded. On timeframes
+/// coarser than hourly the window holds a single candle -- on 1w that is the
+/// latest weekly candle, a full week's notional, the finest approximation
+/// weekly data can express.
+pub(super) fn with_volume_24h(
+    factors: &DataFrame,
+    candles: &DataFrame,
+    candles_per_day: usize,
+) -> Result<DataFrame, PolarsError> {
+    let volume = volume_24h_by_ticker(candles, candles_per_day)?;
+
+    factors.join(
+        &volume,
+        ["ticker"],
+        ["ticker"],
+        JoinArgs::new(JoinType::Left),
+        None,
+    )
+}
+
+/// Per-ticker trailing-24h notional volume, as a `DataFrame` keyed by `ticker`.
+fn volume_24h_by_ticker(
+    candles: &DataFrame,
+    candles_per_day: usize,
+) -> Result<DataFrame, PolarsError> {
+    let window_start = trailing_window_start(candles, candles_per_day)?;
+
+    candles
+        .clone()
+        .lazy()
+        .filter(col("timestamp").gt_eq(lit(window_start)))
+        .group_by([col("ticker")])
+        .agg([(col("volume") * col("close")).sum().alias("volume_24h")])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()
+}
+
+/// The earliest timestamp inside the trailing window: the dataset's
+/// `candles_per_day`-th distinct timestamp from the end (or the very first
+/// when the dataset is shorter than a day).
+///
+/// Anchoring on the dataset rather than each ticker keeps a ticker that
+/// stopped trading from counting candles older than the window.
+fn trailing_window_start(
+    candles: &DataFrame,
+    candles_per_day: usize,
+) -> Result<String, PolarsError> {
+    let mut timestamps: Vec<String> = candles
+        .column("timestamp")?
+        .str()?
+        .iter()
+        .flatten()
+        .map(str::to_string)
+        .collect();
+    timestamps.sort_unstable();
+    timestamps.dedup();
+
+    let start_index = timestamps.len().saturating_sub(candles_per_day);
+
+    // An empty dataset has no window to bound; the empty-string floor matches
+    // every row of the (equally empty) frame.
+    Ok(timestamps.into_iter().nth(start_index).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+
+    fn candles() -> DataFrame {
+        // Timestamps 0..2; ETH stopped trading after timestamp 1 and SOL only
+        // traded the latest interval.
+        df! {
+            "timestamp" => &["0", "1", "2", "0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC", "ETH", "ETH", "SOL"],
+            "close" => &[100.0, 110.0, 120.0, 10.0, 11.0, 3.0_f64],
+            "volume" => &[10.0, 20.0, 30.0, 5.0, 7.0, 1000.0_f64],
+        }
+        .unwrap()
+    }
+
+    #[test]
+    fn volume_24h_sums_notional_over_the_trailing_window() {
+        // Window = last two dataset timestamps ("1", "2"): BTC sums
+        // 20*110 + 30*120 = 5800; base units alone would rank SOL's 1000
+        // contracts above BTC's 50.
+        let out = volume_24h_by_ticker(&candles(), 2).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let volume = out.column("volume_24h").unwrap().f64().unwrap();
+        let notional_for = |ticker: &str| {
+            let index = tickers
+                .iter()
+                .position(|value| value == Some(ticker))
+                .expect("ticker present");
+
+            volume.get(index)
+        };
+
+        assert!((notional_for("BTC").unwrap() - 5800.0).abs() < 1e-12);
+        assert!((notional_for("ETH").unwrap() - 77.0).abs() < 1e-12);
+        assert!(
+            (notional_for("SOL").unwrap() - 3000.0).abs() < 1e-12,
+            "1000 contracts at $3 is $3000 of liquidity, far below BTC's $5800"
+        );
+    }
+
+    #[test]
+    fn volume_24h_excludes_a_stale_ticker_from_the_window() {
+        // Window = the latest dataset timestamp only. ETH's last candle is at
+        // timestamp 1, so it must not re-count its old tail: no rows survive
+        // the window filter and the join below yields null, not stale volume.
+        let out = volume_24h_by_ticker(&candles(), 1).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+
+        assert!(
+            tickers.iter().all(|ticker| ticker != Some("ETH")),
+            "a ticker with no candles inside the window has no volume row"
+        );
+    }
+
+    #[test]
+    fn with_volume_24h_joins_onto_factors_and_keeps_unmatched_tickers() {
+        let factors = df! {
+            "ticker" => &["BTC", "ETH", "SOL"],
+            "sma" => &[1.0, 2.0, 3.0_f64],
+        }
+        .unwrap();
+
+        let out = with_volume_24h(&factors, &candles(), 1).unwrap();
+        assert_eq!(out.height(), 3, "the left join keeps every factors row");
+
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let volume = out.column("volume_24h").unwrap().f64().unwrap();
+        let notional_for = |ticker: &str| {
+            let index = tickers
+                .iter()
+                .position(|value| value == Some(ticker))
+                .expect("ticker present");
+
+            volume.get(index)
+        };
+
+        assert!((notional_for("BTC").unwrap() - 3600.0).abs() < 1e-12);
+        assert!(
+            notional_for("ETH").is_none(),
+            "a stale ticker's volume is null, not its old tail"
+        );
+        assert!((notional_for("SOL").unwrap() - 3000.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn volume_24h_uses_all_candles_when_the_dataset_is_shorter_than_a_day() {
+        let out = volume_24h_by_ticker(&candles(), 100).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let volume = out.column("volume_24h").unwrap().f64().unwrap();
+        let btc_index = tickers
+            .iter()
+            .position(|value| value == Some("BTC"))
+            .expect("ticker present");
+
+        assert!(
+            (volume.get(btc_index).unwrap() - (1000.0 + 2200.0 + 3600.0)).abs() < 1e-12,
+            "a window wider than the dataset sums every candle's notional"
+        );
+    }
+}

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -23,6 +23,7 @@ use crate::candle::{Candle, CandleError, candles_to_dataframe};
 use crate::dataframe::{self, DataFrameError};
 use crate::finance::{Market, Symbol};
 use crate::funding::{self, FundingError, FundingRate};
+use crate::market_metadata::MarketMetadata;
 use crate::timeframe::Timeframe;
 
 /// Maximum number of data points returned by Hyperliquid's historical data endpoints.
@@ -44,6 +45,10 @@ pub(crate) enum HyperliquidError {
     Sdk(#[from] hyperliquid_rust_sdk::Error),
     #[error(transparent)]
     IntConversion(#[from] TryFromIntError),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Polars(#[from] polars::prelude::PolarsError),
 }
 
 /// Abstraction over Hyperliquid's market data API.
@@ -52,6 +57,8 @@ pub(crate) enum HyperliquidError {
 #[async_trait]
 pub(crate) trait Hyperliquid: Send + Sync {
     async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError>;
+
+    async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError>;
 
     async fn fetch_candles(
         &self,
@@ -104,6 +111,61 @@ impl Hyperliquid for HyperliquidClient {
             .collect();
         debug!(count = markets.len(), "fetched markets");
         Ok(markets)
+    }
+
+    #[instrument(skip(self))]
+    async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+        // The SDK's typed `meta()` drops `maxLeverage`, so request the raw `meta`
+        // info payload and parse the fields we need ourselves.
+        #[derive(serde::Serialize)]
+        struct MetaRequest {
+            #[serde(rename = "type")]
+            request_type: &'static str,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawMeta {
+            universe: Vec<RawAsset>,
+        }
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RawAsset {
+            name: String,
+            max_leverage: u32,
+        }
+
+        let url = format!("{}/info", self.info.http_client.base_url);
+        let raw = (|| async {
+            reqwest::Client::new()
+                .post(&url)
+                .json(&MetaRequest {
+                    request_type: "meta",
+                })
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<RawMeta>()
+                .await
+        })
+        .retry(
+            ExponentialBuilder::default()
+                .with_jitter()
+                .with_max_times(self.max_retries),
+        )
+        .notify(|err, dur| {
+            debug!(error = %err, delay = ?dur, "retrying market metadata fetch");
+        })
+        .await?;
+
+        let metadata: Vec<MarketMetadata> = raw
+            .universe
+            .into_iter()
+            .map(|asset| MarketMetadata {
+                symbol: Market::new(asset.name),
+                max_leverage: asset.max_leverage,
+            })
+            .collect();
+        debug!(count = metadata.len(), "fetched market metadata");
+        Ok(metadata)
     }
 
     #[instrument(skip(self))]
@@ -418,6 +480,7 @@ mod tests {
 
     struct MockHyperliquid {
         markets: Vec<Market>,
+        market_metadata: Vec<MarketMetadata>,
         candles: Vec<Candle>,
         funding_rates: Vec<FundingRate>,
         fetch_candles_calls: AtomicUsize,
@@ -428,6 +491,10 @@ mod tests {
         fn new() -> Self {
             Self {
                 markets: vec![Market::new("BTC".to_string())],
+                market_metadata: vec![MarketMetadata {
+                    symbol: Market::new("BTC".to_string()),
+                    max_leverage: 50,
+                }],
                 candles: vec![Candle {
                     timestamp: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
                     open: 42000.0,
@@ -459,6 +526,10 @@ mod tests {
     impl Hyperliquid for MockHyperliquid {
         async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
             Ok(self.markets.clone())
+        }
+
+        async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            Ok(self.market_metadata.clone())
         }
 
         async fn fetch_candles(

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -56,8 +56,6 @@ pub(crate) enum HyperliquidError {
 /// Enables testing with mock implementations.
 #[async_trait]
 pub(crate) trait Hyperliquid: Send + Sync {
-    async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError>;
-
     async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError>;
 
     async fn fetch_candles(
@@ -101,18 +99,6 @@ impl HyperliquidClient {
 
 #[async_trait]
 impl Hyperliquid for HyperliquidClient {
-    #[instrument(skip(self))]
-    async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-        let meta = self.info.meta().await?;
-        let markets: Vec<Market> = meta
-            .universe
-            .into_iter()
-            .map(|asset| Market::new(asset.name))
-            .collect();
-        debug!(count = markets.len(), "fetched markets");
-        Ok(markets)
-    }
-
     #[instrument(skip(self))]
     async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
         // The SDK's typed `meta()` drops `maxLeverage`, so request the raw `meta`
@@ -287,17 +273,6 @@ impl<H: ?Sized + Hyperliquid> CandleIngester<H> {
         }
     }
 
-    #[instrument(skip(self, data_dir), fields(timeframe = ?timeframe))]
-    pub(crate) async fn ingest(
-        &self,
-        timeframe: Timeframe,
-        data_dir: &Path,
-    ) -> Result<(), HyperliquidError> {
-        let markets = self.client.list_markets().await?;
-        self.ingest_with_markets(timeframe, data_dir, &markets)
-            .await
-    }
-
     #[instrument(skip(self, data_dir, markets), fields(timeframe = ?timeframe))]
     pub(crate) async fn ingest_with_markets(
         &self,
@@ -388,14 +363,8 @@ impl<H: ?Sized + Hyperliquid> FundingRateIngester<H> {
         }
     }
 
-    #[instrument(skip(self, data_dir))]
-    pub(crate) async fn ingest(&self, data_dir: &Path) -> Result<(), HyperliquidError> {
-        let markets = self.client.list_markets().await?;
-        self.ingest_with_markets(data_dir, &markets).await
-    }
-
     #[instrument(skip(self, data_dir, markets))]
-    async fn ingest_with_markets(
+    pub(crate) async fn ingest_with_markets(
         &self,
         data_dir: &Path,
         markets: &[Market],
@@ -479,7 +448,6 @@ mod tests {
     use crate::logs_contain_at;
 
     struct MockHyperliquid {
-        markets: Vec<Market>,
         market_metadata: Vec<MarketMetadata>,
         candles: Vec<Candle>,
         funding_rates: Vec<FundingRate>,
@@ -487,10 +455,13 @@ mod tests {
         fetch_funding_calls: AtomicUsize,
     }
 
+    fn btc_markets() -> Vec<Market> {
+        vec![Market::new("BTC".to_string())]
+    }
+
     impl MockHyperliquid {
         fn new() -> Self {
             Self {
-                markets: vec![Market::new("BTC".to_string())],
                 market_metadata: vec![MarketMetadata {
                     symbol: Market::new("BTC".to_string()),
                     max_leverage: 50,
@@ -524,10 +495,6 @@ mod tests {
 
     #[async_trait]
     impl Hyperliquid for MockHyperliquid {
-        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-            Ok(self.markets.clone())
-        }
-
         async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
             Ok(self.market_metadata.clone())
         }
@@ -560,7 +527,7 @@ mod tests {
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
             .await
             .unwrap();
 
@@ -580,7 +547,7 @@ mod tests {
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
             .await
             .unwrap();
 
@@ -594,7 +561,10 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
 
         let csv_path = data_dir.path().join("funding_rate1h.csv");
         assert!(csv_path.exists(), "CSV file should be created");
@@ -620,7 +590,10 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new().with_empty_data());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
 
         assert!(logs_contain_at(Level::INFO, &["no new funding rates"]));
     }
@@ -628,19 +601,17 @@ mod tests {
     #[tokio::test]
     async fn candle_ingester_fetches_for_each_market() {
         let data_dir = TempDir::new().unwrap();
-        let mock = Arc::new(MockHyperliquid {
-            markets: vec![
-                Market::new("BTC".to_string()),
-                Market::new("ETH".to_string()),
-                Market::new("SOL".to_string()),
-            ],
-            ..MockHyperliquid::new()
-        });
+        let markets = vec![
+            Market::new("BTC".to_string()),
+            Market::new("ETH".to_string()),
+            Market::new("SOL".to_string()),
+        ];
+        let mock = Arc::new(MockHyperliquid::new());
         let call_count = Arc::clone(&mock);
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &markets)
             .await
             .unwrap();
 
@@ -654,17 +625,18 @@ mod tests {
     #[tokio::test]
     async fn funding_ingester_fetches_for_each_market() {
         let data_dir = TempDir::new().unwrap();
-        let mock = Arc::new(MockHyperliquid {
-            markets: vec![
-                Market::new("BTC".to_string()),
-                Market::new("ETH".to_string()),
-            ],
-            ..MockHyperliquid::new()
-        });
+        let markets = vec![
+            Market::new("BTC".to_string()),
+            Market::new("ETH".to_string()),
+        ];
+        let mock = Arc::new(MockHyperliquid::new());
         let call_count = Arc::clone(&mock);
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &markets)
+            .await
+            .unwrap();
 
         assert_eq!(
             call_count.fetch_funding_calls.load(Ordering::Relaxed),
@@ -685,7 +657,9 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = CandleIngester::new(mock, 10);
 
-        let result = ingester.ingest(Timeframe::OneHour, data_dir.path()).await;
+        let result = ingester
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
+            .await;
 
         assert!(
             result.is_ok(),
@@ -702,7 +676,7 @@ mod tests {
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
             .await
             .unwrap();
 
@@ -735,7 +709,9 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        let result = ingester.ingest(data_dir.path()).await;
+        let result = ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await;
 
         assert!(
             result.is_ok(),
@@ -751,7 +727,10 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
 
         let csv_content =
             std::fs::read_to_string(data_dir.path().join("funding_rate1h.csv")).unwrap();

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -62,7 +62,14 @@ impl IngestionJob {
             services.max_concurrent_requests,
         );
 
-        match ingest_all(&candle_ingester, &funding_ingester, &services.data_dir).await {
+        match ingest_all(
+            services.hyperliquid.as_ref(),
+            &candle_ingester,
+            &funding_ingester,
+            &services.data_dir,
+        )
+        .await
+        {
             Ok(last_record) => {
                 if let Err(err) = complete_run(&pool, &self.run_id, last_record).await {
                     error!(error = %err, run_id = self.run_id.as_str(), "failed to record ingestion completion");
@@ -85,10 +92,12 @@ impl IngestionJob {
 }
 
 async fn ingest_all(
+    client: &dyn Hyperliquid,
     candle_ingester: &CandleIngester<dyn Hyperliquid>,
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
     data_dir: &Path,
 ) -> Result<DateTime<Utc>, HyperliquidError> {
+    crate::market_metadata::refresh_markets(client, data_dir).await?;
     funding_ingester.ingest(data_dir).await?;
 
     for timeframe in TIMEFRAMES {
@@ -325,6 +334,15 @@ mod tests {
     impl Hyperliquid for MockHyperliquid {
         async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
             Ok(vec![Market::new("BTC".into())])
+        }
+
+        async fn fetch_market_metadata(
+            &self,
+        ) -> Result<Vec<crate::market_metadata::MarketMetadata>, HyperliquidError> {
+            Ok(vec![crate::market_metadata::MarketMetadata {
+                symbol: Market::new("BTC".into()),
+                max_leverage: 50,
+            }])
         }
 
         async fn fetch_candles(

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -97,11 +97,16 @@ async fn ingest_all(
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
     data_dir: &Path,
 ) -> Result<DateTime<Utc>, HyperliquidError> {
-    crate::market_metadata::refresh_markets(client, data_dir).await?;
-    funding_ingester.ingest(data_dir).await?;
+    let markets = crate::market_metadata::refresh_markets(client, data_dir).await?;
+
+    funding_ingester
+        .ingest_with_markets(data_dir, &markets)
+        .await?;
 
     for timeframe in TIMEFRAMES {
-        candle_ingester.ingest(*timeframe, data_dir).await?;
+        candle_ingester
+            .ingest_with_markets(*timeframe, data_dir, &markets)
+            .await?;
     }
 
     Ok(Utc::now())
@@ -332,10 +337,6 @@ mod tests {
 
     #[async_trait]
     impl Hyperliquid for MockHyperliquid {
-        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-            Ok(vec![Market::new("BTC".into())])
-        }
-
         async fn fetch_market_metadata(
             &self,
         ) -> Result<Vec<crate::market_metadata::MarketMetadata>, HyperliquidError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,9 +662,20 @@ mod tests {
                 .is_some()),
             "every row carries information_discreteness as a number (the fixture's returns all vary)"
         );
+        // The fixture ships no funding data, so carry is legitimately null --
+        // but the key itself must stay in the schema for every row.
         assert!(
-            rows.iter().all(|row| row.get("carry").is_some()),
-            "every row carries carry"
+            rows.iter()
+                .all(|row| row.get("carry").is_some_and(serde_json::Value::is_null)),
+            "carry key is present and null for every row without funding data"
+        );
+
+        assert!(
+            rows.iter().all(|row| row
+                .get("beta")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries beta as a number (prices vary and BTC is the benchmark)"
         );
         assert!(
             rows.iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,13 @@ mod tests {
             "every row carries autocorrelation as a number (the fixture's returns all vary)"
         );
         assert!(
+            rows.iter().all(|row| row
+                .get("information_discreteness")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries information_discreteness as a number (the fixture's returns all vary)"
+        );
+        assert!(
             rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,6 +663,10 @@ mod tests {
             "every row carries information_discreteness as a number (the fixture's returns all vary)"
         );
         assert!(
+            rows.iter().all(|row| row.get("carry").is_some()),
+            "every row carries carry"
+        );
+        assert!(
             rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,6 +649,13 @@ mod tests {
             "every row carries sortino as a number (every fixture ticker has downside)"
         );
         assert!(
+            rows.iter().all(|row| row
+                .get("autocorrelation")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries autocorrelation as a number (the fixture's returns all vary)"
+        );
+        assert!(
             rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod finance;
 mod funding;
 mod hyperliquid;
 mod ingestion;
+mod market_metadata;
 mod readonly_portfolio;
 mod screener;
 mod timeframe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod funding;
 mod hyperliquid;
 mod ingestion;
 mod readonly_portfolio;
+mod screener;
 mod timeframe;
 
 use std::net::Ipv4Addr;
@@ -149,6 +150,24 @@ async fn get_factors(
         Err(factors::ReturnsError::NoData { .. }) => Err(Status::NotFound),
         Err(err) => {
             error!(error = %err, "failed to compute factors");
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+#[post("/screener/<timeframe>", data = "<body>")]
+async fn post_screener(
+    config: &State<Config>,
+    timeframe: Timeframe,
+    body: Json<screener::ScreenerRequest>,
+) -> Result<RawJson<Vec<u8>>, Status> {
+    match screener::screen(&config.data_dir, timeframe, &body).await {
+        Ok(json) => Ok(RawJson(json)),
+        Err(screener::ScreenerError::Factors(factors::ReturnsError::NoData { .. })) => {
+            Err(Status::NotFound)
+        }
+        Err(err) => {
+            error!(error = %err, "failed to screen perps");
             Err(Status::InternalServerError)
         }
     }
@@ -451,6 +470,7 @@ pub async fn rocket(
                 health,
                 get_candles,
                 get_factors,
+                post_screener,
                 start_ingestion,
                 get_ingestion_status,
                 post_beta,
@@ -501,9 +521,10 @@ mod tests {
             max_concurrent_requests: 3,
             max_retries: 5,
         };
-        rocket::build()
-            .manage(config)
-            .mount("/", routes![health, get_candles, get_factors])
+        rocket::build().manage(config).mount(
+            "/",
+            routes![health, get_candles, get_factors, post_screener],
+        )
     }
 
     proptest! {
@@ -746,6 +767,46 @@ mod tests {
             btc_row["carry"].is_null(),
             "carry must be null without funding data, got {:?}",
             btc_row["carry"]
+        );
+    }
+
+    #[test]
+    fn post_screener_returns_404_when_no_data() {
+        let data_dir = TempDir::new().unwrap();
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/screener/1d")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"factor":"sharpe"}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[test]
+    fn post_screener_returns_ranked_rows_with_missing_flags() {
+        let data_dir = TempDir::new().unwrap();
+        std::fs::copy(
+            std::path::Path::new("fixtures/ohlcv_1d_beta.csv"),
+            data_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/screener/1d")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"factor":"sharpe"}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        let rows: Vec<serde_json::Value> =
+            serde_json::from_str(&body).expect("screener body is a JSON array");
+        assert!(!rows.is_empty(), "expected ranked rows");
+        assert!(
+            rows.iter().all(|row| row.get("missing").is_some()),
+            "every ranked row carries a missing flag"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,6 +489,7 @@ mod tests {
     use proptest::prelude::*;
     use rocket::local::blocking::Client;
     use tempfile::TempDir;
+    use tracing_test::traced_test;
 
     fn test_rocket(data_dir: &std::path::Path) -> rocket::Rocket<rocket::Build> {
         let config = Config {
@@ -583,6 +584,7 @@ mod tests {
         assert_eq!(response.status(), Status::NotFound);
     }
 
+    #[traced_test]
     #[test]
     fn get_factors_returns_per_ticker_factor_scores_json() {
         let data_dir = TempDir::new().unwrap();
@@ -678,9 +680,72 @@ mod tests {
             "every row carries beta as a number (prices vary and BTC is the benchmark)"
         );
         assert!(
-            rows.iter()
-                .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
-            "BTC is present in the factor scores"
+            rows.iter().all(|row| row
+                .get("volume_24h")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries volume_24h as a number (every fixture ticker has current candles)"
+        );
+        assert_btc_factor_values_are_real(&rows);
+
+        assert!(logs_contain_at(
+            tracing::Level::DEBUG,
+            &["factors computed"]
+        ));
+    }
+
+    /// Key presence alone would pass if every factor serialized as null; pin
+    /// BTC's values so a serialization regression fails the factors route test.
+    fn assert_btc_factor_values_are_real(rows: &[serde_json::Value]) {
+        let btc_row = rows
+            .iter()
+            .find(|row| row.get("ticker").and_then(|ticker| ticker.as_str()) == Some("BTC"))
+            .expect("BTC is present in the factor scores");
+
+        let btc_volatility = btc_row["annualized_volatility"]
+            .as_f64()
+            .expect("BTC annualized_volatility is a number");
+        assert!(
+            btc_volatility > 0.0,
+            "BTC annualized_volatility must be positive, got {btc_volatility}"
+        );
+        for factor_key in [
+            "cum_return",
+            "sma",
+            "mean_return",
+            "price_zscore",
+            "annualized_return",
+            "sharpe",
+            "sortino",
+            "autocorrelation",
+            "information_discreteness",
+            "beta",
+            "volume_24h",
+        ] {
+            let value = btc_row[factor_key].as_f64();
+            assert!(
+                value.is_some_and(f64::is_finite),
+                "BTC {factor_key} must be a finite number, got {value:?}"
+            );
+        }
+
+        // Pin the unit conversion: the fixture's latest BTC candle is 1400
+        // base units against a ~$46.7k close, so notional must be tens of
+        // millions -- a raw base-unit sum (~1400) fails this by four orders
+        // of magnitude.
+        let btc_volume = btc_row["volume_24h"]
+            .as_f64()
+            .expect("BTC volume_24h is a number");
+        assert!(
+            btc_volume > 1e6,
+            "volume_24h must be quote notional, not base units, got {btc_volume}"
+        );
+        // No funding fixture is staged, so carry serializes as null - the
+        // documented no-funding-data behavior.
+        assert!(
+            btc_row["carry"].is_null(),
+            "carry must be null without funding data, got {:?}",
+            btc_row["carry"]
         );
     }
 

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -26,19 +26,44 @@ pub(crate) fn file_name() -> &'static str {
     "markets.csv"
 }
 
-/// Fetches the current markets metadata, merges it with the persisted ledger
-/// (preserving the `disable` flag), and writes `markets.csv`.
+/// Refreshes `markets.csv` from the live exchange and returns the tradable
+/// markets: every fetched market that is not disabled.
+///
+/// Market discovery is driven by the exchange fetch; the ledger only persists
+/// the operator-controlled `disable` flags. Ingestion consumes the returned
+/// list directly, so it never depends on re-reading the CSV.
 pub(crate) async fn refresh_markets(
     client: &dyn Hyperliquid,
     data_dir: &Path,
-) -> Result<(), HyperliquidError> {
+) -> Result<Vec<Market>, HyperliquidError> {
     let fetched = client.fetch_market_metadata().await?;
     let path = data_dir.join(file_name());
     let existing = crate::dataframe::read_csv(path.clone()).await?;
     let frame = build_markets_frame(&fetched, existing.as_ref())?;
+    let tradable = tradable_from_frame(&frame)?;
     crate::dataframe::write_csv(path, frame).await?;
-    info!(markets = fetched.len(), "markets metadata refreshed");
-    Ok(())
+    info!(
+        markets = fetched.len(),
+        tradable = tradable.len(),
+        "markets metadata refreshed"
+    );
+    Ok(tradable)
+}
+
+/// The tradable markets in a freshly built ledger frame: every market whose
+/// `disable` flag is not set.
+fn tradable_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
+    let symbols = frame.column("symbol")?.str()?;
+    let disable = frame.column("disable")?.bool()?;
+    let markets: Vec<Market> = (0..symbols.len())
+        .filter(|&index| disable.get(index) == Some(false))
+        .filter_map(|index| {
+            symbols
+                .get(index)
+                .map(|symbol| Market::new(symbol.to_string()))
+        })
+        .collect();
+    Ok(markets)
 }
 
 /// Builds the markets ledger `DataFrame` (`symbol`, `max_leverage`, `disable`)
@@ -113,10 +138,6 @@ mod tests {
 
     #[async_trait]
     impl Hyperliquid for StubClient {
-        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-            Ok(vec![])
-        }
-
         async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
             Ok(self.metadata.clone())
         }
@@ -193,7 +214,12 @@ mod tests {
             metadata: vec![metadata("BTC", 50), metadata("ETH", 25)],
         };
 
-        refresh_markets(&client, data_dir.path()).await.unwrap();
+        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        assert_eq!(
+            tradable.len(),
+            2,
+            "both markets are tradable on first refresh"
+        );
         assert!(data_dir.path().join("markets.csv").exists());
         assert!(crate::logs_contain_at(
             Level::INFO,
@@ -212,7 +238,12 @@ mod tests {
             .unwrap();
         crate::dataframe::write_csv(path, edited).await.unwrap();
 
-        refresh_markets(&client, data_dir.path()).await.unwrap();
+        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        assert_eq!(
+            tradable.iter().map(Market::as_str).collect::<Vec<_>>(),
+            vec!["ETH"],
+            "BTC is excluded from the tradable set once disabled"
+        );
 
         let reloaded = crate::dataframe::read_csv(data_dir.path().join(file_name()))
             .await
@@ -220,5 +251,65 @@ mod tests {
             .unwrap();
         assert_eq!(disable_for(&reloaded, "BTC"), Some(true));
         assert_eq!(disable_for(&reloaded, "ETH"), Some(false));
+    }
+
+    #[test]
+    fn tradable_from_frame_excludes_disabled_markets() {
+        let frame = df! {
+            "symbol" => &["BTC", "ETH", "SOL"],
+            "max_leverage" => &[50_u32, 25, 20],
+            "disable" => &[false, true, false],
+        }
+        .unwrap();
+
+        let markets = tradable_from_frame(&frame).unwrap();
+        let symbols: Vec<&str> = markets.iter().map(Market::as_str).collect();
+
+        assert_eq!(markets.len(), 2, "the disabled market is excluded");
+        assert!(symbols.contains(&"BTC"));
+        assert!(symbols.contains(&"SOL"));
+        assert!(!symbols.contains(&"ETH"), "ETH is disabled");
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn refresh_discovers_markets_from_the_exchange_not_the_ledger() {
+        let data_dir = TempDir::new().unwrap();
+        // The persisted ledger only knows BTC, which the operator disabled.
+        let existing = df! {
+            "symbol" => &["BTC"],
+            "max_leverage" => &[40_u32],
+            "disable" => &[true],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), existing)
+            .await
+            .unwrap();
+
+        // The exchange now lists BTC, ETH, and SOL.
+        let client = StubClient {
+            metadata: vec![
+                metadata("BTC", 50),
+                metadata("ETH", 25),
+                metadata("SOL", 20),
+            ],
+        };
+
+        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        let symbols: Vec<&str> = tradable.iter().map(Market::as_str).collect();
+
+        // ETH and SOL are discovered from the live fetch even though the ledger
+        // never listed them; BTC stays excluded by its persisted disable flag.
+        assert_eq!(tradable.len(), 2, "newly listed markets are discovered");
+        assert!(symbols.contains(&"ETH"));
+        assert!(symbols.contains(&"SOL"));
+        assert!(
+            !symbols.contains(&"BTC"),
+            "operator-disabled BTC stays excluded"
+        );
+        assert!(crate::logs_contain_at(
+            Level::INFO,
+            &["markets metadata refreshed"]
+        ));
     }
 }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -1,0 +1,224 @@
+//! Markets metadata: the perp universe with each market's max leverage and a
+//! persisted `disable` flag, stored in `markets.csv`.
+//!
+//! The `disable` flag is operator-controlled (edited by hand) and preserved
+//! across refreshes; metadata like max leverage is refreshed from the exchange.
+
+use std::path::Path;
+
+use polars::prelude::{
+    DataFrame, IntoLazy, JoinArgs, JoinType, NamedFrom, PolarsError, Series, col, df, lit,
+};
+use tracing::info;
+
+use crate::finance::Market;
+use crate::hyperliquid::{Hyperliquid, HyperliquidError};
+
+/// A market's exchange metadata as fetched from Hyperliquid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MarketMetadata {
+    pub(crate) symbol: Market,
+    pub(crate) max_leverage: u32,
+}
+
+/// File name of the markets ledger inside the data directory.
+pub(crate) fn file_name() -> &'static str {
+    "markets.csv"
+}
+
+/// Fetches the current markets metadata, merges it with the persisted ledger
+/// (preserving the `disable` flag), and writes `markets.csv`.
+pub(crate) async fn refresh_markets(
+    client: &dyn Hyperliquid,
+    data_dir: &Path,
+) -> Result<(), HyperliquidError> {
+    let fetched = client.fetch_market_metadata().await?;
+    let path = data_dir.join(file_name());
+    let existing = crate::dataframe::read_csv(path.clone()).await?;
+    let frame = build_markets_frame(&fetched, existing.as_ref())?;
+    crate::dataframe::write_csv(path, frame).await?;
+    info!(markets = fetched.len(), "markets metadata refreshed");
+    Ok(())
+}
+
+/// Builds the markets ledger `DataFrame` (`symbol`, `max_leverage`, `disable`)
+/// from freshly fetched metadata, preserving the `disable` flag of any symbol
+/// already in `existing` and defaulting new symbols to enabled (`disable` false).
+fn build_markets_frame(
+    fetched: &[MarketMetadata],
+    existing: Option<&DataFrame>,
+) -> Result<DataFrame, PolarsError> {
+    let symbols: Vec<&str> = fetched
+        .iter()
+        .map(|market| market.symbol.as_str())
+        .collect();
+    let max_leverages: Vec<u32> = fetched.iter().map(|market| market.max_leverage).collect();
+    let fresh = df! {
+        "symbol" => symbols,
+        "max_leverage" => max_leverages,
+    }?;
+
+    let Some(existing) = existing else {
+        let mut fresh = fresh;
+        let disable = Series::new("disable".into(), vec![false; fresh.height()]);
+        fresh.with_column(disable)?;
+        return Ok(fresh);
+    };
+
+    let previous_flags = existing
+        .clone()
+        .lazy()
+        .select([col("symbol"), col("disable").alias("previous_disable")]);
+
+    fresh
+        .lazy()
+        .join(
+            previous_flags,
+            [col("symbol")],
+            [col("symbol")],
+            JoinArgs::new(JoinType::Left),
+        )
+        .with_column(
+            col("previous_disable")
+                .fill_null(lit(false))
+                .alias("disable"),
+        )
+        .select([col("symbol"), col("max_leverage"), col("disable")])
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::{DateTime, Utc};
+    use tempfile::TempDir;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use crate::candle::Candle;
+    use crate::funding::FundingRate;
+    use crate::timeframe::Timeframe;
+
+    fn metadata(symbol: &str, max_leverage: u32) -> MarketMetadata {
+        MarketMetadata {
+            symbol: Market::new(symbol.to_string()),
+            max_leverage,
+        }
+    }
+
+    struct StubClient {
+        metadata: Vec<MarketMetadata>,
+    }
+
+    #[async_trait]
+    impl Hyperliquid for StubClient {
+        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
+            Ok(vec![])
+        }
+
+        async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            Ok(self.metadata.clone())
+        }
+
+        async fn fetch_candles(
+            &self,
+            _market: &Market,
+            _timeframe: Timeframe,
+            _start: DateTime<Utc>,
+        ) -> Result<Vec<Candle>, HyperliquidError> {
+            Ok(vec![])
+        }
+
+        async fn fetch_funding_rates(
+            &self,
+            _market: &Market,
+            _start: DateTime<Utc>,
+        ) -> Result<Vec<FundingRate>, HyperliquidError> {
+            Ok(vec![])
+        }
+    }
+
+    fn disable_for(frame: &DataFrame, symbol: &str) -> Option<bool> {
+        let symbols = frame.column("symbol").unwrap().str().unwrap();
+        let disable = frame.column("disable").unwrap().bool().unwrap();
+        (0..symbols.len())
+            .find(|&index| symbols.get(index) == Some(symbol))
+            .and_then(|index| disable.get(index))
+    }
+
+    #[test]
+    fn new_markets_default_to_enabled() {
+        let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
+
+        let frame = build_markets_frame(&fetched, None).unwrap();
+        assert_eq!(frame.height(), 2);
+        assert_eq!(disable_for(&frame, "BTC"), Some(false));
+        assert_eq!(disable_for(&frame, "ETH"), Some(false));
+    }
+
+    #[test]
+    fn refresh_preserves_disable_flag_and_drops_vanished_markets() {
+        let existing = df! {
+            "symbol" => &["BTC", "SOL"],
+            "max_leverage" => &[40_u32, 20],
+            "disable" => &[true, false],
+        }
+        .unwrap();
+        let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
+
+        let frame = build_markets_frame(&fetched, Some(&existing)).unwrap();
+
+        // BTC keeps its operator-set disable flag; ETH is new (enabled); SOL
+        // vanished from the exchange and is dropped.
+        assert_eq!(frame.height(), 2);
+        assert_eq!(disable_for(&frame, "BTC"), Some(true));
+        assert_eq!(disable_for(&frame, "ETH"), Some(false));
+        assert_eq!(disable_for(&frame, "SOL"), None);
+
+        // max leverage is refreshed from the fetched metadata.
+        let symbols = frame.column("symbol").unwrap().str().unwrap();
+        let leverage = frame.column("max_leverage").unwrap().u32().unwrap();
+        let btc_index = (0..symbols.len())
+            .find(|&index| symbols.get(index) == Some("BTC"))
+            .unwrap();
+        assert_eq!(leverage.get(btc_index), Some(50));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn refresh_writes_markets_csv_and_preserves_disable_across_runs() {
+        let data_dir = TempDir::new().unwrap();
+        let client = StubClient {
+            metadata: vec![metadata("BTC", 50), metadata("ETH", 25)],
+        };
+
+        refresh_markets(&client, data_dir.path()).await.unwrap();
+        assert!(data_dir.path().join("markets.csv").exists());
+        assert!(crate::logs_contain_at(
+            Level::INFO,
+            &["markets metadata refreshed"]
+        ));
+
+        // Operator disables BTC by editing the ledger, then a later refresh keeps it.
+        let path = data_dir.path().join(file_name());
+        let edited = crate::dataframe::read_csv(path.clone())
+            .await
+            .unwrap()
+            .unwrap()
+            .lazy()
+            .with_column(col("symbol").eq(lit("BTC")).alias("disable"))
+            .collect()
+            .unwrap();
+        crate::dataframe::write_csv(path, edited).await.unwrap();
+
+        refresh_markets(&client, data_dir.path()).await.unwrap();
+
+        let reloaded = crate::dataframe::read_csv(data_dir.path().join(file_name()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(disable_for(&reloaded, "BTC"), Some(true));
+        assert_eq!(disable_for(&reloaded, "ETH"), Some(false));
+    }
+}

--- a/src/screener.rs
+++ b/src/screener.rs
@@ -1,0 +1,330 @@
+//! Screener: rank the perp universe by a factor so users build factor-driven
+//! portfolios instead of picking symbols by hand.
+//!
+//! Each factor has a documented default sort direction, ties break by 24h volume
+//! (descending) then symbol (ascending), and rows missing the chosen factor are
+//! always sorted last and tagged with a `missing` flag.
+
+use std::path::Path;
+
+use polars::prelude::{
+    DataFrame, IntoLazy, JsonFormat, JsonWriter, PolarsError, SerWriter, SortMultipleOptions, col,
+};
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::{debug, instrument};
+
+use crate::factors::{ReturnsError, compute_factors};
+use crate::timeframe::Timeframe;
+
+/// A factor the screener can rank the perp universe by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum RankFactor {
+    Beta,
+    Momentum,
+    Carry,
+    Volatility,
+    Sharpe,
+}
+
+/// Sort order for a ranking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SortDirection {
+    Ascending,
+    Descending,
+}
+
+/// A request to rank the universe by a factor, with optional overrides.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ScreenerRequest {
+    factor: RankFactor,
+    /// Overrides the factor's documented default direction when present. For
+    /// carry, ascending expresses a short bias and descending a long bias.
+    direction: Option<SortDirection>,
+    /// Keeps only the top `limit` rows after ranking, when present.
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ScreenerError {
+    #[error(transparent)]
+    Factors(#[from] ReturnsError),
+    #[error(transparent)]
+    Polars(#[from] PolarsError),
+}
+
+/// Ranks the perp universe for `timeframe` by the requested factor and returns
+/// the ranked rows as a JSON array.
+#[instrument(skip_all, fields(data_dir = %data_dir.display()))]
+pub(crate) async fn screen(
+    data_dir: &Path,
+    timeframe: Timeframe,
+    request: &ScreenerRequest,
+) -> Result<Vec<u8>, ScreenerError> {
+    let factors = compute_factors(data_dir, timeframe).await?;
+    let mut ranked = rank_perps_by_factor(factors, request)?;
+
+    let mut buf = Vec::new();
+    JsonWriter::new(&mut buf)
+        .with_json_format(JsonFormat::Json)
+        .finish(&mut ranked)?;
+    Ok(buf)
+}
+
+/// Ranks the factor table by the requested factor.
+///
+/// Adds a `missing` flag (true where the chosen factor is null), sorts missing
+/// rows last regardless of direction, then orders by the factor, breaking ties
+/// by 24h volume (descending) then ticker (ascending). Honors a direction
+/// override and an optional top-`limit` filter.
+pub(crate) fn rank_perps_by_factor(
+    factors: DataFrame,
+    request: &ScreenerRequest,
+) -> Result<DataFrame, PolarsError> {
+    let column = request.factor.column();
+    let direction = request
+        .direction
+        .unwrap_or_else(|| request.factor.default_direction());
+    let descending = matches!(direction, SortDirection::Descending);
+
+    let ranked = factors
+        .lazy()
+        .with_column(col(column).is_null().alias("missing"))
+        // missing first (ascending: present rows, then missing), then the factor
+        // in its direction, then the tie-breaks: 24h volume desc, ticker asc.
+        .sort_by_exprs(
+            [
+                col("missing"),
+                col(column),
+                col("volume_24h"),
+                col("ticker"),
+            ],
+            SortMultipleOptions::default()
+                .with_order_descending_multi([false, descending, true, false])
+                .with_nulls_last(true),
+        )
+        .collect()?;
+
+    let ranked = match request.limit {
+        Some(limit) => ranked.head(Some(limit)),
+        None => ranked,
+    };
+
+    debug!(
+        factor = column,
+        limit = request.limit.unwrap_or(0),
+        rows = ranked.height(),
+        "perps ranked"
+    );
+    Ok(ranked)
+}
+
+impl RankFactor {
+    /// The factor-table column this factor ranks on.
+    fn column(self) -> &'static str {
+        match self {
+            Self::Beta => "beta",
+            Self::Momentum => "cum_return",
+            Self::Carry => "carry",
+            Self::Volatility => "annualized_volatility",
+            Self::Sharpe => "sharpe",
+        }
+    }
+
+    /// The documented default sort direction. Carry defaults to descending (a
+    /// long bias); a short bias is expressed by overriding to ascending.
+    fn default_direction(self) -> SortDirection {
+        match self {
+            Self::Beta | Self::Momentum | Self::Carry | Self::Sharpe => SortDirection::Descending,
+            Self::Volatility => SortDirection::Ascending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+    use std::fs;
+    use tempfile::TempDir;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use crate::logs_contain_at;
+
+    fn request(
+        factor: RankFactor,
+        direction: Option<SortDirection>,
+        limit: Option<usize>,
+    ) -> ScreenerRequest {
+        ScreenerRequest {
+            factor,
+            direction,
+            limit,
+        }
+    }
+
+    fn tickers_in_order(ranked: &DataFrame) -> Vec<String> {
+        let column = ranked.column("ticker").unwrap().str().unwrap();
+        (0..column.len())
+            .map(|index| column.get(index).unwrap().to_string())
+            .collect()
+    }
+
+    #[traced_test]
+    #[test]
+    fn ranks_by_sharpe_descending_by_default() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[1.0, 3.0, 2.0_f64],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Sharpe, None, None)).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC", "AAA"]);
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "sharpe"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn ranks_by_volatility_ascending_by_default() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "annualized_volatility" => &[0.3, 0.1, 0.2_f64],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Volatility, None, None)).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC", "AAA"]);
+        assert!(logs_contain_at(
+            Level::DEBUG,
+            &["perps ranked", "annualized_volatility"]
+        ));
+    }
+
+    #[traced_test]
+    #[test]
+    fn carry_defaults_to_descending_and_short_bias_overrides_to_ascending() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB"],
+            "carry" => &[0.0001, -0.0002_f64],
+            "volume_24h" => &[1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let long =
+            rank_perps_by_factor(factors.clone(), &request(RankFactor::Carry, None, None)).unwrap();
+        assert_eq!(
+            tickers_in_order(&long),
+            ["AAA", "BBB"],
+            "long bias: highest carry first"
+        );
+
+        let short = rank_perps_by_factor(
+            factors,
+            &request(RankFactor::Carry, Some(SortDirection::Ascending), None),
+        )
+        .unwrap();
+        assert_eq!(
+            tickers_in_order(&short),
+            ["BBB", "AAA"],
+            "short bias: lowest carry first"
+        );
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "carry"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn missing_rows_sort_last_and_are_flagged_regardless_of_direction() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[Some(1.0), None, Some(2.0_f64)],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        for direction in [SortDirection::Ascending, SortDirection::Descending] {
+            let ranked = rank_perps_by_factor(
+                factors.clone(),
+                &request(RankFactor::Sharpe, Some(direction), None),
+            )
+            .unwrap();
+            let order = tickers_in_order(&ranked);
+            assert_eq!(order.last().unwrap(), "BBB", "missing row is always last");
+
+            let missing = ranked.column("missing").unwrap().bool().unwrap();
+            let bbb_index = order.iter().position(|ticker| ticker == "BBB").unwrap();
+            assert_eq!(missing.get(bbb_index), Some(true), "missing row is flagged");
+        }
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "sharpe"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn ties_break_by_volume_then_symbol() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[1.0, 1.0, 1.0_f64],
+            "volume_24h" => &[100.0, 300.0, 300.0_f64],
+        }
+        .unwrap();
+
+        // All sharpe equal: higher volume first (BBB, CCC at 300 before AAA at
+        // 100); the BBB/CCC tie breaks by symbol ascending.
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Sharpe, None, None)).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC", "AAA"]);
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "sharpe"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn limit_keeps_only_the_top_rows() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[1.0, 3.0, 2.0_f64],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Sharpe, None, Some(2))).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC"]);
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "limit=2"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn screen_ranks_real_factors_and_logs() {
+        let tmp_dir = TempDir::new().unwrap();
+        fs::copy(
+            "fixtures/ohlcv_1d_beta.csv",
+            tmp_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let body = screen(
+            tmp_dir.path(),
+            Timeframe::OneDay,
+            &request(RankFactor::Sharpe, None, None),
+        )
+        .await
+        .unwrap();
+
+        let rows: Vec<serde_json::Value> =
+            serde_json::from_str(&String::from_utf8(body).unwrap()).unwrap();
+        assert!(!rows.is_empty(), "expected ranked rows");
+        assert!(
+            rows.iter().all(|row| row.get("missing").is_some()),
+            "every row carries a missing flag"
+        );
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked"]));
+    }
+}

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -55,6 +55,17 @@ impl Timeframe {
         }
     }
 
+    /// Number of candles spanning roughly 24 hours, used to sum trailing 24h
+    /// volume. Weekly candles are coarser than a day, so it is 1 (the latest
+    /// weekly candle's volume).
+    pub(crate) fn candles_per_day(self) -> usize {
+        match self {
+            Self::FifteenMin => 24 * 4,
+            Self::OneHour => 24,
+            Self::OneDay | Self::OneWeek => 1,
+        }
+    }
+
     /// Factor-engine parameters for this timeframe, ported from the legacy
     /// `util.py` `TIMEFRAME_CONFIGS`.
     pub(crate) fn config(self) -> TimeframeConfig {
@@ -86,7 +97,10 @@ impl Timeframe {
 
 /// Per-timeframe parameters that drive the factor engine's windowed math.
 pub(crate) struct TimeframeConfig {
-    /// Number of candles in the lookback window for rolling factor math.
+    /// Number of trailing rows in the per-ticker lookback window for rolling
+    /// factor math. Return-based factors window the last N log returns
+    /// (spanning N+1 candles); price-based factors (SMA, price z-score) window
+    /// the last N closes.
     pub(crate) lookback_periods: usize,
     /// Scaling factor to annualize per-period returns and volatility.
     pub(crate) annualized_factor: f64,
@@ -159,6 +173,33 @@ mod tests {
         assert!(
             (compounded_back_to_hourly - hour.min_acceptable_return).abs() < 1e-12,
             "four compounded 15m MARs must reproduce the hourly MAR"
+        );
+    }
+
+    #[test]
+    fn candles_per_day_spans_roughly_one_day() {
+        // Assert the property (window covers one day of intra-day candles)
+        // rather than re-typing the lookup table's literals.
+        const MINUTES_PER_DAY: usize = 24 * 60;
+        assert_eq!(
+            Timeframe::FifteenMin.candles_per_day() * 15,
+            MINUTES_PER_DAY,
+            "15m candles must cover one full day"
+        );
+        assert_eq!(
+            Timeframe::OneHour.candles_per_day() * 60,
+            MINUTES_PER_DAY,
+            "1h candles must cover one full day"
+        );
+        assert_eq!(
+            Timeframe::OneDay.candles_per_day() * MINUTES_PER_DAY,
+            MINUTES_PER_DAY,
+            "a daily candle covers exactly one day"
+        );
+        assert_eq!(
+            Timeframe::OneWeek.candles_per_day(),
+            1,
+            "weekly candles are coarser than a day, so the window is the latest candle"
         );
     }
 

--- a/stories/0x01c.screen-perps-by-factor.md
+++ b/stories/0x01c.screen-perps-by-factor.md
@@ -26,14 +26,18 @@ direction and tie-break order are exposed on the ranking API (e.g.
 `rankPerpsByFactor` / `applyRankingFilter`) so callers can override defaults
 explicitly.
 
-- [ ] The screener can rank perps by beta to BTC (or another benchmark).
-- [ ] The screener can rank perps by momentum over a configurable lookback
+The backend rank API (`POST /screener/<timeframe>`) ships these via
+[#274](https://github.com/data-cartel/moneymentum/pull/274); the final item is
+frontend portfolio-construction work that consumes the API.
+
+- [x] The screener can rank perps by beta to BTC (or another benchmark).
+- [x] The screener can rank perps by momentum over a configurable lookback
       period.
-- [ ] The screener can rank perps by carry (funding rate, signed for the
+- [x] The screener can rank perps by carry (funding rate, signed for the
       direction the user holds).
-- [ ] The screener can rank perps by realized volatility.
-- [ ] The screener can rank perps by Sharpe ratio.
-- [ ] Assets with missing data for the chosen factor are visibly marked, always
+- [x] The screener can rank perps by realized volatility.
+- [x] The screener can rank perps by Sharpe ratio.
+- [x] Assets with missing data for the chosen factor are visibly marked, always
       placed at the bottom, and never silently dropped.
 - [ ] The user can apply the active ranking as a filter when constructing a
       target portfolio.

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -21,7 +21,7 @@ async fn mount_meta_mock(server: &MockServer) {
         .and(path("/info"))
         .and(body_partial_json(json!({"type": "meta"})))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "universe": [{"name": "BTC", "szDecimals": 8}]
+            "universe": [{"name": "BTC", "szDecimals": 8, "maxLeverage": 50}]
         })))
         .mount(server)
         .await;


### PR DESCRIPTION
## Motivation

Lag-1 autocorrelation of returns distinguishes trending assets (persistent
returns) from mean-reverting ones, which is a useful signal for screening.

## Solution

Add a lag-1 Pearson autocorrelation factor in its own `factors/autocorrelation`
submodule. The pair window is a quarter of the factor lookback
(`AUTOCORRELATION_WINDOW_DIVISOR`, e.g. 22 pairs on the 90-period daily
window): a shorter window makes the score track the recent regime instead of
averaging lag-1 persistence over the whole lookback.

Closes #263

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264 👈
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated lag-1 autocorrelation of returns as a new factor in the factors endpoint, computing the metric per ticker over a configurable trailing window to provide insights into return patterns.

* **Tests**
  * Updated test suites to verify the new `autocorrelation` field is correctly computed and included in all factor score outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->