### PR TITLE
feat: screener ranks perps by factor with an endpoint

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -152,7 +152,11 @@ Find assets by factor characteristics, stage portfolio changes, and simulate the
 result before sending trades.
 
 - [ ] [Compare Target vs Current Portfolio](./stories/0x01a.compare-target-vs-current-portfolio.md)
-- [ ] [Screen Perps By Factor](./stories/0x01c.screen-perps-by-factor.md)
+- [ ] [Screen Perps By Factor](./stories/0x01c.screen-perps-by-factor.md) --
+      backend rank API shipped
+      ([#273](https://github.com/data-cartel/moneymentum/issues/273) /
+      [#274](https://github.com/data-cartel/moneymentum/pull/274)); frontend
+      filter integration pending
 - [ ] [Simulate Staged Portfolio Metrics](./stories/0x01d.simulate-staged-portfolio-metrics.md)
 
 ---

--- a/src/factors.rs
+++ b/src/factors.rs
@@ -28,7 +28,7 @@ mod scores;
 mod volume;
 
 pub(crate) use beta::compute_portfolio_beta_report;
-pub(crate) use scores::compute_factors_json;
+pub(crate) use scores::{compute_factors, compute_factors_json};
 
 use thiserror::Error;
 

--- a/src/factors/scores.rs
+++ b/src/factors/scores.rs
@@ -68,7 +68,10 @@ pub(crate) async fn compute_factors_json(
 ///
 /// Returns a `DataFrame` keyed by `ticker`. New factors are added as columns.
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
-async fn compute_factors(data_dir: &Path, timeframe: Timeframe) -> Result<DataFrame, ReturnsError> {
+pub(crate) async fn compute_factors(
+    data_dir: &Path,
+    timeframe: Timeframe,
+) -> Result<DataFrame, ReturnsError> {
     let path = data_dir.join(timeframe.file_name());
     let df = crate::dataframe::read_csv(path.clone()).await?;
     let Some(df) = df else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod funding;
 mod hyperliquid;
 mod ingestion;
 mod readonly_portfolio;
+mod screener;
 mod timeframe;
 
 use std::net::Ipv4Addr;
@@ -149,6 +150,24 @@ async fn get_factors(
         Err(factors::ReturnsError::NoData { .. }) => Err(Status::NotFound),
         Err(err) => {
             error!(error = %err, "failed to compute factors");
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+#[post("/screener/<timeframe>", data = "<body>")]
+async fn post_screener(
+    config: &State<Config>,
+    timeframe: Timeframe,
+    body: Json<screener::ScreenerRequest>,
+) -> Result<RawJson<Vec<u8>>, Status> {
+    match screener::screen(&config.data_dir, timeframe, &body).await {
+        Ok(json) => Ok(RawJson(json)),
+        Err(screener::ScreenerError::Factors(factors::ReturnsError::NoData { .. })) => {
+            Err(Status::NotFound)
+        }
+        Err(err) => {
+            error!(error = %err, "failed to screen perps");
             Err(Status::InternalServerError)
         }
     }
@@ -451,6 +470,7 @@ pub async fn rocket(
                 health,
                 get_candles,
                 get_factors,
+                post_screener,
                 start_ingestion,
                 get_ingestion_status,
                 post_beta,
@@ -501,9 +521,10 @@ mod tests {
             max_concurrent_requests: 3,
             max_retries: 5,
         };
-        rocket::build()
-            .manage(config)
-            .mount("/", routes![health, get_candles, get_factors])
+        rocket::build().manage(config).mount(
+            "/",
+            routes![health, get_candles, get_factors, post_screener],
+        )
     }
 
     proptest! {
@@ -746,6 +767,46 @@ mod tests {
             btc_row["carry"].is_null(),
             "carry must be null without funding data, got {:?}",
             btc_row["carry"]
+        );
+    }
+
+    #[test]
+    fn post_screener_returns_404_when_no_data() {
+        let data_dir = TempDir::new().unwrap();
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/screener/1d")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"factor":"sharpe"}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[test]
+    fn post_screener_returns_ranked_rows_with_missing_flags() {
+        let data_dir = TempDir::new().unwrap();
+        std::fs::copy(
+            std::path::Path::new("fixtures/ohlcv_1d_beta.csv"),
+            data_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/screener/1d")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"factor":"sharpe"}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        let rows: Vec<serde_json::Value> =
+            serde_json::from_str(&body).expect("screener body is a JSON array");
+        assert!(!rows.is_empty(), "expected ranked rows");
+        assert!(
+            rows.iter().all(|row| row.get("missing").is_some()),
+            "every ranked row carries a missing flag"
         );
     }
 

--- a/src/screener.rs
+++ b/src/screener.rs
@@ -1,0 +1,330 @@
+//! Screener: rank the perp universe by a factor so users build factor-driven
+//! portfolios instead of picking symbols by hand.
+//!
+//! Each factor has a documented default sort direction, ties break by 24h volume
+//! (descending) then symbol (ascending), and rows missing the chosen factor are
+//! always sorted last and tagged with a `missing` flag.
+
+use std::path::Path;
+
+use polars::prelude::{
+    DataFrame, IntoLazy, JsonFormat, JsonWriter, PolarsError, SerWriter, SortMultipleOptions, col,
+};
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::{debug, instrument};
+
+use crate::factors::{ReturnsError, compute_factors};
+use crate::timeframe::Timeframe;
+
+/// A factor the screener can rank the perp universe by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum RankFactor {
+    Beta,
+    Momentum,
+    Carry,
+    Volatility,
+    Sharpe,
+}
+
+/// Sort order for a ranking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SortDirection {
+    Ascending,
+    Descending,
+}
+
+/// A request to rank the universe by a factor, with optional overrides.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ScreenerRequest {
+    factor: RankFactor,
+    /// Overrides the factor's documented default direction when present. For
+    /// carry, ascending expresses a short bias and descending a long bias.
+    direction: Option<SortDirection>,
+    /// Keeps only the top `limit` rows after ranking, when present.
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ScreenerError {
+    #[error(transparent)]
+    Factors(#[from] ReturnsError),
+    #[error(transparent)]
+    Polars(#[from] PolarsError),
+}
+
+/// Ranks the perp universe for `timeframe` by the requested factor and returns
+/// the ranked rows as a JSON array.
+#[instrument(skip_all, fields(data_dir = %data_dir.display()))]
+pub(crate) async fn screen(
+    data_dir: &Path,
+    timeframe: Timeframe,
+    request: &ScreenerRequest,
+) -> Result<Vec<u8>, ScreenerError> {
+    let factors = compute_factors(data_dir, timeframe).await?;
+    let mut ranked = rank_perps_by_factor(factors, request)?;
+
+    let mut buf = Vec::new();
+    JsonWriter::new(&mut buf)
+        .with_json_format(JsonFormat::Json)
+        .finish(&mut ranked)?;
+    Ok(buf)
+}
+
+/// Ranks the factor table by the requested factor.
+///
+/// Adds a `missing` flag (true where the chosen factor is null), sorts missing
+/// rows last regardless of direction, then orders by the factor, breaking ties
+/// by 24h volume (descending) then ticker (ascending). Honors a direction
+/// override and an optional top-`limit` filter.
+pub(crate) fn rank_perps_by_factor(
+    factors: DataFrame,
+    request: &ScreenerRequest,
+) -> Result<DataFrame, PolarsError> {
+    let column = request.factor.column();
+    let direction = request
+        .direction
+        .unwrap_or_else(|| request.factor.default_direction());
+    let descending = matches!(direction, SortDirection::Descending);
+
+    let ranked = factors
+        .lazy()
+        .with_column(col(column).is_null().alias("missing"))
+        // missing first (ascending: present rows, then missing), then the factor
+        // in its direction, then the tie-breaks: 24h volume desc, ticker asc.
+        .sort_by_exprs(
+            [
+                col("missing"),
+                col(column),
+                col("volume_24h"),
+                col("ticker"),
+            ],
+            SortMultipleOptions::default()
+                .with_order_descending_multi([false, descending, true, false])
+                .with_nulls_last(true),
+        )
+        .collect()?;
+
+    let ranked = match request.limit {
+        Some(limit) => ranked.head(Some(limit)),
+        None => ranked,
+    };
+
+    debug!(
+        factor = column,
+        limit = request.limit.unwrap_or(0),
+        rows = ranked.height(),
+        "perps ranked"
+    );
+    Ok(ranked)
+}
+
+impl RankFactor {
+    /// The factor-table column this factor ranks on.
+    fn column(self) -> &'static str {
+        match self {
+            Self::Beta => "beta",
+            Self::Momentum => "cum_return",
+            Self::Carry => "carry",
+            Self::Volatility => "annualized_volatility",
+            Self::Sharpe => "sharpe",
+        }
+    }
+
+    /// The documented default sort direction. Carry defaults to descending (a
+    /// long bias); a short bias is expressed by overriding to ascending.
+    fn default_direction(self) -> SortDirection {
+        match self {
+            Self::Beta | Self::Momentum | Self::Carry | Self::Sharpe => SortDirection::Descending,
+            Self::Volatility => SortDirection::Ascending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::df;
+    use std::fs;
+    use tempfile::TempDir;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use crate::logs_contain_at;
+
+    fn request(
+        factor: RankFactor,
+        direction: Option<SortDirection>,
+        limit: Option<usize>,
+    ) -> ScreenerRequest {
+        ScreenerRequest {
+            factor,
+            direction,
+            limit,
+        }
+    }
+
+    fn tickers_in_order(ranked: &DataFrame) -> Vec<String> {
+        let column = ranked.column("ticker").unwrap().str().unwrap();
+        (0..column.len())
+            .map(|index| column.get(index).unwrap().to_string())
+            .collect()
+    }
+
+    #[traced_test]
+    #[test]
+    fn ranks_by_sharpe_descending_by_default() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[1.0, 3.0, 2.0_f64],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Sharpe, None, None)).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC", "AAA"]);
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "sharpe"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn ranks_by_volatility_ascending_by_default() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "annualized_volatility" => &[0.3, 0.1, 0.2_f64],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Volatility, None, None)).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC", "AAA"]);
+        assert!(logs_contain_at(
+            Level::DEBUG,
+            &["perps ranked", "annualized_volatility"]
+        ));
+    }
+
+    #[traced_test]
+    #[test]
+    fn carry_defaults_to_descending_and_short_bias_overrides_to_ascending() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB"],
+            "carry" => &[0.0001, -0.0002_f64],
+            "volume_24h" => &[1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let long =
+            rank_perps_by_factor(factors.clone(), &request(RankFactor::Carry, None, None)).unwrap();
+        assert_eq!(
+            tickers_in_order(&long),
+            ["AAA", "BBB"],
+            "long bias: highest carry first"
+        );
+
+        let short = rank_perps_by_factor(
+            factors,
+            &request(RankFactor::Carry, Some(SortDirection::Ascending), None),
+        )
+        .unwrap();
+        assert_eq!(
+            tickers_in_order(&short),
+            ["BBB", "AAA"],
+            "short bias: lowest carry first"
+        );
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "carry"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn missing_rows_sort_last_and_are_flagged_regardless_of_direction() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[Some(1.0), None, Some(2.0_f64)],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        for direction in [SortDirection::Ascending, SortDirection::Descending] {
+            let ranked = rank_perps_by_factor(
+                factors.clone(),
+                &request(RankFactor::Sharpe, Some(direction), None),
+            )
+            .unwrap();
+            let order = tickers_in_order(&ranked);
+            assert_eq!(order.last().unwrap(), "BBB", "missing row is always last");
+
+            let missing = ranked.column("missing").unwrap().bool().unwrap();
+            let bbb_index = order.iter().position(|ticker| ticker == "BBB").unwrap();
+            assert_eq!(missing.get(bbb_index), Some(true), "missing row is flagged");
+        }
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "sharpe"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn ties_break_by_volume_then_symbol() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[1.0, 1.0, 1.0_f64],
+            "volume_24h" => &[100.0, 300.0, 300.0_f64],
+        }
+        .unwrap();
+
+        // All sharpe equal: higher volume first (BBB, CCC at 300 before AAA at
+        // 100); the BBB/CCC tie breaks by symbol ascending.
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Sharpe, None, None)).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC", "AAA"]);
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "sharpe"]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn limit_keeps_only_the_top_rows() {
+        let factors = df! {
+            "ticker" => &["AAA", "BBB", "CCC"],
+            "sharpe" => &[1.0, 3.0, 2.0_f64],
+            "volume_24h" => &[1.0, 1.0, 1.0_f64],
+        }
+        .unwrap();
+
+        let ranked =
+            rank_perps_by_factor(factors, &request(RankFactor::Sharpe, None, Some(2))).unwrap();
+        assert_eq!(tickers_in_order(&ranked), ["BBB", "CCC"]);
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked", "limit=2"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn screen_ranks_real_factors_and_logs() {
+        let tmp_dir = TempDir::new().unwrap();
+        fs::copy(
+            "fixtures/ohlcv_1d_beta.csv",
+            tmp_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let body = screen(
+            tmp_dir.path(),
+            Timeframe::OneDay,
+            &request(RankFactor::Sharpe, None, None),
+        )
+        .await
+        .unwrap();
+
+        let rows: Vec<serde_json::Value> =
+            serde_json::from_str(&String::from_utf8(body).unwrap()).unwrap();
+        assert!(!rows.is_empty(), "expected ranked rows");
+        assert!(
+            rows.iter().all(|row| row.get("missing").is_some()),
+            "every row carries a missing flag"
+        );
+        assert!(logs_contain_at(Level::DEBUG, &["perps ranked"]));
+    }
+}

--- a/stories/0x01c.screen-perps-by-factor.md
+++ b/stories/0x01c.screen-perps-by-factor.md
@@ -26,14 +26,18 @@ direction and tie-break order are exposed on the ranking API (e.g.
 `rankPerpsByFactor` / `applyRankingFilter`) so callers can override defaults
 explicitly.
 
-- [ ] The screener can rank perps by beta to BTC (or another benchmark).
-- [ ] The screener can rank perps by momentum over a configurable lookback
+The backend rank API (`POST /screener/<timeframe>`) ships these via
+[#274](https://github.com/data-cartel/moneymentum/pull/274); the final item is
+frontend portfolio-construction work that consumes the API.
+
+- [x] The screener can rank perps by beta to BTC (or another benchmark).
+- [x] The screener can rank perps by momentum over a configurable lookback
       period.
-- [ ] The screener can rank perps by carry (funding rate, signed for the
+- [x] The screener can rank perps by carry (funding rate, signed for the
       direction the user holds).
-- [ ] The screener can rank perps by realized volatility.
-- [ ] The screener can rank perps by Sharpe ratio.
-- [ ] Assets with missing data for the chosen factor are visibly marked, always
+- [x] The screener can rank perps by realized volatility.
+- [x] The screener can rank perps by Sharpe ratio.
+- [x] Assets with missing data for the chosen factor are visibly marked, always
       placed at the bottom, and never silently dropped.
 - [ ] The user can apply the active ranking as a filter when constructing a
       target portfolio.


### PR DESCRIPTION
## Motivation

Users build factor-driven portfolios by ranking the tradable universe on a chosen
factor rather than picking symbols by hand (story 0x01c). Nothing exposed that
ranking.

## Solution

Add `POST /screener/<timeframe>` that ranks the perp universe by a factor, with a
documented default sort direction per factor, an optional direction/limit
override, rows missing the factor sorted last (and flagged), and ties broken by
24h volume (desc) then ticker (asc). `rank_perps_by_factor` logs a deterministic
completion line for observability.


Closes #273

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274 👈
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->