### PR TITLE
chore: use standard BUSL-1.1 with the correct licensor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,13 +2,24 @@ Business Source License 1.1
 
 Parameters
 
-Licensor: Data Cartel
-Licensed Work: The Licensed Work is (c) 2026 Data Cartel.
-Change Date: Four years from the date of first publication
-Change License: GNU General Public License v2.0 or later
+Licensor:             Data Clique Software Design FZCO
+Licensed Work:        Moneymentum
+                      The Licensed Work is (c) 2026 Data Clique Software
+                      Design FZCO.
 Additional Use Grant: None
+Change Date:          Two years from the date of first publication of a
+                      given version of the Licensed Work
+Change License:       GNU General Public License v2.0 or later
 
-For information regarding commercial licensing, please contact Data Cartel.
+For information regarding commercial licensing, please contact
+Data Clique Software Design FZCO.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+License text copyright © 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
 Terms
 
@@ -34,38 +45,45 @@ separately for each version of the Licensed Work and the Change Date may vary
 for each version of the Licensed Work released by Licensor.
 
 You must conspicuously display this License on each original or modified copy
-of the Licensed Work. If you receive the Licensed Work in original form from
-the Licensor, the Licensed Work may be distributed under the terms of this
-License directly.
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
 
-If you receive the Licensed Work in modified form from any other entity
-(the "Modified Work"), you may distribute the Modified Work under the terms
-of this License (as the original Licensor), provided that you include clear
-notices that you have modified the Licensed Work.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-Restrictions
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-You may not offer the Licensed Work to third parties on a hosted or embedded
-basis which is competitive with Licensor's provision of the Licensed Work. If
-you breach this restriction, your rights will be immediately terminated.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
 
-You may only offer the Licensed Work to third parties on a hosted or embedded
-basis pursuant to an Additional Use Grant, if one is provided by Licensor.
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark “Business Source License”,
+as long as you comply with the Covenants of Licensor below.
 
-Disclaimer
+Covenants of Licensor
 
-THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS
-ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT
-LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-NON-INFRINGEMENT, AND TITLE.
+In consideration of the right to use this License’s text and the “Business
+Source License” name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-Licensor will not be liable for any damages suffered by you as a result of
-using, modifying or distributing the Licensed Work or its derivatives.
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where “compatible” means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
 
-Termination
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text “None”.
 
-If you violate the terms of this License, all your rights granted hereunder
-will terminate immediately.
+3. To specify a Change Date.
 
-License text copyright © 2017 MariaDB Corporation Ab.
-"Business Source License" is a trademark of MariaDB Corporation Ab.
+4. Not to modify this License in any other way.


### PR DESCRIPTION
## Motivation

The LICENSE was a *modified* BUSL-1.1: it added a custom "Restrictions" section
and reworded several clauses, which the BUSL covenant explicitly forbids ("do not
modify this License in any other way") -- so it was not a valid Business Source
License. It also named the Licensor as "Data Cartel", which is only the GitHub
org name, not the real legal entity.

## Solution

Replace it with the unmodified canonical BUSL-1.1 text (fetched verbatim via the
`reuse` tool, not regenerated), with the correct parameters:

- Licensor: Data Clique Software Design FZCO (the legal entity).
- Change Date: two years from each version's first publication -- a rolling
  per-version head start (the canonical text's four-year anniversary still caps
  it as the outer bound).
- Change License: GPL v2.0 or later.
- Additional Use Grant: None.

Until the Change Date, the Licensed Work is source-available, non-production use
only; after it, each version converts to GPL.

## Note on the license-text copyright (MariaDB)

The BUSL-1.1 text is (c) 2017 MariaDB Corporation Ab and "Business Source
License" is a MariaDB trademark. MariaDB grants the right to use the text and the
trademark **provided the licensor honors the BUSL "Covenants of Licensor"** --
which this LICENSE does, so there is nothing blocking:

- Change License is GPL v2.0 or later (GPL-compatible) -- Covenant 1.
- Additional Use Grant is "None" -- Covenant 2.
- A Change Date is specified -- Covenant 3.
- The license text is unmodified; only the Parameters block is filled in --
  Covenant 4.

MariaDB's copyright and trademark notice is retained verbatim in the LICENSE.

Not legal advice -- worth a counsel sign-off for a fund handling real money. One
nuance to confirm with counsel: the Change Date is expressed as a per-version
relative date ("two years from that version's first publication") rather than a
fixed calendar date.


Closes #299

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 1 in a stack** made with GitButler:
- <kbd>&nbsp;1&nbsp;</kbd> #293 👈
<!-- GitButler Footer Boundary Bottom -->
