### PR TITLE
feat: refresh markets metadata ledger during ingestion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,9 @@ of them.
 - [x] Factor: 24h volume (screener tie-break) --
       [#271](https://github.com/data-cartel/moneymentum/issues/271) /
       [#272](https://github.com/data-cartel/moneymentum/pull/272)
-- [ ] Markets metadata + persisted disable flag
+- [x] Markets metadata + persisted disable flag --
+      [#275](https://github.com/data-cartel/moneymentum/issues/275) /
+      [#276](https://github.com/data-cartel/moneymentum/pull/276)
 - [ ] Tradable filter wired into ingestion
 
 ---

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -23,6 +23,7 @@ use crate::candle::{Candle, CandleError, candles_to_dataframe};
 use crate::dataframe::{self, DataFrameError};
 use crate::finance::{Market, Symbol};
 use crate::funding::{self, FundingError, FundingRate};
+use crate::market_metadata::MarketMetadata;
 use crate::timeframe::Timeframe;
 
 /// Maximum number of data points returned by Hyperliquid's historical data endpoints.
@@ -44,6 +45,10 @@ pub(crate) enum HyperliquidError {
     Sdk(#[from] hyperliquid_rust_sdk::Error),
     #[error(transparent)]
     IntConversion(#[from] TryFromIntError),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Polars(#[from] polars::prelude::PolarsError),
 }
 
 /// Abstraction over Hyperliquid's market data API.
@@ -52,6 +57,8 @@ pub(crate) enum HyperliquidError {
 #[async_trait]
 pub(crate) trait Hyperliquid: Send + Sync {
     async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError>;
+
+    async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError>;
 
     async fn fetch_candles(
         &self,
@@ -104,6 +111,61 @@ impl Hyperliquid for HyperliquidClient {
             .collect();
         debug!(count = markets.len(), "fetched markets");
         Ok(markets)
+    }
+
+    #[instrument(skip(self))]
+    async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+        // The SDK's typed `meta()` drops `maxLeverage`, so request the raw `meta`
+        // info payload and parse the fields we need ourselves.
+        #[derive(serde::Serialize)]
+        struct MetaRequest {
+            #[serde(rename = "type")]
+            request_type: &'static str,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawMeta {
+            universe: Vec<RawAsset>,
+        }
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RawAsset {
+            name: String,
+            max_leverage: u32,
+        }
+
+        let url = format!("{}/info", self.info.http_client.base_url);
+        let raw = (|| async {
+            reqwest::Client::new()
+                .post(&url)
+                .json(&MetaRequest {
+                    request_type: "meta",
+                })
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<RawMeta>()
+                .await
+        })
+        .retry(
+            ExponentialBuilder::default()
+                .with_jitter()
+                .with_max_times(self.max_retries),
+        )
+        .notify(|err, dur| {
+            debug!(error = %err, delay = ?dur, "retrying market metadata fetch");
+        })
+        .await?;
+
+        let metadata: Vec<MarketMetadata> = raw
+            .universe
+            .into_iter()
+            .map(|asset| MarketMetadata {
+                symbol: Market::new(asset.name),
+                max_leverage: asset.max_leverage,
+            })
+            .collect();
+        debug!(count = metadata.len(), "fetched market metadata");
+        Ok(metadata)
     }
 
     #[instrument(skip(self))]
@@ -418,6 +480,7 @@ mod tests {
 
     struct MockHyperliquid {
         markets: Vec<Market>,
+        market_metadata: Vec<MarketMetadata>,
         candles: Vec<Candle>,
         funding_rates: Vec<FundingRate>,
         fetch_candles_calls: AtomicUsize,
@@ -428,6 +491,10 @@ mod tests {
         fn new() -> Self {
             Self {
                 markets: vec![Market::new("BTC".to_string())],
+                market_metadata: vec![MarketMetadata {
+                    symbol: Market::new("BTC".to_string()),
+                    max_leverage: 50,
+                }],
                 candles: vec![Candle {
                     timestamp: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
                     open: 42000.0,
@@ -459,6 +526,10 @@ mod tests {
     impl Hyperliquid for MockHyperliquid {
         async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
             Ok(self.markets.clone())
+        }
+
+        async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            Ok(self.market_metadata.clone())
         }
 
         async fn fetch_candles(

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -62,7 +62,14 @@ impl IngestionJob {
             services.max_concurrent_requests,
         );
 
-        match ingest_all(&candle_ingester, &funding_ingester, &services.data_dir).await {
+        match ingest_all(
+            services.hyperliquid.as_ref(),
+            &candle_ingester,
+            &funding_ingester,
+            &services.data_dir,
+        )
+        .await
+        {
             Ok(last_record) => {
                 if let Err(err) = complete_run(&pool, &self.run_id, last_record).await {
                     error!(error = %err, run_id = self.run_id.as_str(), "failed to record ingestion completion");
@@ -85,10 +92,12 @@ impl IngestionJob {
 }
 
 async fn ingest_all(
+    client: &dyn Hyperliquid,
     candle_ingester: &CandleIngester<dyn Hyperliquid>,
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
     data_dir: &Path,
 ) -> Result<DateTime<Utc>, HyperliquidError> {
+    crate::market_metadata::refresh_markets(client, data_dir).await?;
     funding_ingester.ingest(data_dir).await?;
 
     for timeframe in TIMEFRAMES {
@@ -325,6 +334,15 @@ mod tests {
     impl Hyperliquid for MockHyperliquid {
         async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
             Ok(vec![Market::new("BTC".into())])
+        }
+
+        async fn fetch_market_metadata(
+            &self,
+        ) -> Result<Vec<crate::market_metadata::MarketMetadata>, HyperliquidError> {
+            Ok(vec![crate::market_metadata::MarketMetadata {
+                symbol: Market::new("BTC".into()),
+                max_leverage: 50,
+            }])
         }
 
         async fn fetch_candles(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod finance;
 mod funding;
 mod hyperliquid;
 mod ingestion;
+mod market_metadata;
 mod readonly_portfolio;
 mod screener;
 mod timeframe;

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -1,0 +1,224 @@
+//! Markets metadata: the perp universe with each market's max leverage and a
+//! persisted `disable` flag, stored in `markets.csv`.
+//!
+//! The `disable` flag is operator-controlled (edited by hand) and preserved
+//! across refreshes; metadata like max leverage is refreshed from the exchange.
+
+use std::path::Path;
+
+use polars::prelude::{
+    DataFrame, IntoLazy, JoinArgs, JoinType, NamedFrom, PolarsError, Series, col, df, lit,
+};
+use tracing::info;
+
+use crate::finance::Market;
+use crate::hyperliquid::{Hyperliquid, HyperliquidError};
+
+/// A market's exchange metadata as fetched from Hyperliquid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MarketMetadata {
+    pub(crate) symbol: Market,
+    pub(crate) max_leverage: u32,
+}
+
+/// File name of the markets ledger inside the data directory.
+pub(crate) fn file_name() -> &'static str {
+    "markets.csv"
+}
+
+/// Fetches the current markets metadata, merges it with the persisted ledger
+/// (preserving the `disable` flag), and writes `markets.csv`.
+pub(crate) async fn refresh_markets(
+    client: &dyn Hyperliquid,
+    data_dir: &Path,
+) -> Result<(), HyperliquidError> {
+    let fetched = client.fetch_market_metadata().await?;
+    let path = data_dir.join(file_name());
+    let existing = crate::dataframe::read_csv(path.clone()).await?;
+    let frame = build_markets_frame(&fetched, existing.as_ref())?;
+    crate::dataframe::write_csv(path, frame).await?;
+    info!(markets = fetched.len(), "markets metadata refreshed");
+    Ok(())
+}
+
+/// Builds the markets ledger `DataFrame` (`symbol`, `max_leverage`, `disable`)
+/// from freshly fetched metadata, preserving the `disable` flag of any symbol
+/// already in `existing` and defaulting new symbols to enabled (`disable` false).
+fn build_markets_frame(
+    fetched: &[MarketMetadata],
+    existing: Option<&DataFrame>,
+) -> Result<DataFrame, PolarsError> {
+    let symbols: Vec<&str> = fetched
+        .iter()
+        .map(|market| market.symbol.as_str())
+        .collect();
+    let max_leverages: Vec<u32> = fetched.iter().map(|market| market.max_leverage).collect();
+    let fresh = df! {
+        "symbol" => symbols,
+        "max_leverage" => max_leverages,
+    }?;
+
+    let Some(existing) = existing else {
+        let mut fresh = fresh;
+        let disable = Series::new("disable".into(), vec![false; fresh.height()]);
+        fresh.with_column(disable)?;
+        return Ok(fresh);
+    };
+
+    let previous_flags = existing
+        .clone()
+        .lazy()
+        .select([col("symbol"), col("disable").alias("previous_disable")]);
+
+    fresh
+        .lazy()
+        .join(
+            previous_flags,
+            [col("symbol")],
+            [col("symbol")],
+            JoinArgs::new(JoinType::Left),
+        )
+        .with_column(
+            col("previous_disable")
+                .fill_null(lit(false))
+                .alias("disable"),
+        )
+        .select([col("symbol"), col("max_leverage"), col("disable")])
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::{DateTime, Utc};
+    use tempfile::TempDir;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use crate::candle::Candle;
+    use crate::funding::FundingRate;
+    use crate::timeframe::Timeframe;
+
+    fn metadata(symbol: &str, max_leverage: u32) -> MarketMetadata {
+        MarketMetadata {
+            symbol: Market::new(symbol.to_string()),
+            max_leverage,
+        }
+    }
+
+    struct StubClient {
+        metadata: Vec<MarketMetadata>,
+    }
+
+    #[async_trait]
+    impl Hyperliquid for StubClient {
+        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
+            Ok(vec![])
+        }
+
+        async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            Ok(self.metadata.clone())
+        }
+
+        async fn fetch_candles(
+            &self,
+            _market: &Market,
+            _timeframe: Timeframe,
+            _start: DateTime<Utc>,
+        ) -> Result<Vec<Candle>, HyperliquidError> {
+            Ok(vec![])
+        }
+
+        async fn fetch_funding_rates(
+            &self,
+            _market: &Market,
+            _start: DateTime<Utc>,
+        ) -> Result<Vec<FundingRate>, HyperliquidError> {
+            Ok(vec![])
+        }
+    }
+
+    fn disable_for(frame: &DataFrame, symbol: &str) -> Option<bool> {
+        let symbols = frame.column("symbol").unwrap().str().unwrap();
+        let disable = frame.column("disable").unwrap().bool().unwrap();
+        (0..symbols.len())
+            .find(|&index| symbols.get(index) == Some(symbol))
+            .and_then(|index| disable.get(index))
+    }
+
+    #[test]
+    fn new_markets_default_to_enabled() {
+        let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
+
+        let frame = build_markets_frame(&fetched, None).unwrap();
+        assert_eq!(frame.height(), 2);
+        assert_eq!(disable_for(&frame, "BTC"), Some(false));
+        assert_eq!(disable_for(&frame, "ETH"), Some(false));
+    }
+
+    #[test]
+    fn refresh_preserves_disable_flag_and_drops_vanished_markets() {
+        let existing = df! {
+            "symbol" => &["BTC", "SOL"],
+            "max_leverage" => &[40_u32, 20],
+            "disable" => &[true, false],
+        }
+        .unwrap();
+        let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
+
+        let frame = build_markets_frame(&fetched, Some(&existing)).unwrap();
+
+        // BTC keeps its operator-set disable flag; ETH is new (enabled); SOL
+        // vanished from the exchange and is dropped.
+        assert_eq!(frame.height(), 2);
+        assert_eq!(disable_for(&frame, "BTC"), Some(true));
+        assert_eq!(disable_for(&frame, "ETH"), Some(false));
+        assert_eq!(disable_for(&frame, "SOL"), None);
+
+        // max leverage is refreshed from the fetched metadata.
+        let symbols = frame.column("symbol").unwrap().str().unwrap();
+        let leverage = frame.column("max_leverage").unwrap().u32().unwrap();
+        let btc_index = (0..symbols.len())
+            .find(|&index| symbols.get(index) == Some("BTC"))
+            .unwrap();
+        assert_eq!(leverage.get(btc_index), Some(50));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn refresh_writes_markets_csv_and_preserves_disable_across_runs() {
+        let data_dir = TempDir::new().unwrap();
+        let client = StubClient {
+            metadata: vec![metadata("BTC", 50), metadata("ETH", 25)],
+        };
+
+        refresh_markets(&client, data_dir.path()).await.unwrap();
+        assert!(data_dir.path().join("markets.csv").exists());
+        assert!(crate::logs_contain_at(
+            Level::INFO,
+            &["markets metadata refreshed"]
+        ));
+
+        // Operator disables BTC by editing the ledger, then a later refresh keeps it.
+        let path = data_dir.path().join(file_name());
+        let edited = crate::dataframe::read_csv(path.clone())
+            .await
+            .unwrap()
+            .unwrap()
+            .lazy()
+            .with_column(col("symbol").eq(lit("BTC")).alias("disable"))
+            .collect()
+            .unwrap();
+        crate::dataframe::write_csv(path, edited).await.unwrap();
+
+        refresh_markets(&client, data_dir.path()).await.unwrap();
+
+        let reloaded = crate::dataframe::read_csv(data_dir.path().join(file_name()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(disable_for(&reloaded, "BTC"), Some(true));
+        assert_eq!(disable_for(&reloaded, "ETH"), Some(false));
+    }
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -21,7 +21,7 @@ async fn mount_meta_mock(server: &MockServer) {
         .and(path("/info"))
         .and(body_partial_json(json!({"type": "meta"})))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "universe": [{"name": "BTC", "szDecimals": 8}]
+            "universe": [{"name": "BTC", "szDecimals": 8, "maxLeverage": 50}]
         })))
         .mount(server)
         .await;


### PR DESCRIPTION
## Motivation

The system needs to know the tradable perp universe and each market's max
leverage, with an operator-controlled `disable` flag that survives across
ingestion runs so disabled markets stay disabled.

## Solution

Add `market_metadata.rs`: fetch each market's `maxLeverage` from Hyperliquid and
persist a `markets.csv` ledger (`symbol`, `max_leverage`, `disable`), preserving
the operator's `disable` flag across refreshes (left-join old flags, new markets
default to enabled). The ledger is refreshed at the start of ingestion.


Closes #275

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276 👈
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->