### PR TITLE
feat: project staged portfolio metrics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,6 +188,10 @@ result before sending trades.
       [#274](https://github.com/dataclique/moneymentum/pull/274)); frontend
       filter integration pending
 - [ ] [Simulate Staged Portfolio Metrics](./stories/0x01d.simulate-staged-portfolio-metrics.md)
+      -- backend simulate API shipped
+      ([#281](https://github.com/data-cartel/moneymentum/issues/281) /
+      [#282](https://github.com/data-cartel/moneymentum/pull/282)); frontend
+      staging view pending
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod portfolio;
 mod portfolio_comparison;
 mod readonly_portfolio;
 mod screener;
+mod simulation;
 mod timeframe;
 mod venue;
 
@@ -201,6 +202,21 @@ fn post_portfolio_compare(
     portfolio_comparison::compare_portfolios(&body.into_inner())
         .map(Json)
         .map_err(|_| Status::BadRequest)
+}
+
+#[post("/portfolio/simulate", data = "<body>")]
+async fn post_portfolio_simulate(
+    config: &State<Config>,
+    body: Json<simulation::SimulationRequest>,
+) -> Result<Json<simulation::SimulationResponse>, Status> {
+    match simulation::simulate(&config.data_dir, &body).await {
+        Ok(response) => Ok(Json(response)),
+        Err(factors::ReturnsError::NoData { .. }) => Err(Status::NotFound),
+        Err(err) => {
+            error!(error = %err, "failed to simulate portfolio");
+            Err(Status::InternalServerError)
+        }
+    }
 }
 
 #[post("/ingest")]
@@ -920,6 +936,7 @@ pub async fn rocket(
                 post_portfolio_archive,
                 post_screener,
                 post_portfolio_compare,
+                post_portfolio_simulate,
                 start_ingestion,
                 get_ingestion_status,
                 post_market_disable,
@@ -982,7 +999,8 @@ mod tests {
                 get_candles,
                 get_factors,
                 post_screener,
-                post_portfolio_compare
+                post_portfolio_compare,
+                post_portfolio_simulate
             ],
         )
     }
@@ -1580,6 +1598,44 @@ mod tests {
                 .abs()
                 < 1e-9
         );
+    }
+
+    #[test]
+    fn post_portfolio_simulate_returns_404_when_no_data() {
+        let data_dir = TempDir::new().unwrap();
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/portfolio/simulate")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"current":{"BTC":1.0},"staged":{"BTC":1.0}}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[test]
+    fn post_portfolio_simulate_projects_current_and_staged_beta() {
+        let data_dir = TempDir::new().unwrap();
+        std::fs::copy(
+            std::path::Path::new("fixtures/ohlcv_1d_beta.csv"),
+            data_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let client = Client::tracked(test_rocket(data_dir.path())).unwrap();
+        let response = client
+            .post("/portfolio/simulate")
+            .header(rocket::http::ContentType::JSON)
+            .body(r#"{"current":{"BTC":1.0},"staged":{"BTC":0.6,"ETH":-0.4}}"#)
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().unwrap()).unwrap();
+        let current = body["current"]["beta"].as_f64().unwrap();
+        let staged = body["staged"]["beta"].as_f64().unwrap();
+        assert!((current - 1.0).abs() < 1e-10);
+        assert!((staged - 0.592_091_722_3).abs() < 1e-10);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,6 +814,44 @@ fn spawn_ingestion_scheduler(
     });
 }
 
+struct EventSourcedStores {
+    portfolio_store: Arc<Store<Portfolio>>,
+    portfolio_projection: Arc<Projection<Portfolio>>,
+    ingestion_store: Arc<Store<IngestionRun>>,
+    ingestion_projection: Arc<Projection<IngestionRun>>,
+    market_catalog: Arc<Store<MarketCatalog>>,
+    market_catalog_projection: Arc<Projection<MarketCatalog>>,
+    market_enablement: Arc<Store<MarketEnablement>>,
+    market_enablement_projection: Arc<Projection<MarketEnablement>>,
+}
+
+async fn build_event_sourced_stores(
+    pool: SqlitePool,
+) -> Result<EventSourcedStores, Box<dyn std::error::Error + Send + Sync>> {
+    let (portfolio_store, portfolio_projection) =
+        StoreBuilder::<Portfolio>::new(pool.clone()).build().await?;
+    let (ingestion_store, ingestion_projection) = StoreBuilder::<IngestionRun>::new(pool.clone())
+        .build()
+        .await?;
+    let (market_catalog, market_catalog_projection) =
+        StoreBuilder::<MarketCatalog>::new(pool.clone())
+            .build()
+            .await?;
+    let (market_enablement, market_enablement_projection) =
+        StoreBuilder::<MarketEnablement>::new(pool).build().await?;
+    debug!("event-sourced stores ready");
+    Ok(EventSourcedStores {
+        portfolio_store,
+        portfolio_projection,
+        ingestion_store,
+        ingestion_projection,
+        market_catalog,
+        market_catalog_projection,
+        market_enablement,
+        market_enablement_projection,
+    })
+}
+
 /// Build and configure the Rocket HTTP server for the moneymentum backend.
 ///
 /// # Errors
@@ -848,23 +886,16 @@ pub async fn rocket(
     migrations.set_ignore_missing(true).run(&pool).await?;
     debug!(count = migrations.iter().count(), "migrations applied");
 
-    // One Store + Projection per event-sourced aggregate, built once here and
-    // shared via Rocket state. `build()` reconciles the schema registry (clearing
-    // stale snapshots on a SCHEMA_VERSION bump) and auto-wires the projection.
-    let (portfolio_store, portfolio_projection) =
-        StoreBuilder::<Portfolio>::new(pool.clone()).build().await?;
-    let (ingestion_store, ingestion_projection) = StoreBuilder::<IngestionRun>::new(pool.clone())
-        .build()
-        .await?;
-    let (market_catalog, market_catalog_projection) =
-        StoreBuilder::<MarketCatalog>::new(pool.clone())
-            .build()
-            .await?;
-    let (market_enablement, market_enablement_projection) =
-        StoreBuilder::<MarketEnablement>::new(pool.clone())
-            .build()
-            .await?;
-    debug!("event-sourced stores ready");
+    let EventSourcedStores {
+        portfolio_store,
+        portfolio_projection,
+        ingestion_store,
+        ingestion_projection,
+        market_catalog,
+        market_catalog_projection,
+        market_enablement,
+        market_enablement_projection,
+    } = build_event_sourced_stores(pool.clone()).await?;
 
     // Abandon any run left Running by a crash before we accept /ingest, so the
     // one-running slot can never stay wedged across a restart (issue #339).

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,0 +1,128 @@
+//! Forward simulation: project portfolio metrics for a staged set of weights so
+//! users can see a rebalance's impact before sending any trades.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument};
+
+use crate::factors::{ReturnsError, compute_portfolio_beta_report};
+use crate::finance::Symbol;
+
+/// Benchmark for projected portfolio beta. Bitcoin beta is the SPEC's core risk
+/// metric, so simulations always project beta to BTC.
+const BENCHMARK_TICKER: &str = "BTC";
+
+/// A request to project metrics for the current and staged portfolios.
+///
+/// Weights are signed proportions (negative for shorts).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SimulationRequest {
+    current: HashMap<String, f64>,
+    staged: HashMap<String, f64>,
+}
+
+/// Projected metrics for one portfolio. Extended as the risk engine lands.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProjectedMetrics {
+    /// Portfolio beta to Bitcoin; null when there is insufficient return data.
+    beta: Option<f64>,
+}
+
+/// Current and staged projections, side by side for direct comparison.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SimulationResponse {
+    current: ProjectedMetrics,
+    staged: ProjectedMetrics,
+}
+
+/// Projects metrics for the current and staged portfolios.
+#[instrument(skip_all, fields(data_dir = %data_dir.display()))]
+pub(crate) async fn simulate(
+    data_dir: &Path,
+    request: &SimulationRequest,
+) -> Result<SimulationResponse, ReturnsError> {
+    let current = project_metrics(data_dir, &request.current).await?;
+    let staged = project_metrics(data_dir, &request.staged).await?;
+    debug!(
+        current_beta = ?current.beta,
+        staged_beta = ?staged.beta,
+        "portfolio simulated"
+    );
+    Ok(SimulationResponse { current, staged })
+}
+
+/// Projects metrics for a single set of weights.
+async fn project_metrics(
+    data_dir: &Path,
+    weights: &HashMap<String, f64>,
+) -> Result<ProjectedMetrics, ReturnsError> {
+    let weights: Vec<(Symbol, f64)> = weights
+        .iter()
+        .map(|(symbol, weight)| (Symbol::from_raw(symbol), *weight))
+        .collect();
+    let beta =
+        compute_portfolio_beta_report(data_dir, &weights, &Symbol::from_raw(BENCHMARK_TICKER))
+            .await?
+            .beta;
+
+    Ok(ProjectedMetrics { beta })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use crate::logs_contain_at;
+
+    fn weights(entries: &[(&str, f64)]) -> HashMap<String, f64> {
+        entries
+            .iter()
+            .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+            .collect()
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn projects_current_and_staged_beta_side_by_side() {
+        let data_dir = TempDir::new().unwrap();
+        fs::copy(
+            "fixtures/ohlcv_1d_beta.csv",
+            data_dir.path().join("ohlcv_1d.csv"),
+        )
+        .unwrap();
+
+        let request = SimulationRequest {
+            current: weights(&[("BTC", 1.0)]),
+            staged: weights(&[("BTC", 0.6), ("ETH", -0.4)]),
+        };
+
+        let response = simulate(data_dir.path(), &request).await.unwrap();
+
+        // A pure-BTC portfolio has beta 1 to BTC; the staged 60/-40 portfolio
+        // matches the POST /beta regression value.
+        assert!((response.current.beta.unwrap() - 1.0).abs() < 1e-10);
+        assert!((response.staged.beta.unwrap() - 0.592_091_722_3).abs() < 1e-10);
+        assert!(logs_contain_at(Level::DEBUG, &["portfolio simulated"]));
+    }
+
+    #[tokio::test]
+    async fn errors_when_no_candle_data() {
+        let data_dir = TempDir::new().unwrap();
+        let request = SimulationRequest {
+            current: weights(&[("BTC", 1.0)]),
+            staged: weights(&[("BTC", 1.0)]),
+        };
+
+        let result = simulate(data_dir.path(), &request).await;
+        assert!(matches!(result, Err(ReturnsError::NoData { .. })));
+    }
+}

--- a/stories/0x01d.simulate-staged-portfolio-metrics.md
+++ b/stories/0x01d.simulate-staged-portfolio-metrics.md
@@ -10,6 +10,12 @@ send any trades.
 
 ## Acceptance Criteria
 
+The backend `POST /portfolio/simulate` API
+([#282](https://github.com/data-cartel/moneymentum/pull/282)) projects the
+staged portfolio's beta to Bitcoin alongside the current portfolio; further
+projected risk metrics arrive with the risk engine. The criteria themselves are
+the frontend staging view.
+
 - [ ] Staging a position change projects the post-change portfolio weights.
 - [ ] Staging projects the post-change beta to Bitcoin.
 - [ ] Staging projects the post-change risk metrics where they are available.


### PR DESCRIPTION
## Motivation

Before committing a staged rebalance, users need to see the staged portfolio's
projected metrics side-by-side with their current portfolio (story 0x01d).

## Solution

Add `POST /portfolio/simulate` that projects the staged portfolio's beta
(weighting per-asset betas) alongside the current portfolio's, so the two can be
compared before staging.


Closes #281

<!-- GitButler Footer Boundary Top -->
---
This is **part 10 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282 👈
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added POST endpoint for portfolio simulation that projects risk metrics, including beta, for both current and staged portfolios.

* **Documentation**
  * Updated roadmap and acceptance criteria documenting the shipped backend simulation API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->