### PR TITLE
feat: compare target vs current portfolio

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -178,6 +178,10 @@ Find assets by factor characteristics, stage portfolio changes, and simulate the
 result before sending trades.
 
 - [ ] [Compare Target vs Current Portfolio](./stories/0x01a.compare-target-vs-current-portfolio.md)
+      -- backend compare API shipped
+      ([#279](https://github.com/data-cartel/moneymentum/issues/279) /
+      [#280](https://github.com/data-cartel/moneymentum/pull/280)); frontend
+      portfolio surface pending
 - [ ] [Screen Perps By Factor](./stories/0x01c.screen-perps-by-factor.md) --
       backend rank API shipped
       ([#273](https://github.com/dataclique/moneymentum/issues/273) /

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,10 @@ async fn post_screener(
 #[post("/portfolio/compare", data = "<body>")]
 fn post_portfolio_compare(
     body: Json<portfolio_comparison::PortfolioComparisonRequest>,
-) -> Json<Vec<portfolio_comparison::PositionComparison>> {
-    Json(portfolio_comparison::compare_portfolios(&body.into_inner()))
+) -> Result<Json<Vec<portfolio_comparison::PositionComparison>>, Status> {
+    portfolio_comparison::compare_portfolios(&body.into_inner())
+        .map(Json)
+        .map_err(|_| Status::BadRequest)
 }
 
 #[post("/ingest")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod market_catalog;
 mod market_enablement;
 mod market_metadata;
 mod portfolio;
+mod portfolio_comparison;
 mod readonly_portfolio;
 mod screener;
 mod timeframe;
@@ -191,6 +192,13 @@ async fn post_screener(
             Err(Status::InternalServerError)
         }
     }
+}
+
+#[post("/portfolio/compare", data = "<body>")]
+fn post_portfolio_compare(
+    body: Json<portfolio_comparison::PortfolioComparisonRequest>,
+) -> Json<Vec<portfolio_comparison::PositionComparison>> {
+    Json(portfolio_comparison::compare_portfolios(&body.into_inner()))
 }
 
 #[post("/ingest")]
@@ -909,6 +917,7 @@ pub async fn rocket(
                 post_portfolio_rename,
                 post_portfolio_archive,
                 post_screener,
+                post_portfolio_compare,
                 start_ingestion,
                 get_ingestion_status,
                 post_market_disable,
@@ -966,7 +975,13 @@ mod tests {
         };
         rocket::build().manage(config).mount(
             "/",
-            routes![health, get_candles, get_factors, post_screener],
+            routes![
+                health,
+                get_candles,
+                get_factors,
+                post_screener,
+                post_portfolio_compare
+            ],
         )
     }
 
@@ -1530,6 +1545,38 @@ mod tests {
         assert!(
             rows.iter().all(|row| row.get("missing").is_some()),
             "every ranked row carries a missing flag"
+        );
+    }
+
+    #[test]
+    fn post_portfolio_compare_returns_per_position_deltas() {
+        let data_dir = TempDir::new().unwrap();
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/portfolio/compare")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"target":{"BTC":0.6},"current":{"BTC":0.5},"minTradableChange":0.05}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        let rows: Vec<serde_json::Value> =
+            serde_json::from_str(&body).expect("comparison body is a JSON array");
+        let btc = rows
+            .iter()
+            .find(|row| row.get("symbol").and_then(|s| s.as_str()) == Some("BTC"))
+            .expect("BTC row present");
+        assert_eq!(
+            btc.get("tradable").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert!(
+            (btc.get("delta")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap()
+                - 0.1)
+                .abs()
+                < 1e-9
         );
     }
 

--- a/src/portfolio_comparison.rs
+++ b/src/portfolio_comparison.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tracing::debug;
 
 /// A request to compare target vs current portfolio weights.
@@ -32,9 +33,42 @@ pub(crate) struct PositionComparison {
     tradable: bool,
 }
 
+/// Why a comparison request is rejected before any delta is computed.
+///
+/// JSON parses out-of-range floats (`1e309`) to infinity and serializes
+/// non-finite floats back as `null`, so an unvalidated request silently yields a
+/// corrupt response; a negative threshold marks every position tradable. Both are
+/// caller errors the endpoint must refuse rather than answer.
+#[derive(Debug, Error, PartialEq)]
+pub(crate) enum ComparisonError {
+    #[error("portfolio weights must be finite")]
+    NonFiniteWeight,
+
+    #[error("minimum tradable change must be finite and non-negative")]
+    InvalidThreshold,
+}
+
 /// Compares target vs current weights, one row per symbol present in either side
 /// (sorted by symbol). A position is tradable when `|delta| >= min_tradable_change`.
-pub(crate) fn compare_portfolios(request: &PortfolioComparisonRequest) -> Vec<PositionComparison> {
+///
+/// Rejects non-finite weights and a non-finite or negative threshold so the
+/// response never carries `null` deltas or a degenerate all-tradable result.
+pub(crate) fn compare_portfolios(
+    request: &PortfolioComparisonRequest,
+) -> Result<Vec<PositionComparison>, ComparisonError> {
+    let all_finite = request
+        .target
+        .values()
+        .chain(request.current.values())
+        .all(|weight| weight.is_finite());
+    if !all_finite {
+        return Err(ComparisonError::NonFiniteWeight);
+    }
+
+    if !request.min_tradable_change.is_finite() || request.min_tradable_change < 0.0 {
+        return Err(ComparisonError::InvalidThreshold);
+    }
+
     let mut symbols: Vec<&String> = request
         .target
         .keys()
@@ -65,7 +99,7 @@ pub(crate) fn compare_portfolios(request: &PortfolioComparisonRequest) -> Vec<Po
         positions = comparisons.len(),
         tradable, "portfolio compared"
     );
-    comparisons
+    Ok(comparisons)
 }
 
 #[cfg(test)]
@@ -108,7 +142,8 @@ mod tests {
             &[("BTC", 0.6), ("ETH", 0.4)],
             &[("BTC", 0.5), ("ETH", 0.3)],
             0.05,
-        ));
+        ))
+        .expect("finite weights and a valid threshold");
 
         let btc = row(&comparison, "BTC");
         assert!((btc.target_weight - 0.6).abs() < 1e-12);
@@ -121,7 +156,8 @@ mod tests {
 
     #[test]
     fn marks_sub_threshold_positions_not_tradable() {
-        let comparison = compare_portfolios(&request(&[("BTC", 0.55)], &[("BTC", 0.5)], 0.1));
+        let comparison = compare_portfolios(&request(&[("BTC", 0.55)], &[("BTC", 0.5)], 0.1))
+            .expect("finite weights and a valid threshold");
         assert!(
             !row(&comparison, "BTC").tradable,
             "a 0.05 delta is below the 0.1 threshold"
@@ -132,7 +168,8 @@ mod tests {
     fn includes_symbols_present_on_only_one_side() {
         // SOL is a current position with no target (a full exit); NEW is a target
         // with no current position (a fresh entry).
-        let comparison = compare_portfolios(&request(&[("NEW", 0.3)], &[("SOL", 0.2)], 0.05));
+        let comparison = compare_portfolios(&request(&[("NEW", 0.3)], &[("SOL", 0.2)], 0.05))
+            .expect("finite weights and a valid threshold");
 
         let sol = row(&comparison, "SOL");
         assert!((sol.target_weight - 0.0).abs() < 1e-12);
@@ -151,8 +188,30 @@ mod tests {
             &[("SOL", 0.3), ("BTC", 0.4), ("ETH", 0.3)],
             &[],
             0.0,
-        ));
+        ))
+        .expect("finite weights and a valid threshold");
         let symbols: Vec<&str> = comparison.iter().map(|row| row.symbol.as_str()).collect();
         assert_eq!(symbols, ["BTC", "ETH", "SOL"]);
+    }
+
+    #[test]
+    fn rejects_non_finite_weight() {
+        let infinite = compare_portfolios(&request(&[("BTC", f64::INFINITY)], &[], 0.05));
+        assert_eq!(infinite, Err(ComparisonError::NonFiniteWeight));
+
+        let not_a_number = compare_portfolios(&request(&[], &[("ETH", f64::NAN)], 0.05));
+        assert_eq!(not_a_number, Err(ComparisonError::NonFiniteWeight));
+    }
+
+    #[test]
+    fn rejects_negative_threshold() {
+        let comparison = compare_portfolios(&request(&[("BTC", 0.5)], &[("BTC", 0.5)], -0.05));
+        assert_eq!(comparison, Err(ComparisonError::InvalidThreshold));
+    }
+
+    #[test]
+    fn rejects_non_finite_threshold() {
+        let comparison = compare_portfolios(&request(&[("BTC", 0.5)], &[("BTC", 0.4)], f64::NAN));
+        assert_eq!(comparison, Err(ComparisonError::InvalidThreshold));
     }
 }

--- a/src/portfolio_comparison.rs
+++ b/src/portfolio_comparison.rs
@@ -1,0 +1,158 @@
+//! Compare a target portfolio against the current one: per-position weight
+//! deltas, with positions below the minimum tradable change marked so the UI
+//! and the staged trades agree on what counts as tradable.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// A request to compare target vs current portfolio weights.
+///
+/// Weights are signed proportions (negative for shorts); a symbol absent from a
+/// side has weight 0 there. `min_tradable_change` is the minimum absolute weight
+/// delta for a position to count as tradable, sourced from the caller's single
+/// `portfolio.minTradableChange` config so the preview and the rebalance agree.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PortfolioComparisonRequest {
+    target: HashMap<String, f64>,
+    current: HashMap<String, f64>,
+    min_tradable_change: f64,
+}
+
+/// One position's target vs current comparison.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PositionComparison {
+    symbol: String,
+    target_weight: f64,
+    current_weight: f64,
+    delta: f64,
+    tradable: bool,
+}
+
+/// Compares target vs current weights, one row per symbol present in either side
+/// (sorted by symbol). A position is tradable when `|delta| >= min_tradable_change`.
+pub(crate) fn compare_portfolios(request: &PortfolioComparisonRequest) -> Vec<PositionComparison> {
+    let mut symbols: Vec<&String> = request
+        .target
+        .keys()
+        .chain(request.current.keys())
+        .collect();
+    symbols.sort_unstable();
+    symbols.dedup();
+
+    let comparisons: Vec<PositionComparison> = symbols
+        .into_iter()
+        .map(|symbol| {
+            // A symbol absent from a side has zero weight there (no position).
+            let target_weight = request.target.get(symbol).copied().unwrap_or(0.0);
+            let current_weight = request.current.get(symbol).copied().unwrap_or(0.0);
+            let delta = target_weight - current_weight;
+            PositionComparison {
+                symbol: symbol.clone(),
+                target_weight,
+                current_weight,
+                delta,
+                tradable: delta.abs() >= request.min_tradable_change,
+            }
+        })
+        .collect();
+
+    let tradable = comparisons.iter().filter(|row| row.tradable).count();
+    debug!(
+        positions = comparisons.len(),
+        tradable, "portfolio compared"
+    );
+    comparisons
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use crate::logs_contain_at;
+
+    fn request(
+        target: &[(&str, f64)],
+        current: &[(&str, f64)],
+        min_tradable_change: f64,
+    ) -> PortfolioComparisonRequest {
+        PortfolioComparisonRequest {
+            target: target
+                .iter()
+                .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+                .collect(),
+            current: current
+                .iter()
+                .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+                .collect(),
+            min_tradable_change,
+        }
+    }
+
+    fn row<'a>(comparisons: &'a [PositionComparison], symbol: &str) -> &'a PositionComparison {
+        comparisons
+            .iter()
+            .find(|row| row.symbol == symbol)
+            .expect("symbol present")
+    }
+
+    #[traced_test]
+    #[test]
+    fn computes_delta_and_tradability_per_position() {
+        let comparison = compare_portfolios(&request(
+            &[("BTC", 0.6), ("ETH", 0.4)],
+            &[("BTC", 0.5), ("ETH", 0.3)],
+            0.05,
+        ));
+
+        let btc = row(&comparison, "BTC");
+        assert!((btc.target_weight - 0.6).abs() < 1e-12);
+        assert!((btc.current_weight - 0.5).abs() < 1e-12);
+        assert!((btc.delta - 0.1).abs() < 1e-12);
+        assert!(btc.tradable, "0.1 delta exceeds the 0.05 threshold");
+
+        assert!(logs_contain_at(Level::DEBUG, &["portfolio compared"]));
+    }
+
+    #[test]
+    fn marks_sub_threshold_positions_not_tradable() {
+        let comparison = compare_portfolios(&request(&[("BTC", 0.55)], &[("BTC", 0.5)], 0.1));
+        assert!(
+            !row(&comparison, "BTC").tradable,
+            "a 0.05 delta is below the 0.1 threshold"
+        );
+    }
+
+    #[test]
+    fn includes_symbols_present_on_only_one_side() {
+        // SOL is a current position with no target (a full exit); NEW is a target
+        // with no current position (a fresh entry).
+        let comparison = compare_portfolios(&request(&[("NEW", 0.3)], &[("SOL", 0.2)], 0.05));
+
+        let sol = row(&comparison, "SOL");
+        assert!((sol.target_weight - 0.0).abs() < 1e-12);
+        assert!((sol.delta - (-0.2)).abs() < 1e-12);
+        assert!(sol.tradable);
+
+        let new = row(&comparison, "NEW");
+        assert!((new.current_weight - 0.0).abs() < 1e-12);
+        assert!((new.delta - 0.3).abs() < 1e-12);
+        assert!(new.tradable);
+    }
+
+    #[test]
+    fn rows_are_sorted_by_symbol() {
+        let comparison = compare_portfolios(&request(
+            &[("SOL", 0.3), ("BTC", 0.4), ("ETH", 0.3)],
+            &[],
+            0.0,
+        ));
+        let symbols: Vec<&str> = comparison.iter().map(|row| row.symbol.as_str()).collect();
+        assert_eq!(symbols, ["BTC", "ETH", "SOL"]);
+    }
+}

--- a/stories/0x01a.compare-target-vs-current-portfolio.md
+++ b/stories/0x01a.compare-target-vs-current-portfolio.md
@@ -10,6 +10,11 @@ when I do.
 
 ## Acceptance Criteria
 
+The backend `POST /portfolio/compare` API
+([#280](https://github.com/data-cartel/moneymentum/pull/280)) supplies the
+per-position target/current/delta data and the tradable flag these criteria
+render; the criteria themselves are the frontend portfolio surface.
+
 - [ ] The portfolio surface labels target and current allocations distinctly.
 - [ ] Each position row shows target weight, current weight, and the delta.
 - [ ] Positions whose delta is below the minimum tradable change are visibly


### PR DESCRIPTION
## Motivation

When staging a rebalance, users need to see the delta between their target
portfolio and their current one, ignoring changes too small to be worth trading
(story 0x01a).

## Solution

Add `POST /portfolio/compare`: takes target and current weights and returns the
per-asset deltas, dropping changes below a `minTradableChange` threshold.


Closes #279

<!-- GitButler Footer Boundary Top -->
---
This is **part 9 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280 👈
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a portfolio comparison endpoint that returns per-position target, current, delta, and tradable information.
  * Comparison results now handle symbols present on only one side and are returned in a consistent order.

* **Bug Fixes**
  * Invalid or non-finite comparison inputs now return a clear bad-request response.

* **Documentation**
  * Updated the roadmap and acceptance criteria to reflect the backend compare API status and expected portfolio comparison output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->