### PR TITLE
feat: add 24h volume factor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,9 @@ of them.
 - [x] Factor: beta (per-asset, to benchmark) --
       [#269](https://github.com/data-cartel/moneymentum/issues/269) /
       [#270](https://github.com/data-cartel/moneymentum/pull/270)
+- [x] Factor: 24h volume (screener tie-break) --
+      [#271](https://github.com/data-cartel/moneymentum/issues/271) /
+      [#272](https://github.com/data-cartel/moneymentum/pull/272)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,9 @@ of them.
 - [x] Factor: carry (signed funding) --
       [#267](https://github.com/data-cartel/moneymentum/issues/267) /
       [#268](https://github.com/data-cartel/moneymentum/pull/268)
+- [x] Factor: beta (per-asset, to benchmark) --
+      [#269](https://github.com/data-cartel/moneymentum/issues/269) /
+      [#270](https://github.com/data-cartel/moneymentum/pull/270)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,9 @@ of them.
 - [x] Factor: autocorrelation --
       [#263](https://github.com/data-cartel/moneymentum/issues/263) /
       [#264](https://github.com/data-cartel/moneymentum/pull/264)
-- [ ] Factor: information discreteness
+- [x] Factor: information discreteness --
+      [#265](https://github.com/data-cartel/moneymentum/issues/265) /
+      [#266](https://github.com/data-cartel/moneymentum/pull/266)
 - [ ] Factor: carry (signed funding)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,9 @@ of them.
 - [x] Factor: information discreteness --
       [#265](https://github.com/data-cartel/moneymentum/issues/265) /
       [#266](https://github.com/data-cartel/moneymentum/pull/266)
-- [ ] Factor: carry (signed funding)
+- [x] Factor: carry (signed funding) --
+      [#267](https://github.com/data-cartel/moneymentum/issues/267) /
+      [#268](https://github.com/data-cartel/moneymentum/pull/268)
 - [ ] Markets metadata + persisted disable flag
 - [ ] Tradable filter wired into ingestion
 

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -17,6 +17,7 @@
 //!   scores.
 //! - [`carry`]: latest signed funding rate, joined into the scores.
 //! - [`asset_beta`]: per-asset beta to the benchmark, joined into the scores.
+//! - [`volume`]: trailing 24h volume, joined into the scores.
 
 mod asset_beta;
 mod autocorrelation;
@@ -24,6 +25,7 @@ mod beta;
 mod carry;
 mod returns;
 mod scores;
+mod volume;
 
 pub(crate) use beta::compute_portfolio_beta_report;
 pub(crate) use scores::compute_factors_json;

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -15,9 +15,11 @@
 //!   mean return, price z-score), served by `GET /factors`.
 //! - [`autocorrelation`]: lag-1 autocorrelation of returns, joined into the
 //!   scores.
+//! - [`carry`]: latest signed funding rate, joined into the scores.
 
 mod autocorrelation;
 mod beta;
+mod carry;
 mod returns;
 mod scores;
 

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -16,7 +16,9 @@
 //! - [`autocorrelation`]: lag-1 autocorrelation of returns, joined into the
 //!   scores.
 //! - [`carry`]: latest signed funding rate, joined into the scores.
+//! - [`asset_beta`]: per-asset beta to the benchmark, joined into the scores.
 
+mod asset_beta;
 mod autocorrelation;
 mod beta;
 mod carry;

--- a/src/factors/asset_beta.rs
+++ b/src/factors/asset_beta.rs
@@ -1,0 +1,167 @@
+//! Per-asset beta to a benchmark: how strongly each asset's returns move with
+//! the benchmark's. This is a per-ticker screener factor, distinct from the
+//! portfolio beta in [`super::beta`].
+
+use polars::prelude::{
+    DataFrame, Expr, IntoLazy, JoinArgs, JoinType, NULL, PolarsError, SortMultipleOptions, col,
+    lit, when,
+};
+
+use super::returns::chronological;
+
+/// Per-ticker beta to `benchmark_ticker` over the last `lookback` paired returns:
+/// `Cov(asset, benchmark) / Var(benchmark)` (population moments).
+///
+/// Returns a `DataFrame` with columns `ticker` and `beta`. Beta is null when the
+/// benchmark has no return variance in the window. The benchmark's beta to
+/// itself is 1.
+pub(super) fn asset_beta_by_ticker(
+    with_returns: &DataFrame,
+    benchmark_ticker: &str,
+    lookback: usize,
+) -> Result<DataFrame, PolarsError> {
+    let benchmark = with_returns
+        .clone()
+        .lazy()
+        .filter(col("ticker").eq(lit(benchmark_ticker)))
+        .select([
+            col("timestamp"),
+            col("log_return").alias("benchmark_return"),
+        ]);
+
+    with_returns
+        .clone()
+        .lazy()
+        // Pair each asset return with the benchmark's return at the same time;
+        // covariance and variance are then measured over the same observations.
+        // Inner join by intent: an asset row without a benchmark row at that
+        // timestamp cannot form a pair and must not survive.
+        .join(
+            benchmark,
+            [col("timestamp")],
+            [col("timestamp")],
+            JoinArgs::new(JoinType::Inner),
+        )
+        // Drop incomplete pairs where either side's return is null (e.g. each
+        // ticker's first candle has no previous close).
+        .filter(
+            col("log_return")
+                .is_not_null()
+                .and(col("benchmark_return").is_not_null()),
+        )
+        .group_by([col("ticker")])
+        .agg([
+            {
+                let asset = chronological("log_return").tail(Some(lookback));
+                let asset_dev = asset.clone() - asset.mean();
+                (asset_dev * benchmark_deviation(lookback))
+                    .sum()
+                    .alias("beta_cov_sum")
+            },
+            (benchmark_deviation(lookback) * benchmark_deviation(lookback))
+                .sum()
+                .alias("beta_var_sum"),
+        ])
+        .with_column(
+            when(col("beta_var_sum").gt(lit(0.0)))
+                .then(col("beta_cov_sum") / col("beta_var_sum"))
+                .otherwise(lit(NULL))
+                .alias("beta"),
+        )
+        .select([col("ticker"), col("beta")])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()
+}
+
+/// Deviation of the benchmark's trailing returns from their window mean, the
+/// term shared by the covariance and variance aggregations above.
+fn benchmark_deviation(lookback: usize) -> Expr {
+    let benchmark_returns = chronological("benchmark_return").tail(Some(lookback));
+    benchmark_returns.clone() - benchmark_returns.mean()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+    use proptest::prelude::*;
+
+    fn returns_frame(btc: &[f64], eth: &[f64]) -> DataFrame {
+        let count = btc.len();
+        let timestamps: Vec<String> = (0..count)
+            .chain(0..count)
+            .map(|index| format!("{index:04}"))
+            .collect();
+        let tickers: Vec<&str> = std::iter::repeat_n("BTC", count)
+            .chain(std::iter::repeat_n("ETH", count))
+            .collect();
+        let log_returns: Vec<f64> = btc.iter().chain(eth.iter()).copied().collect();
+        df! {
+            "timestamp" => timestamps,
+            "ticker" => tickers,
+            "log_return" => log_returns,
+        }
+        .unwrap()
+    }
+
+    #[test]
+    fn beta_to_self_is_one_and_doubled_returns_give_two() {
+        let btc = [0.01, -0.02, 0.03, -0.01, 0.02];
+        let eth: Vec<f64> = btc.iter().map(|value| value * 2.0).collect();
+        let with_returns = returns_frame(&btc, &eth);
+
+        let out = asset_beta_by_ticker(&with_returns, "BTC", 100).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let beta = out.column("beta").unwrap().f64().unwrap();
+
+        assert_eq!(tickers.get(0), Some("BTC"));
+        assert!(
+            (beta.get(0).unwrap() - 1.0).abs() < 1e-12,
+            "the benchmark's beta to itself must be 1"
+        );
+        assert_eq!(tickers.get(1), Some("ETH"));
+        assert!(
+            (beta.get(1).unwrap() - 2.0).abs() < 1e-12,
+            "doubled returns must give beta 2"
+        );
+    }
+
+    #[test]
+    fn beta_is_null_when_benchmark_has_no_variance() {
+        let btc = [0.0, 0.0, 0.0, 0.0];
+        let eth = [0.01, -0.02, 0.03, -0.01];
+        let with_returns = returns_frame(&btc, &eth);
+
+        let out = asset_beta_by_ticker(&with_returns, "BTC", 100).unwrap();
+        let beta = out.column("beta").unwrap().f64().unwrap();
+
+        assert!(
+            beta.iter().all(|beta_value| beta_value.is_none()),
+            "a benchmark with no variance gives undefined (null) beta"
+        );
+    }
+
+    proptest! {
+        /// When an asset's returns are an exact multiple of the benchmark's, beta
+        /// recovers that multiple.
+        #[test]
+        fn beta_recovers_a_linear_coefficient(
+            btc in prop::collection::vec(-0.2_f64..0.2, 4..30),
+            coefficient in -3.0_f64..3.0,
+        ) {
+            prop_assume!(btc.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+            let eth: Vec<f64> = btc.iter().map(|value| value * coefficient).collect();
+            let with_returns = returns_frame(&btc, &eth);
+
+            let out = asset_beta_by_ticker(&with_returns, "BTC", 100).unwrap();
+            let tickers = out.column("ticker").unwrap().str().unwrap();
+            let beta = out.column("beta").unwrap().f64().unwrap();
+            let eth_index = tickers.iter().position(|ticker| ticker == Some("ETH")).unwrap();
+
+            prop_assert!(
+                (beta.get(eth_index).unwrap() - coefficient).abs() < 1e-9,
+                "beta should recover the coefficient {coefficient}"
+            );
+        }
+    }
+}

--- a/src/factors/carry.rs
+++ b/src/factors/carry.rs
@@ -1,0 +1,138 @@
+//! Carry factor: the latest signed funding rate per asset, joined into the
+//! per-ticker factor scores from `funding_rate1h.csv`.
+
+use polars::prelude::{
+    DataFrame, DataFrameJoinOps, DataType, IntoLazy, JoinArgs, JoinType, NULL, PolarsError,
+    SortMultipleOptions, col, lit,
+};
+
+use super::returns::chronological;
+
+/// Joins the carry factor (latest signed funding rate per ticker) into `factors`.
+///
+/// When funding data is absent, adds a null `carry` column so the factor table
+/// keeps a stable schema.
+pub(super) fn with_carry(
+    factors: DataFrame,
+    funding: Option<&DataFrame>,
+) -> Result<DataFrame, PolarsError> {
+    match funding {
+        Some(funding) => {
+            let carry = carry_by_ticker(funding)?;
+            Ok(factors.join(
+                &carry,
+                ["ticker"],
+                ["ticker"],
+                JoinArgs::new(JoinType::Left),
+                None,
+            )?)
+        }
+        None => Ok(factors
+            .lazy()
+            .with_column(lit(NULL).cast(DataType::Float64).alias("carry"))
+            .collect()?),
+    }
+}
+
+/// Latest funding rate per symbol, as a `DataFrame` keyed by `ticker`.
+///
+/// Funding rates are signed: positive means longs pay shorts, so a positive
+/// carry is a cost of being long and a yield for being short.
+fn carry_by_ticker(funding: &DataFrame) -> Result<DataFrame, PolarsError> {
+    funding
+        .clone()
+        .lazy()
+        .group_by([col("symbol")])
+        .agg([chronological("funding_rate").last().alias("carry")])
+        .select([col("symbol").alias("ticker"), col("carry")])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+
+    fn sample_funding() -> DataFrame {
+        // BTC's latest rate comes first so "latest" must win by timestamp,
+        // not by row order surviving into the group.
+        df! {
+            "timestamp" => &[
+                "2024-01-01T01:00:00Z",
+                "2024-01-01T00:00:00Z",
+                "2024-01-01T00:00:00Z",
+            ],
+            "funding_rate" => &[0.0003, 0.0001, -0.0002_f64],
+            "symbol" => &["BTC", "BTC", "ETH"],
+        }
+        .unwrap()
+    }
+
+    #[test]
+    fn carry_is_latest_funding_rate_per_symbol() {
+        let out = carry_by_ticker(&sample_funding()).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let carry = out.column("carry").unwrap().f64().unwrap();
+
+        assert_eq!(tickers.get(0), Some("BTC"));
+        assert!(
+            (carry.get(0).unwrap() - 0.0003).abs() < 1e-12,
+            "BTC carry should be the latest funding rate 0.0003"
+        );
+        assert_eq!(tickers.get(1), Some("ETH"));
+        assert!(
+            (carry.get(1).unwrap() - (-0.0002)).abs() < 1e-12,
+            "ETH carry should be its only funding rate -0.0002"
+        );
+    }
+
+    #[test]
+    fn with_carry_joins_latest_funding_onto_factors() {
+        // SOL has candles but no funding entry -- the most common real-world
+        // case. The left join must keep it with a null carry; an accidental
+        // inner join would silently drop every asset without a perp listing.
+        let factors = df! {
+            "ticker" => &["BTC", "ETH", "SOL"],
+            "sma" => &[1.0, 2.0, 3.0_f64],
+        }
+        .unwrap();
+
+        let out = with_carry(factors, Some(&sample_funding())).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let carry = out.column("carry").unwrap().f64().unwrap();
+        let carry_for = |ticker: &str| {
+            let index = (0..tickers.len())
+                .find(|&index| tickers.get(index) == Some(ticker))
+                .expect("every factors ticker survives the join");
+
+            carry.get(index)
+        };
+
+        assert!((carry_for("BTC").unwrap() - 0.0003).abs() < 1e-12);
+        assert!((carry_for("ETH").unwrap() - (-0.0002)).abs() < 1e-12);
+        assert!(
+            carry_for("SOL").is_none(),
+            "a ticker without funding data must keep a null carry, not vanish"
+        );
+    }
+
+    #[test]
+    fn with_carry_adds_null_column_when_funding_absent() {
+        let factors = df! {
+            "ticker" => &["BTC"],
+            "sma" => &[1.0_f64],
+        }
+        .unwrap();
+
+        let out = with_carry(factors, None).unwrap();
+        assert!(
+            out.column("carry").is_ok(),
+            "carry column is always present"
+        );
+        assert!(
+            out.column("carry").unwrap().f64().unwrap().get(0).is_none(),
+            "carry is null when there is no funding data"
+        );
+    }
+}

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -12,6 +12,7 @@ use tracing::{info, instrument};
 
 use super::ReturnsError;
 use super::autocorrelation::autocorrelation_by_ticker;
+use super::carry::with_carry;
 use super::returns::compute_log_returns;
 use crate::timeframe::{Timeframe, TimeframeConfig};
 
@@ -20,8 +21,8 @@ const PRICE_STDDEV_EPS: f64 = 1e-8;
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
 /// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
-/// `autocorrelation`, and `information_discreteness`; further factors are added
-/// as columns as they land.
+/// `autocorrelation`, `information_discreteness`, and `carry`; further factors
+/// are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -51,6 +52,8 @@ pub(crate) async fn compute_factors_json(
 ///   `lookback_periods` / 4 pairs; null when returns have no variation
 /// - `information_discreteness` = sign(`cum_return`) * (fraction of negative
 ///   returns - fraction of positive returns); -1 for a smooth trend
+/// - `carry` = latest signed funding rate from `funding_rate1h.csv`; null when
+///   no funding data is available
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -60,8 +63,13 @@ async fn compute_factors(data_dir: &Path, timeframe: Timeframe) -> Result<DataFr
     let Some(df) = df else {
         return Err(ReturnsError::NoData { path });
     };
+    let funding = crate::dataframe::read_csv(data_dir.join(crate::funding::file_name())).await?;
     let config = timeframe.config();
-    let out = tokio::task::spawn_blocking(move || per_ticker_factors(&df, &config)).await??;
+    let out = tokio::task::spawn_blocking(move || {
+        let factors = per_ticker_factors(&df, &config)?;
+        with_carry(factors, funding.as_ref())
+    })
+    .await??;
     info!(tickers = out.height(), "factors computed");
     Ok(out)
 }
@@ -820,8 +828,46 @@ mod tests {
         assert!(out.column("sortino").is_ok());
         assert!(out.column("autocorrelation").is_ok());
         assert!(out.column("information_discreteness").is_ok());
+        assert!(out.column("carry").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
+            &["factors computed"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn compute_factors_joins_latest_carry_from_funding_file() {
+        let tmp_dir = TempDir::new().unwrap();
+        fs::copy(
+            "fixtures/ohlcv_1d_beta.csv",
+            tmp_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+        fs::write(
+            tmp_dir.path().join("funding_rate1h.csv"),
+            "timestamp,funding_rate,symbol\n\
+             2024-01-01T00:00:00Z,0.0001,BTC\n\
+             2024-01-02T00:00:00Z,0.0005,BTC\n",
+        )
+        .unwrap();
+
+        let out = compute_factors(tmp_dir.path(), Timeframe::OneDay)
+            .await
+            .unwrap();
+
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let carry = out.column("carry").unwrap().f64().unwrap();
+        let btc_index = (0..tickers.len())
+            .find(|&index| tickers.get(index) == Some("BTC"))
+            .expect("BTC present");
+        assert!(
+            (carry.get(btc_index).unwrap() - 0.0005).abs() < 1e-12,
+            "BTC carry should be the latest funding rate 0.0005"
+        );
+
+        assert!(crate::logs_contain_at(
+            tracing::Level::DEBUG,
             &["factors computed"]
         ));
     }

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -8,13 +8,14 @@ use polars::prelude::{
     JsonFormat, JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit,
     when,
 };
-use tracing::{info, instrument};
+use tracing::{debug, instrument};
 
 use super::ReturnsError;
 use super::asset_beta::asset_beta_by_ticker;
 use super::autocorrelation::autocorrelation_by_ticker;
 use super::carry::with_carry;
-use super::returns::compute_log_returns;
+use super::returns::{chronological, compute_log_returns};
+use super::volume::with_volume_24h;
 use crate::timeframe::{Timeframe, TimeframeConfig};
 
 const PRICE_STDDEV_EPS: f64 = 1e-8;
@@ -26,8 +27,8 @@ const BENCHMARK_TICKER: &str = "BTC";
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
 /// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
-/// `autocorrelation`, `information_discreteness`, `carry`, and `beta`; further
-/// factors are added as columns as they land.
+/// `autocorrelation`, `information_discreteness`, `carry`, `beta`, and
+/// `volume_24h`; further factors are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -61,6 +62,9 @@ pub(crate) async fn compute_factors_json(
 ///   no funding data is available
 /// - `beta` = per-asset beta to the benchmark (BTC) over the lookback; null when
 ///   the benchmark has no return variance
+/// - `volume_24h` = quote notional (`volume * close`) summed over the
+///   dataset's trailing day of candles; null for a ticker with no candles in
+///   that window. On 1w this is the latest weekly candle -- a week's notional
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -72,12 +76,14 @@ async fn compute_factors(data_dir: &Path, timeframe: Timeframe) -> Result<DataFr
     };
     let funding = crate::dataframe::read_csv(data_dir.join(crate::funding::file_name())).await?;
     let config = timeframe.config();
+    let candles_per_day = timeframe.candles_per_day();
     let out = tokio::task::spawn_blocking(move || {
         let factors = per_ticker_factors(&df, &config)?;
+        let factors = with_volume_24h(&factors, &df, candles_per_day)?;
         with_carry(factors, funding.as_ref())
     })
     .await??;
-    info!(tickers = out.height(), "factors computed");
+    debug!(tickers = out.height(), "factors computed");
     Ok(out)
 }
 
@@ -105,9 +111,14 @@ fn per_ticker_factors(
         autocorrelation_by_ticker(&with_returns, lookback / AUTOCORRELATION_WINDOW_DIVISOR)?;
     let asset_beta = asset_beta_by_ticker(&with_returns, BENCHMARK_TICKER, lookback)?;
 
+    // Every factor must window the same trailing rows: single-source the two
+    // window expressions so one factor cannot silently diverge from the rest.
+    let trailing_returns = || chronological("log_return").tail(Some(lookback));
+    let trailing_closes = || chronological("close").tail(Some(lookback));
+
     // Downside deviation inputs for Sortino: sum of squared shortfalls below the
     // minimum acceptable return, and the observation count to average over.
-    let above_mar = col("log_return").tail(Some(lookback)) - lit(config.min_acceptable_return);
+    let above_mar = trailing_returns() - lit(config.min_acceptable_return);
     let downside_sq_sum = when(above_mar.clone().lt(lit(0.0)))
         .then(above_mar.pow(lit(2)))
         .otherwise(lit(0.0))
@@ -118,42 +129,33 @@ fn per_ticker_factors(
         .lazy()
         .group_by([col("ticker")])
         .agg([
-            (col("log_return").tail(Some(lookback)).std(1) * lit(annualization_multiplier))
+            (trailing_returns().std(1) * lit(annualization_multiplier))
                 .alias("annualized_volatility"),
-            col("log_return")
-                .tail(Some(lookback))
-                .sum()
-                .alias("cum_log_return"),
-            col("close").tail(Some(lookback)).mean().alias("sma"),
-            col("log_return")
-                .tail(Some(lookback))
-                .mean()
-                .alias("mean_return"),
-            col("close")
-                .tail(Some(lookback))
-                .std(1)
-                .alias("price_stddev"),
-            col("close").last().alias("last_close"),
+            trailing_returns().sum().alias("cum_log_return"),
+            trailing_closes().mean().alias("sma"),
+            trailing_returns().mean().alias("mean_return"),
+            trailing_closes().std(1).alias("price_stddev"),
+            chronological("close").last().alias("last_close"),
             downside_sq_sum,
-            col("log_return")
-                .tail(Some(lookback))
-                .count()
-                .alias("obs_count"),
-            (col("log_return").tail(Some(lookback)).gt(lit(0.0)))
-                .sum()
-                .alias("pos_count"),
-            (col("log_return").tail(Some(lookback)).lt(lit(0.0)))
-                .sum()
-                .alias("neg_count"),
+            trailing_returns().count().alias("obs_count"),
+            (trailing_returns().gt(lit(0.0))).sum().alias("pos_count"),
+            (trailing_returns().lt(lit(0.0))).sum().alias("neg_count"),
         ])
         // price z-score = (latest close - SMA) / price stddev; undefined (null)
-        // when there is no price dispersion (constant prices over the window).
+        // when there is no price dispersion (constant prices over the window)
+        // or no measurable dispersion at all (a NaN stddev must never pass the
+        // guard, mirroring the annualized_return finiteness guard).
         .with_column(
-            when(col("price_stddev").gt(lit(PRICE_STDDEV_EPS)))
-                .then((col("last_close") - col("sma")) / col("price_stddev"))
-                .otherwise(lit(NULL))
-                .alias("price_zscore"),
+            when(
+                col("price_stddev")
+                    .is_finite()
+                    .and(col("price_stddev").gt(lit(PRICE_STDDEV_EPS))),
+            )
+            .then((col("last_close") - col("sma")) / col("price_stddev"))
+            .otherwise(lit(NULL))
+            .alias("price_zscore"),
         )
+        .drop(cols(["price_stddev", "last_close"]))
         .sort(["ticker"], SortMultipleOptions::default())
         .collect()?;
 
@@ -222,8 +224,6 @@ fn add_return_and_risk_factors(
         .collect()?;
 
     factors.drop_in_place("cum_log_return")?;
-    factors.drop_in_place("price_stddev")?;
-    factors.drop_in_place("last_close")?;
 
     let downside_deviation = (col("downside_sq_sum") / col("obs_count")).pow(lit(0.5));
 
@@ -473,6 +473,230 @@ mod tests {
                 "a smooth uptrend must give information_discreteness -1, got {information_discreteness}"
             );
         }
+    }
+
+    #[test]
+    fn factor_windows_select_the_chronologically_latest_returns() {
+        // 8 candles per ticker with a lookback of 3: the first five closes are
+        // flat (zero returns), the last three returns are ln(1.1), ln(1/1.1),
+        // ln(1.1). A stale window of zeros gives cum_return 0 instead of 0.1,
+        // and while one other window ([0, 0, ln(1.1)]) also sums to ln(1.1),
+        // the sma assertion below discriminates it (its closes average lower
+        // than the trailing window's).
+        let candles = df! {
+            "timestamp" => &[
+                "0", "1", "2", "3", "4", "5", "6", "7",
+                "0", "1", "2", "3", "4", "5", "6", "7",
+            ],
+            "ticker" => &["BTC"; 8].iter().chain(&["ETH"; 8]).copied().collect::<Vec<_>>(),
+            "close" => &[
+                100.0, 100.0, 100.0, 100.0, 100.0, 110.0, 100.0, 110.0,
+                200.0, 200.0, 200.0, 200.0, 200.0, 220.0, 200.0, 220.0_f64,
+            ],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 3,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let ticker_column = out.column("ticker").unwrap().str().unwrap();
+        for (ticker, expected_sma) in [
+            ("BTC", (110.0 + 100.0 + 110.0) / 3.0),
+            ("ETH", (220.0 + 200.0 + 220.0) / 3.0),
+        ] {
+            let row_index = (0..out.height())
+                .find(|row| ticker_column.get(*row) == Some(ticker))
+                .expect("ticker row present in the factor output");
+
+            let cum_return = out
+                .column("cum_return")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(row_index)
+                .unwrap();
+            assert!(
+                (cum_return - 0.1).abs() < 1e-12,
+                "{ticker}: trailing-window cum_return must be 0.1, got {cum_return}"
+            );
+
+            let sma = out
+                .column("sma")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(row_index)
+                .unwrap();
+            assert!(
+                (sma - expected_sma).abs() < 1e-9,
+                "{ticker}: sma over the trailing window must be {expected_sma}, got {sma}"
+            );
+        }
+    }
+
+    #[test]
+    fn per_ticker_factors_sharpe_is_null_when_a_zero_close_poisons_volatility() {
+        // A zero close produces a -inf log return: std over the window goes
+        // NaN while annualized_return collapses to a finite -1, so only the
+        // is_finite() denominator guard stands between this input and a NaN
+        // sharpe in the /factors JSON.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[100.0, 0.0, 101.0],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let sharpe = out.column("sharpe").unwrap().f64().unwrap().get(0);
+        assert!(
+            sharpe.is_none_or(|value| !value.is_nan()),
+            "a NaN volatility must never produce a NaN sharpe, got {sharpe:?}"
+        );
+
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0);
+        assert!(
+            information_discreteness.is_none(),
+            "a NaN cum_return is unmeasurable, not \"perfectly choppy\": \
+             information_discreteness must be null, got {information_discreteness:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_sharpe_is_negative_for_a_downtrend() {
+        // Every other sharpe test uses a non-negative return, so a sign error
+        // in the formula (e.g. an accidental abs on the numerator) would pass
+        // the whole suite while misranking every asset in a drawdown.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 99.0, 97.5, 95.0],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let sharpe = out
+            .column("sharpe")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .expect("a varying downtrend has non-zero volatility");
+        assert!(
+            sharpe < 0.0,
+            "a losing asset must have a negative sharpe, got {sharpe}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_nulls_annualized_return_when_exp_overflows() {
+        // exp(mean_return * annualized_factor) overflows f64 for an extreme
+        // mean return; the guard must surface null, never inf, which would
+        // corrupt screener rankings and is unrepresentable in JSON. Two
+        // distinct returns keep the volatility finite and non-zero, so the
+        // sharpe assertion below genuinely tests null propagation from
+        // annualized_return rather than a null-volatility shortcut.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[1.0, 1e100, 1e150_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let annualized_return = out
+            .column("annualized_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0);
+        assert!(
+            annualized_return.is_none(),
+            "an overflowing annualized return must be null, got {annualized_return:?}"
+        );
+        let sharpe = out.column("sharpe").unwrap().f64().unwrap().get(0);
+        assert!(
+            sharpe.is_none(),
+            "sharpe derives from annualized_return and must be null too, got {sharpe:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_zscore_is_null_when_a_close_is_nan() {
+        // A NaN close poisons the window's stddev to NaN, and NaN != 0.0 is
+        // true in IEEE 754 - without the is_finite() guard the z-score would
+        // serialize as NaN and silently dominate any z-score-ranked output.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC"],
+            "close" => &[100.0, f64::NAN, 101.0],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0);
+        assert!(
+            zscore.is_none(),
+            "a NaN close gives no measurable dispersion, so price_zscore must be null, got {zscore:?}"
+        );
+    }
+
+    #[test]
+    fn per_ticker_factors_zscore_is_null_for_a_single_candle_ticker() {
+        // A single observation yields a null (not NaN) stddev from std(ddof=1);
+        // pin the documented null so the edge stays covered.
+        let candles = df! {
+            "timestamp" => &["0"],
+            "ticker" => &["BTC"],
+            "close" => &[100.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+
+        let zscore = out.column("price_zscore").unwrap().f64().unwrap().get(0);
+        assert!(
+            zscore.is_none(),
+            "a single candle has no price dispersion, so price_zscore must be null, got {zscore:?}"
+        );
     }
 
     #[test]
@@ -847,20 +1071,75 @@ mod tests {
             .unwrap();
 
         assert!(out.height() > 0, "expected a factor row per ticker");
-        assert!(out.column("annualized_volatility").is_ok());
-        assert!(out.column("cum_return").is_ok());
-        assert!(out.column("sma").is_ok());
-        assert!(out.column("mean_return").is_ok());
-        assert!(out.column("price_zscore").is_ok());
-        assert!(out.column("annualized_return").is_ok());
-        assert!(out.column("sharpe").is_ok());
-        assert!(out.column("sortino").is_ok());
-        assert!(out.column("autocorrelation").is_ok());
-        assert!(out.column("information_discreteness").is_ok());
-        assert!(out.column("carry").is_ok());
-        assert!(out.column("beta").is_ok());
+
+        // Pin real values for a known fixture ticker (the value lookups also
+        // prove every column exists); schema presence alone would pass on
+        // all-NaN output.
+        let ticker_column = out.column("ticker").unwrap().str().unwrap();
+        let btc_row = (0..out.height())
+            .find(|row| ticker_column.get(*row) == Some("BTC"))
+            .expect("BTC present in the fixture");
+        let btc_volatility = out
+            .column("annualized_volatility")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(btc_row)
+            .expect("BTC volatility computed");
+        assert!(
+            btc_volatility.is_finite() && btc_volatility > 0.0,
+            "BTC volatility must be a positive finite number, got {btc_volatility}"
+        );
+        let btc_cum_return = out
+            .column("cum_return")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(btc_row)
+            .expect("BTC cum_return computed");
+        assert!(
+            btc_cum_return.is_finite() && btc_cum_return > 0.0,
+            "the fixture's BTC closes rise over the lookback window, so \
+             cum_return must be positive, got {btc_cum_return}"
+        );
+
+        // The fixture's BTC series varies, so every series-derived factor must
+        // be a real number for BTC, not null.
+        for factor_column in [
+            "sma",
+            "mean_return",
+            "price_zscore",
+            "annualized_return",
+            "sharpe",
+            "sortino",
+            "autocorrelation",
+            "information_discreteness",
+            "beta",
+            "volume_24h",
+        ] {
+            let value = out
+                .column(factor_column)
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(btc_row);
+            assert!(
+                value.is_some_and(f64::is_finite),
+                "BTC {factor_column} must be a finite number, got {value:?}"
+            );
+        }
+
+        // No funding file was written, so carry must be null - the documented
+        // no-funding-data behavior (the carry join is covered with real data by
+        // compute_factors_joins_latest_carry_from_funding_file).
+        let btc_carry = out.column("carry").unwrap().f64().unwrap().get(btc_row);
+        assert!(
+            btc_carry.is_none(),
+            "carry must be null without funding data, got {btc_carry:?}"
+        );
+
         assert!(crate::logs_contain_at(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["factors computed"]
         ));
     }

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -4,8 +4,9 @@
 use std::path::Path;
 
 use polars::prelude::{
-    ChunkApply, DataFrame, DataFrameJoinOps, IntoLazy, IntoSeries, JoinArgs, JoinType, JsonFormat,
-    JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit, when,
+    ChunkApply, DataFrame, DataFrameJoinOps, DataType, IntoLazy, IntoSeries, JoinArgs, JoinType,
+    JsonFormat, JsonWriter, NULL, PolarsError, SerWriter, SortMultipleOptions, col, cols, lit,
+    when,
 };
 use tracing::{info, instrument};
 
@@ -18,8 +19,9 @@ const PRICE_STDDEV_EPS: f64 = 1e-8;
 
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
-/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`, and
-/// `autocorrelation`; further factors are added as columns as they land.
+/// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
+/// `autocorrelation`, and `information_discreteness`; further factors are added
+/// as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -47,6 +49,8 @@ pub(crate) async fn compute_factors_json(
 ///   when there is no downside
 /// - `autocorrelation` = lag-1 autocorrelation of returns over the last
 ///   `lookback_periods` / 4 pairs; null when returns have no variation
+/// - `information_discreteness` = sign(`cum_return`) * (fraction of negative
+///   returns - fraction of positive returns); -1 for a smooth trend
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -118,6 +122,12 @@ fn per_ticker_factors(
                 .tail(Some(lookback))
                 .count()
                 .alias("obs_count"),
+            (col("log_return").tail(Some(lookback)).gt(lit(0.0)))
+                .sum()
+                .alias("pos_count"),
+            (col("log_return").tail(Some(lookback)).lt(lit(0.0)))
+                .sum()
+                .alias("neg_count"),
         ])
         // price z-score = (latest close - SMA) / price stddev; undefined (null)
         // when there is no price dispersion (constant prices over the window).
@@ -146,8 +156,10 @@ fn per_ticker_factors(
 /// Derives the return and risk-adjusted factors from the aggregated columns and
 /// drops the intermediate sums/counts they were computed from.
 ///
-/// Adds `cum_return`, `annualized_return`, `sharpe`, and `sortino`.
-/// `sharpe`/`sortino` are null when their risk denominator is zero.
+/// Adds `cum_return`, `annualized_return`, `sharpe`, `sortino`, and
+/// `information_discreteness`. `sharpe`/`sortino` are null when their risk
+/// denominator is zero; `information_discreteness` is `sign(cum_return)` times
+/// the negative-minus-positive return fraction.
 fn add_return_and_risk_factors(
     mut factors: DataFrame,
     annualized_factor: f64,
@@ -188,10 +200,21 @@ fn add_return_and_risk_factors(
     factors.drop_in_place("price_stddev")?;
     factors.drop_in_place("last_close")?;
 
-    // sharpe = annualized_return / annualized_volatility (risk-free 0); sortino =
-    // annualized_return / downside deviation below the MAR. Both are undefined
-    // (null) when their risk denominator is zero.
     let downside_deviation = (col("downside_sq_sum") / col("obs_count")).pow(lit(0.5));
+
+    // information discreteness = sign(cum_return) * (pct_negative - pct_positive):
+    // -1 for a smooth one-directional trend, near 0 for choppy or flat returns.
+    let return_sign = when(col("cum_return").gt(lit(0.0)))
+        .then(lit(1.0))
+        .otherwise(
+            when(col("cum_return").lt(lit(0.0)))
+                .then(lit(-1.0))
+                .otherwise(lit(0.0)),
+        );
+    let pct_difference = (col("neg_count").cast(DataType::Float64)
+        - col("pos_count").cast(DataType::Float64))
+        / col("obs_count").cast(DataType::Float64);
+
     let factors = factors
         .lazy()
         .with_columns([
@@ -218,8 +241,25 @@ fn add_return_and_risk_factors(
             .then(col("annualized_return") / downside_deviation)
             .otherwise(lit(NULL))
             .alias("sortino"),
+            // NaN > 0.0 and NaN < 0.0 are both false, so a NaN-poisoned
+            // cum_return would slip through return_sign as a legitimate-looking
+            // 0.0 ("perfectly choppy") without the explicit finiteness guard
+            // its sibling factors all carry.
+            when(
+                col("obs_count")
+                    .gt(lit(0))
+                    .and(col("cum_return").is_finite()),
+            )
+            .then(return_sign * pct_difference)
+            .otherwise(lit(NULL))
+            .alias("information_discreteness"),
         ])
-        .drop(cols(["downside_sq_sum", "obs_count"]))
+        .drop(cols([
+            "downside_sq_sum",
+            "obs_count",
+            "pos_count",
+            "neg_count",
+        ]))
         .collect()?;
 
     Ok(factors)
@@ -315,6 +355,18 @@ mod tests {
                     "sortino must be finite when present, got {sortino}"
                 );
             }
+
+            let information_discreteness = out
+                .column("information_discreteness")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            prop_assert!(
+                (-1.0 - 1e-9..=1.0 + 1e-9).contains(&information_discreteness),
+                "information_discreteness {information_discreteness} outside [-1, 1]"
+            );
         }
 
         /// For a strictly increasing close series the latest close is the maximum,
@@ -376,6 +428,20 @@ mod tests {
             prop_assert!(
                 sortino.is_none(),
                 "increasing closes have no downside, so sortino must be null, got {sortino:?}"
+            );
+
+            // A smooth uptrend is fully positive returns, so information
+            // discreteness is sign(+) * (0 - 1) = -1.
+            let information_discreteness = out
+                .column("information_discreteness")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            prop_assert!(
+                (information_discreteness - (-1.0)).abs() < 1e-12,
+                "a smooth uptrend must give information_discreteness -1, got {information_discreteness}"
             );
         }
     }
@@ -481,6 +547,20 @@ mod tests {
             .get(0)
             .unwrap();
         assert!(sortino.abs() < 1e-12, "sortino should be ~0, got {sortino}");
+
+        // cum_return is 0, so sign(cum_return) is 0 and information discreteness
+        // is 0 regardless of the positive/negative return split.
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            information_discreteness.abs() < 1e-12,
+            "information_discreteness should be ~0, got {information_discreteness}"
+        );
     }
 
     #[test]
@@ -577,6 +657,20 @@ mod tests {
             autocorrelation.is_none(),
             "constant prices give an undefined (null) autocorrelation, got {autocorrelation:?}"
         );
+
+        // cum_return is 0 (sign 0) with no positive or negative returns, so
+        // information discreteness is exactly 0.
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            information_discreteness.abs() < 1e-12,
+            "constant prices give zero information_discreteness, got {information_discreteness}"
+        );
     }
 
     #[test]
@@ -642,6 +736,67 @@ mod tests {
         );
     }
 
+    #[test]
+    fn information_discreteness_matches_manual_value_for_mixed_signs() {
+        // Three up moves and one down move with a net-positive cum_return:
+        // sign(+) * (pct_negative - pct_positive) = 1 * (1/4 - 3/4) = -0.5.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3", "4"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 102.0, 101.0, 103.0, 105.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+
+        assert!(
+            (information_discreteness - (-0.5)).abs() < 1e-12,
+            "1 down of 4 returns on a net uptrend must give -0.5, got {information_discreteness}"
+        );
+    }
+
+    #[test]
+    fn information_discreteness_is_minus_one_for_smooth_downtrend() {
+        // A smooth downtrend is fully negative returns, so information
+        // discreteness is sign(-) * (1 - 0) = -1, mirroring the uptrend case.
+        let candles = df! {
+            "timestamp" => &["0", "1", "2", "3"],
+            "ticker" => &["BTC", "BTC", "BTC", "BTC"],
+            "close" => &[100.0, 99.0, 98.0, 97.0_f64],
+        }
+        .unwrap();
+        let config = TimeframeConfig {
+            lookback_periods: 10,
+            annualized_factor: 365.0,
+            min_acceptable_return: 0.0,
+        };
+
+        let out = per_ticker_factors(&candles, &config).unwrap();
+        let information_discreteness = out
+            .column("information_discreteness")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert!(
+            (information_discreteness - (-1.0)).abs() < 1e-12,
+            "a smooth downtrend must give information_discreteness -1, got {information_discreteness}"
+        );
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn compute_factors_reads_candles_and_logs() {
@@ -664,6 +819,7 @@ mod tests {
         assert!(out.column("sharpe").is_ok());
         assert!(out.column("sortino").is_ok());
         assert!(out.column("autocorrelation").is_ok());
+        assert!(out.column("information_discreteness").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -11,6 +11,7 @@ use polars::prelude::{
 use tracing::{info, instrument};
 
 use super::ReturnsError;
+use super::asset_beta::asset_beta_by_ticker;
 use super::autocorrelation::autocorrelation_by_ticker;
 use super::carry::with_carry;
 use super::returns::compute_log_returns;
@@ -18,11 +19,15 @@ use crate::timeframe::{Timeframe, TimeframeConfig};
 
 const PRICE_STDDEV_EPS: f64 = 1e-8;
 
+/// Benchmark asset for the per-ticker beta factor. Bitcoin beta is the SPEC's
+/// core risk metric, so the factor table's `beta` column is always beta to BTC.
+const BENCHMARK_TICKER: &str = "BTC";
+
 /// Per-ticker factor scores serialized as a JSON array, for the `/factors`
 /// endpoint. Exposes `annualized_volatility`, `cum_return`, `sma`,
 /// `mean_return`, `price_zscore`, `annualized_return`, `sharpe`, `sortino`,
-/// `autocorrelation`, `information_discreteness`, and `carry`; further factors
-/// are added as columns as they land.
+/// `autocorrelation`, `information_discreteness`, `carry`, and `beta`; further
+/// factors are added as columns as they land.
 pub(crate) async fn compute_factors_json(
     data_dir: &Path,
     timeframe: Timeframe,
@@ -54,6 +59,8 @@ pub(crate) async fn compute_factors_json(
 ///   returns - fraction of positive returns); -1 for a smooth trend
 /// - `carry` = latest signed funding rate from `funding_rate1h.csv`; null when
 ///   no funding data is available
+/// - `beta` = per-asset beta to the benchmark (BTC) over the lookback; null when
+///   the benchmark has no return variance
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
@@ -85,8 +92,9 @@ fn per_ticker_factors(
     let lookback = config.lookback_periods;
     let annualization_multiplier = config.annualized_factor.sqrt();
 
-    // Lag-1 autocorrelation needs its own complete-pairs pass over a shorter
-    // window, computed separately and joined back in by ticker below.
+    // Lag-1 autocorrelation and per-asset beta each need their own pass (a
+    // shorter complete-pairs window, and a benchmark join), computed separately
+    // and joined back in by ticker below.
     //
     // The pair window is a quarter of the factor lookback (e.g. 22 pairs on
     // the 90-period daily window): a shorter window makes the score track the
@@ -95,6 +103,7 @@ fn per_ticker_factors(
     const AUTOCORRELATION_WINDOW_DIVISOR: usize = 4;
     let autocorrelation =
         autocorrelation_by_ticker(&with_returns, lookback / AUTOCORRELATION_WINDOW_DIVISOR)?;
+    let asset_beta = asset_beta_by_ticker(&with_returns, BENCHMARK_TICKER, lookback)?;
 
     // Downside deviation inputs for Sortino: sum of squared shortfalls below the
     // minimum acceptable return, and the observation count to average over.
@@ -152,6 +161,14 @@ fn per_ticker_factors(
 
     let factors = factors.join(
         &autocorrelation,
+        ["ticker"],
+        ["ticker"],
+        JoinArgs::new(JoinType::Left),
+        None,
+    )?;
+
+    let factors = factors.join(
+        &asset_beta,
         ["ticker"],
         ["ticker"],
         JoinArgs::new(JoinType::Left),
@@ -375,6 +392,10 @@ mod tests {
                 (-1.0 - 1e-9..=1.0 + 1e-9).contains(&information_discreteness),
                 "information_discreteness {information_discreteness} outside [-1, 1]"
             );
+
+            if let Some(beta) = out.column("beta").unwrap().f64().unwrap().get(0) {
+                prop_assert!(beta.is_finite(), "beta must be finite when present, got {beta}");
+            }
         }
 
         /// For a strictly increasing close series the latest close is the maximum,
@@ -679,6 +700,14 @@ mod tests {
             information_discreteness.abs() < 1e-12,
             "constant prices give zero information_discreteness, got {information_discreteness}"
         );
+
+        // BTC is the benchmark, so constant prices mean zero benchmark
+        // variance and the beta guard must fire through the full pipeline.
+        let beta = out.column("beta").unwrap().f64().unwrap().get(0);
+        assert!(
+            beta.is_none(),
+            "constant benchmark prices give undefined (null) beta, got {beta:?}"
+        );
     }
 
     #[test]
@@ -829,6 +858,7 @@ mod tests {
         assert!(out.column("autocorrelation").is_ok());
         assert!(out.column("information_discreteness").is_ok());
         assert!(out.column("carry").is_ok());
+        assert!(out.column("beta").is_ok());
         assert!(crate::logs_contain_at(
             tracing::Level::INFO,
             &["factors computed"]

--- a/src/factors/volume.rs
+++ b/src/factors/volume.rs
@@ -1,0 +1,187 @@
+//! Trailing 24h traded notional per asset, a liquidity measure the screener
+//! uses as its tie-break.
+
+use polars::prelude::{
+    DataFrame, DataFrameJoinOps, IntoLazy, JoinArgs, JoinType, PolarsError, SortMultipleOptions,
+    col, lit,
+};
+
+/// Joins per-ticker trailing-24h notional volume into `factors`.
+///
+/// Hyperliquid's candleSnapshot `v` field is denominated in the base asset
+/// (the recorded fixtures show BTC hourly volumes of ~200 against $65k closes,
+/// and the API docs' example value is 0.98639), so raw sums are not comparable
+/// across assets. Each candle's volume is converted to quote notional
+/// (`volume * close`) before summing, making `volume_24h` a real cross-asset
+/// liquidity measure.
+///
+/// The window is the dataset's trailing `candles_per_day` distinct timestamps,
+/// anchored to the most liquid market's clock rather than each ticker's own
+/// last rows: a stale (halted/delisted) ticker has no candles at recent
+/// timestamps and gets a null instead of re-counting its old tail, and a thin
+/// market contributes only the intervals it actually traded. On timeframes
+/// coarser than hourly the window holds a single candle -- on 1w that is the
+/// latest weekly candle, a full week's notional, the finest approximation
+/// weekly data can express.
+pub(super) fn with_volume_24h(
+    factors: &DataFrame,
+    candles: &DataFrame,
+    candles_per_day: usize,
+) -> Result<DataFrame, PolarsError> {
+    let volume = volume_24h_by_ticker(candles, candles_per_day)?;
+
+    factors.join(
+        &volume,
+        ["ticker"],
+        ["ticker"],
+        JoinArgs::new(JoinType::Left),
+        None,
+    )
+}
+
+/// Per-ticker trailing-24h notional volume, as a `DataFrame` keyed by `ticker`.
+fn volume_24h_by_ticker(
+    candles: &DataFrame,
+    candles_per_day: usize,
+) -> Result<DataFrame, PolarsError> {
+    let window_start = trailing_window_start(candles, candles_per_day)?;
+
+    candles
+        .clone()
+        .lazy()
+        .filter(col("timestamp").gt_eq(lit(window_start)))
+        .group_by([col("ticker")])
+        .agg([(col("volume") * col("close")).sum().alias("volume_24h")])
+        .sort(["ticker"], SortMultipleOptions::default())
+        .collect()
+}
+
+/// The earliest timestamp inside the trailing window: the dataset's
+/// `candles_per_day`-th distinct timestamp from the end (or the very first
+/// when the dataset is shorter than a day).
+///
+/// Anchoring on the dataset rather than each ticker keeps a ticker that
+/// stopped trading from counting candles older than the window.
+fn trailing_window_start(
+    candles: &DataFrame,
+    candles_per_day: usize,
+) -> Result<String, PolarsError> {
+    let mut timestamps: Vec<String> = candles
+        .column("timestamp")?
+        .str()?
+        .iter()
+        .flatten()
+        .map(str::to_string)
+        .collect();
+    timestamps.sort_unstable();
+    timestamps.dedup();
+
+    let start_index = timestamps.len().saturating_sub(candles_per_day);
+
+    // An empty dataset has no window to bound; the empty-string floor matches
+    // every row of the (equally empty) frame.
+    Ok(timestamps.into_iter().nth(start_index).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+
+    fn candles() -> DataFrame {
+        // Timestamps 0..2; ETH stopped trading after timestamp 1 and SOL only
+        // traded the latest interval.
+        df! {
+            "timestamp" => &["0", "1", "2", "0", "1", "2"],
+            "ticker" => &["BTC", "BTC", "BTC", "ETH", "ETH", "SOL"],
+            "close" => &[100.0, 110.0, 120.0, 10.0, 11.0, 3.0_f64],
+            "volume" => &[10.0, 20.0, 30.0, 5.0, 7.0, 1000.0_f64],
+        }
+        .unwrap()
+    }
+
+    #[test]
+    fn volume_24h_sums_notional_over_the_trailing_window() {
+        // Window = last two dataset timestamps ("1", "2"): BTC sums
+        // 20*110 + 30*120 = 5800; base units alone would rank SOL's 1000
+        // contracts above BTC's 50.
+        let out = volume_24h_by_ticker(&candles(), 2).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let volume = out.column("volume_24h").unwrap().f64().unwrap();
+        let notional_for = |ticker: &str| {
+            let index = tickers
+                .iter()
+                .position(|value| value == Some(ticker))
+                .expect("ticker present");
+
+            volume.get(index)
+        };
+
+        assert!((notional_for("BTC").unwrap() - 5800.0).abs() < 1e-12);
+        assert!((notional_for("ETH").unwrap() - 77.0).abs() < 1e-12);
+        assert!(
+            (notional_for("SOL").unwrap() - 3000.0).abs() < 1e-12,
+            "1000 contracts at $3 is $3000 of liquidity, far below BTC's $5800"
+        );
+    }
+
+    #[test]
+    fn volume_24h_excludes_a_stale_ticker_from_the_window() {
+        // Window = the latest dataset timestamp only. ETH's last candle is at
+        // timestamp 1, so it must not re-count its old tail: no rows survive
+        // the window filter and the join below yields null, not stale volume.
+        let out = volume_24h_by_ticker(&candles(), 1).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+
+        assert!(
+            tickers.iter().all(|ticker| ticker != Some("ETH")),
+            "a ticker with no candles inside the window has no volume row"
+        );
+    }
+
+    #[test]
+    fn with_volume_24h_joins_onto_factors_and_keeps_unmatched_tickers() {
+        let factors = df! {
+            "ticker" => &["BTC", "ETH", "SOL"],
+            "sma" => &[1.0, 2.0, 3.0_f64],
+        }
+        .unwrap();
+
+        let out = with_volume_24h(&factors, &candles(), 1).unwrap();
+        assert_eq!(out.height(), 3, "the left join keeps every factors row");
+
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let volume = out.column("volume_24h").unwrap().f64().unwrap();
+        let notional_for = |ticker: &str| {
+            let index = tickers
+                .iter()
+                .position(|value| value == Some(ticker))
+                .expect("ticker present");
+
+            volume.get(index)
+        };
+
+        assert!((notional_for("BTC").unwrap() - 3600.0).abs() < 1e-12);
+        assert!(
+            notional_for("ETH").is_none(),
+            "a stale ticker's volume is null, not its old tail"
+        );
+        assert!((notional_for("SOL").unwrap() - 3000.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn volume_24h_uses_all_candles_when_the_dataset_is_shorter_than_a_day() {
+        let out = volume_24h_by_ticker(&candles(), 100).unwrap();
+        let tickers = out.column("ticker").unwrap().str().unwrap();
+        let volume = out.column("volume_24h").unwrap().f64().unwrap();
+        let btc_index = tickers
+            .iter()
+            .position(|value| value == Some("BTC"))
+            .expect("ticker present");
+
+        assert!(
+            (volume.get(btc_index).unwrap() - (1000.0 + 2200.0 + 3600.0)).abs() < 1e-12,
+            "a window wider than the dataset sums every candle's notional"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,9 +662,20 @@ mod tests {
                 .is_some()),
             "every row carries information_discreteness as a number (the fixture's returns all vary)"
         );
+        // The fixture ships no funding data, so carry is legitimately null --
+        // but the key itself must stay in the schema for every row.
         assert!(
-            rows.iter().all(|row| row.get("carry").is_some()),
-            "every row carries carry"
+            rows.iter()
+                .all(|row| row.get("carry").is_some_and(serde_json::Value::is_null)),
+            "carry key is present and null for every row without funding data"
+        );
+
+        assert!(
+            rows.iter().all(|row| row
+                .get("beta")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries beta as a number (prices vary and BTC is the benchmark)"
         );
         assert!(
             rows.iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,13 @@ mod tests {
             "every row carries autocorrelation as a number (the fixture's returns all vary)"
         );
         assert!(
+            rows.iter().all(|row| row
+                .get("information_discreteness")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries information_discreteness as a number (the fixture's returns all vary)"
+        );
+        assert!(
             rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,6 +663,10 @@ mod tests {
             "every row carries information_discreteness as a number (the fixture's returns all vary)"
         );
         assert!(
+            rows.iter().all(|row| row.get("carry").is_some()),
+            "every row carries carry"
+        );
+        assert!(
             rows.iter()
                 .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
             "BTC is present in the factor scores"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,6 +489,7 @@ mod tests {
     use proptest::prelude::*;
     use rocket::local::blocking::Client;
     use tempfile::TempDir;
+    use tracing_test::traced_test;
 
     fn test_rocket(data_dir: &std::path::Path) -> rocket::Rocket<rocket::Build> {
         let config = Config {
@@ -583,6 +584,7 @@ mod tests {
         assert_eq!(response.status(), Status::NotFound);
     }
 
+    #[traced_test]
     #[test]
     fn get_factors_returns_per_ticker_factor_scores_json() {
         let data_dir = TempDir::new().unwrap();
@@ -678,9 +680,72 @@ mod tests {
             "every row carries beta as a number (prices vary and BTC is the benchmark)"
         );
         assert!(
-            rows.iter()
-                .any(|row| row.get("ticker").and_then(|t| t.as_str()) == Some("BTC")),
-            "BTC is present in the factor scores"
+            rows.iter().all(|row| row
+                .get("volume_24h")
+                .and_then(serde_json::Value::as_f64)
+                .is_some()),
+            "every row carries volume_24h as a number (every fixture ticker has current candles)"
+        );
+        assert_btc_factor_values_are_real(&rows);
+
+        assert!(logs_contain_at(
+            tracing::Level::DEBUG,
+            &["factors computed"]
+        ));
+    }
+
+    /// Key presence alone would pass if every factor serialized as null; pin
+    /// BTC's values so a serialization regression fails the factors route test.
+    fn assert_btc_factor_values_are_real(rows: &[serde_json::Value]) {
+        let btc_row = rows
+            .iter()
+            .find(|row| row.get("ticker").and_then(|ticker| ticker.as_str()) == Some("BTC"))
+            .expect("BTC is present in the factor scores");
+
+        let btc_volatility = btc_row["annualized_volatility"]
+            .as_f64()
+            .expect("BTC annualized_volatility is a number");
+        assert!(
+            btc_volatility > 0.0,
+            "BTC annualized_volatility must be positive, got {btc_volatility}"
+        );
+        for factor_key in [
+            "cum_return",
+            "sma",
+            "mean_return",
+            "price_zscore",
+            "annualized_return",
+            "sharpe",
+            "sortino",
+            "autocorrelation",
+            "information_discreteness",
+            "beta",
+            "volume_24h",
+        ] {
+            let value = btc_row[factor_key].as_f64();
+            assert!(
+                value.is_some_and(f64::is_finite),
+                "BTC {factor_key} must be a finite number, got {value:?}"
+            );
+        }
+
+        // Pin the unit conversion: the fixture's latest BTC candle is 1400
+        // base units against a ~$46.7k close, so notional must be tens of
+        // millions -- a raw base-unit sum (~1400) fails this by four orders
+        // of magnitude.
+        let btc_volume = btc_row["volume_24h"]
+            .as_f64()
+            .expect("BTC volume_24h is a number");
+        assert!(
+            btc_volume > 1e6,
+            "volume_24h must be quote notional, not base units, got {btc_volume}"
+        );
+        // No funding fixture is staged, so carry serializes as null - the
+        // documented no-funding-data behavior.
+        assert!(
+            btc_row["carry"].is_null(),
+            "carry must be null without funding data, got {:?}",
+            btc_row["carry"]
         );
     }
 

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -55,6 +55,17 @@ impl Timeframe {
         }
     }
 
+    /// Number of candles spanning roughly 24 hours, used to sum trailing 24h
+    /// volume. Weekly candles are coarser than a day, so it is 1 (the latest
+    /// weekly candle's volume).
+    pub(crate) fn candles_per_day(self) -> usize {
+        match self {
+            Self::FifteenMin => 24 * 4,
+            Self::OneHour => 24,
+            Self::OneDay | Self::OneWeek => 1,
+        }
+    }
+
     /// Factor-engine parameters for this timeframe, ported from the legacy
     /// `util.py` `TIMEFRAME_CONFIGS`.
     pub(crate) fn config(self) -> TimeframeConfig {
@@ -86,7 +97,10 @@ impl Timeframe {
 
 /// Per-timeframe parameters that drive the factor engine's windowed math.
 pub(crate) struct TimeframeConfig {
-    /// Number of candles in the lookback window for rolling factor math.
+    /// Number of trailing rows in the per-ticker lookback window for rolling
+    /// factor math. Return-based factors window the last N log returns
+    /// (spanning N+1 candles); price-based factors (SMA, price z-score) window
+    /// the last N closes.
     pub(crate) lookback_periods: usize,
     /// Scaling factor to annualize per-period returns and volatility.
     pub(crate) annualized_factor: f64,
@@ -159,6 +173,33 @@ mod tests {
         assert!(
             (compounded_back_to_hourly - hour.min_acceptable_return).abs() < 1e-12,
             "four compounded 15m MARs must reproduce the hourly MAR"
+        );
+    }
+
+    #[test]
+    fn candles_per_day_spans_roughly_one_day() {
+        // Assert the property (window covers one day of intra-day candles)
+        // rather than re-typing the lookup table's literals.
+        const MINUTES_PER_DAY: usize = 24 * 60;
+        assert_eq!(
+            Timeframe::FifteenMin.candles_per_day() * 15,
+            MINUTES_PER_DAY,
+            "15m candles must cover one full day"
+        );
+        assert_eq!(
+            Timeframe::OneHour.candles_per_day() * 60,
+            MINUTES_PER_DAY,
+            "1h candles must cover one full day"
+        );
+        assert_eq!(
+            Timeframe::OneDay.candles_per_day() * MINUTES_PER_DAY,
+            MINUTES_PER_DAY,
+            "a daily candle covers exactly one day"
+        );
+        assert_eq!(
+            Timeframe::OneWeek.candles_per_day(),
+            1,
+            "weekly candles are coarser than a day, so the window is the latest candle"
         );
     }
 


### PR DESCRIPTION
## Motivation

24h volume is needed as a liquidity signal and, specifically, as the screener's
deterministic tie-break when two assets rank equally on the chosen factor.

## Solution

Add a `volume_24h` per-ticker factor (sum of the trailing day's candle volume,
using the timeframe's candles-per-day), wired in as the screener tie-break input.


Closes #271

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272 👈
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->