### PR TITLE
feat: ingest only tradable markets

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,9 @@ of them.
 - [x] Markets metadata + persisted disable flag --
       [#275](https://github.com/data-cartel/moneymentum/issues/275) /
       [#276](https://github.com/data-cartel/moneymentum/pull/276)
-- [ ] Tradable filter wired into ingestion
+- [x] Tradable filter wired into ingestion --
+      [#277](https://github.com/data-cartel/moneymentum/issues/277) /
+      [#278](https://github.com/data-cartel/moneymentum/pull/278)
 
 ---
 

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -56,8 +56,6 @@ pub(crate) enum HyperliquidError {
 /// Enables testing with mock implementations.
 #[async_trait]
 pub(crate) trait Hyperliquid: Send + Sync {
-    async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError>;
-
     async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError>;
 
     async fn fetch_candles(
@@ -101,18 +99,6 @@ impl HyperliquidClient {
 
 #[async_trait]
 impl Hyperliquid for HyperliquidClient {
-    #[instrument(skip(self))]
-    async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-        let meta = self.info.meta().await?;
-        let markets: Vec<Market> = meta
-            .universe
-            .into_iter()
-            .map(|asset| Market::new(asset.name))
-            .collect();
-        debug!(count = markets.len(), "fetched markets");
-        Ok(markets)
-    }
-
     #[instrument(skip(self))]
     async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
         // The SDK's typed `meta()` drops `maxLeverage`, so request the raw `meta`
@@ -287,17 +273,6 @@ impl<H: ?Sized + Hyperliquid> CandleIngester<H> {
         }
     }
 
-    #[instrument(skip(self, data_dir), fields(timeframe = ?timeframe))]
-    pub(crate) async fn ingest(
-        &self,
-        timeframe: Timeframe,
-        data_dir: &Path,
-    ) -> Result<(), HyperliquidError> {
-        let markets = self.client.list_markets().await?;
-        self.ingest_with_markets(timeframe, data_dir, &markets)
-            .await
-    }
-
     #[instrument(skip(self, data_dir, markets), fields(timeframe = ?timeframe))]
     pub(crate) async fn ingest_with_markets(
         &self,
@@ -388,14 +363,8 @@ impl<H: ?Sized + Hyperliquid> FundingRateIngester<H> {
         }
     }
 
-    #[instrument(skip(self, data_dir))]
-    pub(crate) async fn ingest(&self, data_dir: &Path) -> Result<(), HyperliquidError> {
-        let markets = self.client.list_markets().await?;
-        self.ingest_with_markets(data_dir, &markets).await
-    }
-
     #[instrument(skip(self, data_dir, markets))]
-    async fn ingest_with_markets(
+    pub(crate) async fn ingest_with_markets(
         &self,
         data_dir: &Path,
         markets: &[Market],
@@ -479,7 +448,6 @@ mod tests {
     use crate::logs_contain_at;
 
     struct MockHyperliquid {
-        markets: Vec<Market>,
         market_metadata: Vec<MarketMetadata>,
         candles: Vec<Candle>,
         funding_rates: Vec<FundingRate>,
@@ -487,10 +455,13 @@ mod tests {
         fetch_funding_calls: AtomicUsize,
     }
 
+    fn btc_markets() -> Vec<Market> {
+        vec![Market::new("BTC".to_string())]
+    }
+
     impl MockHyperliquid {
         fn new() -> Self {
             Self {
-                markets: vec![Market::new("BTC".to_string())],
                 market_metadata: vec![MarketMetadata {
                     symbol: Market::new("BTC".to_string()),
                     max_leverage: 50,
@@ -524,10 +495,6 @@ mod tests {
 
     #[async_trait]
     impl Hyperliquid for MockHyperliquid {
-        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-            Ok(self.markets.clone())
-        }
-
         async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
             Ok(self.market_metadata.clone())
         }
@@ -560,7 +527,7 @@ mod tests {
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
             .await
             .unwrap();
 
@@ -580,7 +547,7 @@ mod tests {
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
             .await
             .unwrap();
 
@@ -594,7 +561,10 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
 
         let csv_path = data_dir.path().join("funding_rate1h.csv");
         assert!(csv_path.exists(), "CSV file should be created");
@@ -620,7 +590,10 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new().with_empty_data());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
 
         assert!(logs_contain_at(Level::INFO, &["no new funding rates"]));
     }
@@ -628,19 +601,17 @@ mod tests {
     #[tokio::test]
     async fn candle_ingester_fetches_for_each_market() {
         let data_dir = TempDir::new().unwrap();
-        let mock = Arc::new(MockHyperliquid {
-            markets: vec![
-                Market::new("BTC".to_string()),
-                Market::new("ETH".to_string()),
-                Market::new("SOL".to_string()),
-            ],
-            ..MockHyperliquid::new()
-        });
+        let markets = vec![
+            Market::new("BTC".to_string()),
+            Market::new("ETH".to_string()),
+            Market::new("SOL".to_string()),
+        ];
+        let mock = Arc::new(MockHyperliquid::new());
         let call_count = Arc::clone(&mock);
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &markets)
             .await
             .unwrap();
 
@@ -654,17 +625,18 @@ mod tests {
     #[tokio::test]
     async fn funding_ingester_fetches_for_each_market() {
         let data_dir = TempDir::new().unwrap();
-        let mock = Arc::new(MockHyperliquid {
-            markets: vec![
-                Market::new("BTC".to_string()),
-                Market::new("ETH".to_string()),
-            ],
-            ..MockHyperliquid::new()
-        });
+        let markets = vec![
+            Market::new("BTC".to_string()),
+            Market::new("ETH".to_string()),
+        ];
+        let mock = Arc::new(MockHyperliquid::new());
         let call_count = Arc::clone(&mock);
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &markets)
+            .await
+            .unwrap();
 
         assert_eq!(
             call_count.fetch_funding_calls.load(Ordering::Relaxed),
@@ -685,7 +657,9 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = CandleIngester::new(mock, 10);
 
-        let result = ingester.ingest(Timeframe::OneHour, data_dir.path()).await;
+        let result = ingester
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
+            .await;
 
         assert!(
             result.is_ok(),
@@ -702,7 +676,7 @@ mod tests {
         let ingester = CandleIngester::new(mock, 10);
 
         ingester
-            .ingest(Timeframe::OneHour, data_dir.path())
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &btc_markets())
             .await
             .unwrap();
 
@@ -735,7 +709,9 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        let result = ingester.ingest(data_dir.path()).await;
+        let result = ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await;
 
         assert!(
             result.is_ok(),
@@ -751,7 +727,10 @@ mod tests {
         let mock = Arc::new(MockHyperliquid::new());
         let ingester = FundingRateIngester::new(mock, 10);
 
-        ingester.ingest(data_dir.path()).await.unwrap();
+        ingester
+            .ingest_with_markets(data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
 
         let csv_content =
             std::fs::read_to_string(data_dir.path().join("funding_rate1h.csv")).unwrap();

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -97,11 +97,16 @@ async fn ingest_all(
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
     data_dir: &Path,
 ) -> Result<DateTime<Utc>, HyperliquidError> {
-    crate::market_metadata::refresh_markets(client, data_dir).await?;
-    funding_ingester.ingest(data_dir).await?;
+    let markets = crate::market_metadata::refresh_markets(client, data_dir).await?;
+
+    funding_ingester
+        .ingest_with_markets(data_dir, &markets)
+        .await?;
 
     for timeframe in TIMEFRAMES {
-        candle_ingester.ingest(*timeframe, data_dir).await?;
+        candle_ingester
+            .ingest_with_markets(*timeframe, data_dir, &markets)
+            .await?;
     }
 
     Ok(Utc::now())
@@ -332,10 +337,6 @@ mod tests {
 
     #[async_trait]
     impl Hyperliquid for MockHyperliquid {
-        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-            Ok(vec![Market::new("BTC".into())])
-        }
-
         async fn fetch_market_metadata(
             &self,
         ) -> Result<Vec<crate::market_metadata::MarketMetadata>, HyperliquidError> {

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -26,19 +26,44 @@ pub(crate) fn file_name() -> &'static str {
     "markets.csv"
 }
 
-/// Fetches the current markets metadata, merges it with the persisted ledger
-/// (preserving the `disable` flag), and writes `markets.csv`.
+/// Refreshes `markets.csv` from the live exchange and returns the tradable
+/// markets: every fetched market that is not disabled.
+///
+/// Market discovery is driven by the exchange fetch; the ledger only persists
+/// the operator-controlled `disable` flags. Ingestion consumes the returned
+/// list directly, so it never depends on re-reading the CSV.
 pub(crate) async fn refresh_markets(
     client: &dyn Hyperliquid,
     data_dir: &Path,
-) -> Result<(), HyperliquidError> {
+) -> Result<Vec<Market>, HyperliquidError> {
     let fetched = client.fetch_market_metadata().await?;
     let path = data_dir.join(file_name());
     let existing = crate::dataframe::read_csv(path.clone()).await?;
     let frame = build_markets_frame(&fetched, existing.as_ref())?;
+    let tradable = tradable_from_frame(&frame)?;
     crate::dataframe::write_csv(path, frame).await?;
-    info!(markets = fetched.len(), "markets metadata refreshed");
-    Ok(())
+    info!(
+        markets = fetched.len(),
+        tradable = tradable.len(),
+        "markets metadata refreshed"
+    );
+    Ok(tradable)
+}
+
+/// The tradable markets in a freshly built ledger frame: every market whose
+/// `disable` flag is not set.
+fn tradable_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
+    let symbols = frame.column("symbol")?.str()?;
+    let disable = frame.column("disable")?.bool()?;
+    let markets: Vec<Market> = (0..symbols.len())
+        .filter(|&index| disable.get(index) == Some(false))
+        .filter_map(|index| {
+            symbols
+                .get(index)
+                .map(|symbol| Market::new(symbol.to_string()))
+        })
+        .collect();
+    Ok(markets)
 }
 
 /// Builds the markets ledger `DataFrame` (`symbol`, `max_leverage`, `disable`)
@@ -113,10 +138,6 @@ mod tests {
 
     #[async_trait]
     impl Hyperliquid for StubClient {
-        async fn list_markets(&self) -> Result<Vec<Market>, HyperliquidError> {
-            Ok(vec![])
-        }
-
         async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
             Ok(self.metadata.clone())
         }
@@ -193,7 +214,12 @@ mod tests {
             metadata: vec![metadata("BTC", 50), metadata("ETH", 25)],
         };
 
-        refresh_markets(&client, data_dir.path()).await.unwrap();
+        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        assert_eq!(
+            tradable.len(),
+            2,
+            "both markets are tradable on first refresh"
+        );
         assert!(data_dir.path().join("markets.csv").exists());
         assert!(crate::logs_contain_at(
             Level::INFO,
@@ -212,7 +238,12 @@ mod tests {
             .unwrap();
         crate::dataframe::write_csv(path, edited).await.unwrap();
 
-        refresh_markets(&client, data_dir.path()).await.unwrap();
+        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        assert_eq!(
+            tradable.iter().map(Market::as_str).collect::<Vec<_>>(),
+            vec!["ETH"],
+            "BTC is excluded from the tradable set once disabled"
+        );
 
         let reloaded = crate::dataframe::read_csv(data_dir.path().join(file_name()))
             .await
@@ -220,5 +251,65 @@ mod tests {
             .unwrap();
         assert_eq!(disable_for(&reloaded, "BTC"), Some(true));
         assert_eq!(disable_for(&reloaded, "ETH"), Some(false));
+    }
+
+    #[test]
+    fn tradable_from_frame_excludes_disabled_markets() {
+        let frame = df! {
+            "symbol" => &["BTC", "ETH", "SOL"],
+            "max_leverage" => &[50_u32, 25, 20],
+            "disable" => &[false, true, false],
+        }
+        .unwrap();
+
+        let markets = tradable_from_frame(&frame).unwrap();
+        let symbols: Vec<&str> = markets.iter().map(Market::as_str).collect();
+
+        assert_eq!(markets.len(), 2, "the disabled market is excluded");
+        assert!(symbols.contains(&"BTC"));
+        assert!(symbols.contains(&"SOL"));
+        assert!(!symbols.contains(&"ETH"), "ETH is disabled");
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn refresh_discovers_markets_from_the_exchange_not_the_ledger() {
+        let data_dir = TempDir::new().unwrap();
+        // The persisted ledger only knows BTC, which the operator disabled.
+        let existing = df! {
+            "symbol" => &["BTC"],
+            "max_leverage" => &[40_u32],
+            "disable" => &[true],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), existing)
+            .await
+            .unwrap();
+
+        // The exchange now lists BTC, ETH, and SOL.
+        let client = StubClient {
+            metadata: vec![
+                metadata("BTC", 50),
+                metadata("ETH", 25),
+                metadata("SOL", 20),
+            ],
+        };
+
+        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        let symbols: Vec<&str> = tradable.iter().map(Market::as_str).collect();
+
+        // ETH and SOL are discovered from the live fetch even though the ledger
+        // never listed them; BTC stays excluded by its persisted disable flag.
+        assert_eq!(tradable.len(), 2, "newly listed markets are discovered");
+        assert!(symbols.contains(&"ETH"));
+        assert!(symbols.contains(&"SOL"));
+        assert!(
+            !symbols.contains(&"BTC"),
+            "operator-disabled BTC stays excluded"
+        );
+        assert!(crate::logs_contain_at(
+            Level::INFO,
+            &["markets metadata refreshed"]
+        ));
     }
 }


### PR DESCRIPTION
## Motivation

Ingestion should only pull candles and funding for tradable (non-disabled)
markets, not the entire exchange universe.

## Solution

Drive ingestion's market discovery from the live exchange fetch and filter out
disabled markets: `refresh_markets` fetches the universe, merges the persisted
`disable` flags, and returns the tradable subset, which `ingest_all` consumes
directly. The `markets.csv` ledger is only the operator's disable-flag store, not
the discovery source — so a missing/stale ledger can never silently shrink the
ingested universe.


Closes #277

<!-- GitButler Footer Boundary Top -->
---
This is **part 8 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278 👈
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->