### PR TITLE
feat: report the Ledoit-Wolf shrunk correlation matrix on the risk endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2421,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,6 +3442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,6 +3529,7 @@ dependencies = [
  "event-sorcery",
  "futures",
  "hyperliquid_rust_sdk",
+ "nalgebra",
  "polars",
  "proptest",
  "reqwest 0.13.4",
@@ -3524,6 +3568,37 @@ dependencies = [
  "tokio",
  "tokio-util",
  "version_check",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+dependencies = [
+ "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3594,6 +3669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,6 +3699,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -4964,6 +5059,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,6 +5732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5975,6 +6085,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simba"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "wide",
 ]
 
 [[package]]
@@ -7692,6 +7814,16 @@ name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8418,15 +8418,18 @@ dependencies = [
  "alloy-primitives",
  "async-trait",
  "hex",
+ "serde_json",
  "solana-pubkey",
  "solana-signature",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-test",
  "turnkey_api_key_stamper",
  "turnkey_client",
  "uuid 1.23.3",
  "wallet",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7915,8 +7915,10 @@ dependencies = [
  "solana-signature",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "turnkey_api_key_stamper",
  "turnkey_client",
+ "uuid 1.23.3",
  "wallet",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "apalis"
 version = "1.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1347,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2136,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "five8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_const"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +2897,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3003,6 +3068,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3887,6 +3958,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,6 +4036,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-slash"
@@ -4762,6 +4851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,6 +4921,38 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5275,6 +5405,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5989,6 +6120,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6214,6 +6373,71 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "solana-address"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
+dependencies = [
+ "borsh",
+ "five8",
+ "five8_const",
+ "serde",
+ "solana-atomic-u64",
+ "solana-define-syscall",
+ "solana-program-error",
+ "solana-sanitize",
+ "wincode",
+]
+
+[[package]]
+name = "solana-atomic-u64"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
+
+[[package]]
+name = "solana-pubkey"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
+dependencies = [
+ "solana-address",
+]
+
+[[package]]
+name = "solana-sanitize"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
+
+[[package]]
+name = "solana-signature"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0364c7577c3c82a693ce28a1febc8d1b5d1b0a175fdc2114ae6186b69effe1e"
+dependencies = [
+ "five8",
+ "serde",
+ "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
@@ -7414,6 +7638,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "turnkey_api_key_stamper"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f72e05a07cb04163efff0c766521ebacbb268a851db83d419b7c56df90d046"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "k256",
+ "p256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "turnkey_client"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f216ea270ec4a37daa491679b716962cda7819cac982b49088979b2edf6067df"
+dependencies = [
+ "mime",
+ "prost",
+ "prost-types",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "turnkey_api_key_stamper",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7648,6 +7906,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wallet"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "hex",
+ "solana-pubkey",
+ "solana-signature",
+ "thiserror 2.0.18",
+ "tokio",
+ "turnkey_api_key_stamper",
+ "turnkey_client",
+ "wallet",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7855,6 +8128,31 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-primitives"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.1.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.4",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "secp256k1 0.31.1",
+ "serde",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +305,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "array-init-cursor"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +583,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -568,7 +795,7 @@ dependencies = [
  "bitcoin_hashes",
  "hex-conservative",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.29.1",
 ]
 
 [[package]]
@@ -828,7 +1055,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1015,7 +1242,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -1120,6 +1347,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1428,12 +1664,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -1445,6 +1701,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.118",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1478,6 +1748,15 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1598,6 +1877,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,8 +1948,28 @@ dependencies = [
  "rand 0.8.6",
  "rlp",
  "serde",
- "sha3",
+ "sha3 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1728,7 +2039,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "thiserror 1.0.69",
  "uuid 0.8.2",
 ]
@@ -1745,7 +2056,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.9",
  "thiserror 1.0.69",
  "uint",
 ]
@@ -1907,7 +2218,7 @@ dependencies = [
  "chrono",
  "ethers-core",
  "reqwest 0.11.27",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2016,7 +2327,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "solang-parser",
@@ -2104,6 +2415,28 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "ff"
@@ -2635,6 +2968,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashers"
@@ -3201,9 +3537,27 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3248,7 +3602,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "simd_cesu8",
  "syn 2.0.118",
 ]
@@ -3339,6 +3693,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -4038,6 +4412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,6 +4499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,7 +4525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -5180,6 +5570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5671,6 +6070,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.6",
+ "rand 0.9.4",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5711,11 +6144,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5896,7 +6338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -5983,7 +6425,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -5991,6 +6444,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -6020,12 +6482,30 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -6198,7 +6678,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -6287,7 +6787,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
  "simdutf8",
 ]
 
@@ -7018,7 +7518,7 @@ dependencies = [
  "hex",
  "once_cell",
  "reqwest 0.11.27",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -7687,6 +8187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7909,6 +8415,7 @@ dependencies = [
 name = "wallet"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "hex",
  "solana-pubkey",
@@ -8540,7 +9047,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.1",
  "send_wrapper",
  "thiserror 2.0.18",
  "wasm-bindgen",
@@ -8647,6 +9154,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ cron = "=0.16.0"
 event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery", tag = "0.2.0-rc2", version = "0.1.0" }
 futures = "0.3.31"
 hyperliquid_rust_sdk = "0.6.0"
+nalgebra = "0.35.0"
 polars = { version = "0.51", features = [
   "parquet",
   "lazy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,32 @@
+[workspace]
+members = [".", "crates/*"]
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+# Zero tolerance for panics in non-test code
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unreachable = "deny"
+unimplemented = "deny"
+indexing_slicing = "deny"
+
+enum_glob_use = "deny"
+
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+
+doc_markdown = "allow"
+items_after_statements = "allow"
+missing_const_for_fn = "allow"
+missing_docs_in_private_items = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+must_use_candidate = "allow"
+redundant_pub_crate = "allow"
+
 [package]
 name = "moneymentum"
 version = "0.1.0"
@@ -48,31 +77,8 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.3", features = ["v4", "serde"] }
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-# Zero tolerance for panics in non-test code
-unwrap_used = "deny"
-expect_used = "deny"
-panic = "deny"
-unreachable = "deny"
-unimplemented = "deny"
-indexing_slicing = "deny"
-
-enum_glob_use = "deny"
-
-pedantic = { level = "deny", priority = -1 }
-nursery = { level = "deny", priority = -1 }
-
-doc_markdown = "allow"
-items_after_statements = "allow"
-missing_const_for_fn = "allow"
-missing_docs_in_private_items = "allow"
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-must_use_candidate = "allow"
-redundant_pub_crate = "allow"
+[lints]
+workspace = true
 
 [dev-dependencies]
 event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery", tag = "0.2.0-rc2", features = [

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,6 +117,9 @@ of them.
 - [x] Risk metrics: historical max drawdown --
       [#345](https://github.com/dataclique/moneymentum/issues/345) /
       [#346](https://github.com/dataclique/moneymentum/pull/346)
+- [x] Risk metrics: Ledoit-Wolf shrunk correlation matrix --
+      [#347](https://github.com/dataclique/moneymentum/issues/347) /
+      [#348](https://github.com/dataclique/moneymentum/pull/348)
 
 ---
 
@@ -220,8 +223,11 @@ Portfolio risk assessment beyond beta and crash-specific simulations.
       [#344](https://github.com/data-cartel/moneymentum/pull/344)); historical
       max drawdown shipped
       ([#345](https://github.com/data-cartel/moneymentum/issues/345) /
-      [#346](https://github.com/data-cartel/moneymentum/pull/346)); correlation,
-      ENB, Monte Carlo metrics and the frontend pending
+      [#346](https://github.com/data-cartel/moneymentum/pull/346)); shrunk
+      correlation matrix shipped
+      ([#347](https://github.com/data-cartel/moneymentum/issues/347) /
+      [#348](https://github.com/data-cartel/moneymentum/pull/348)); ENB, Monte
+      Carlo metrics and the frontend pending
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,6 +120,9 @@ of them.
 - [x] Risk metrics: Ledoit-Wolf shrunk correlation matrix --
       [#347](https://github.com/dataclique/moneymentum/issues/347) /
       [#348](https://github.com/dataclique/moneymentum/pull/348)
+- [x] Risk metrics: effective number of bets (Meucci + stressed + 1/HHI) --
+      [#349](https://github.com/dataclique/moneymentum/issues/349) /
+      [#350](https://github.com/dataclique/moneymentum/pull/350)
 
 ---
 
@@ -226,8 +229,11 @@ Portfolio risk assessment beyond beta and crash-specific simulations.
       [#346](https://github.com/data-cartel/moneymentum/pull/346)); shrunk
       correlation matrix shipped
       ([#347](https://github.com/data-cartel/moneymentum/issues/347) /
-      [#348](https://github.com/data-cartel/moneymentum/pull/348)); ENB, Monte
-      Carlo metrics and the frontend pending
+      [#348](https://github.com/data-cartel/moneymentum/pull/348)); effective
+      number of bets shipped
+      ([#349](https://github.com/data-cartel/moneymentum/issues/349) /
+      [#350](https://github.com/data-cartel/moneymentum/pull/350)); Monte Carlo
+      metrics and the frontend pending
 
 ---
 

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -32,6 +32,9 @@ alloy-primitives = { version = "1.5.7", optional = true }
 [dev-dependencies]
 wallet = { path = ".", features = ["mock", "turnkey"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+wiremock = "0.6.5"
+tracing-test = "0.2.6"
+serde_json = "1.0.150"
 
 [lints]
 workspace = true

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "wallet"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+mock = []
+turnkey = [
+  "dep:turnkey_client",
+  "dep:turnkey_api_key_stamper",
+  "dep:hex",
+  "dep:solana-pubkey",
+  "dep:solana-signature",
+]
+
+[dependencies]
+async-trait = "0.1"
+thiserror = "2"
+
+turnkey_client = { version = "0.6.0", optional = true }
+turnkey_api_key_stamper = { version = "0.6.0", optional = true }
+hex = { version = "0.4", optional = true }
+solana-pubkey = { version = "4.2.0", optional = true }
+solana-signature = { version = "3.4.1", optional = true }
+
+[dev-dependencies]
+wallet = { path = ".", features = ["mock", "turnkey"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -11,6 +11,8 @@ turnkey = [
   "dep:hex",
   "dep:solana-pubkey",
   "dep:solana-signature",
+  "dep:uuid",
+  "dep:tracing",
 ]
 
 [dependencies]
@@ -22,6 +24,8 @@ turnkey_api_key_stamper = { version = "0.6.0", optional = true }
 hex = { version = "0.4", optional = true }
 solana-pubkey = { version = "4.2.0", optional = true }
 solana-signature = { version = "3.4.1", optional = true }
+uuid = { version = "1.23.2", default-features = false, optional = true }
+tracing = { version = "0.1.44", optional = true }
 
 [dev-dependencies]
 wallet = { path = ".", features = ["mock", "turnkey"] }

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -33,7 +33,7 @@ alloy-primitives = { version = "1.5.7", optional = true }
 wallet = { path = ".", features = ["mock", "turnkey"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 wiremock = "0.6.5"
-tracing-test = "0.2.6"
+tracing-test = "0.2.5"
 serde_json = "1.0.150"
 
 [lints]

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -13,6 +13,7 @@ turnkey = [
   "dep:solana-signature",
   "dep:uuid",
   "dep:tracing",
+  "dep:alloy-primitives",
 ]
 
 [dependencies]
@@ -26,6 +27,7 @@ solana-pubkey = { version = "4.2.0", optional = true }
 solana-signature = { version = "3.4.1", optional = true }
 uuid = { version = "1.23.2", default-features = false, optional = true }
 tracing = { version = "0.1.44", optional = true }
+alloy-primitives = { version = "1.5.7", optional = true }
 
 [dev-dependencies]
 wallet = { path = ".", features = ["mock", "turnkey"] }

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -6,7 +6,10 @@ mod turnkey_solana;
 #[cfg(feature = "mock")]
 pub use mock::MockWallet;
 #[cfg(feature = "turnkey")]
-pub use turnkey_solana::{OrganizationId, TurnkeySolanaWallet, TurnkeyWalletError};
+pub use turnkey_solana::{
+    OrganizationId, ProvisionedSolanaWallet, TurnkeySolanaWallet, TurnkeyWalletError,
+    provision_solana_wallet,
+};
 
 /// Domain capability for transaction signing and address retrieval.
 ///

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -49,3 +49,11 @@ pub trait Wallet: Send + Sync {
     /// Signs the given payload and returns a chain-valid signature.
     async fn sign(&self, payload: &Self::Payload) -> Result<Self::Signature, Self::Error>;
 }
+
+/// Lowercase hex with a `0x` prefix -- the form Turnkey's `signRawPayload`
+/// expects. Shared by the Solana and EVM wallets so both encode payloads
+/// identically, without pulling the EVM `alloy` hex helpers into Solana code.
+#[cfg(feature = "turnkey")]
+pub(crate) fn hex_prefixed(bytes: impl AsRef<[u8]>) -> String {
+    format!("0x{}", hex::encode(bytes))
+}

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -7,8 +7,8 @@ mod turnkey_solana;
 pub use mock::MockWallet;
 #[cfg(feature = "turnkey")]
 pub use turnkey_solana::{
-    OrganizationId, ProvisionedSolanaWallet, TurnkeySolanaWallet, TurnkeyWalletError,
-    provision_solana_wallet,
+    OrganizationId, OrganizationIdError, ProvisionedSolanaWallet, TurnkeySolanaWallet,
+    TurnkeyWalletError, provision_solana_wallet,
 };
 
 /// Domain capability for transaction signing and address retrieval.

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -1,14 +1,21 @@
 #[cfg(feature = "mock")]
 mod mock;
 #[cfg(feature = "turnkey")]
+mod turnkey;
+#[cfg(feature = "turnkey")]
+mod turnkey_evm;
+#[cfg(feature = "turnkey")]
 mod turnkey_solana;
 
 #[cfg(feature = "mock")]
 pub use mock::MockWallet;
 #[cfg(feature = "turnkey")]
+pub use turnkey::{OrganizationId, OrganizationIdError};
+#[cfg(feature = "turnkey")]
+pub use turnkey_evm::{TurnkeyEvmWallet, TurnkeyEvmWalletError};
+#[cfg(feature = "turnkey")]
 pub use turnkey_solana::{
-    OrganizationId, OrganizationIdError, ProvisionedSolanaWallet, TurnkeySolanaWallet,
-    TurnkeyWalletError, provision_solana_wallet,
+    ProvisionedSolanaWallet, TurnkeySolanaWallet, TurnkeySolanaWalletError, provision_solana_wallet,
 };
 
 /// Domain capability for transaction signing and address retrieval.

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -10,7 +10,7 @@ mod turnkey_solana;
 #[cfg(feature = "mock")]
 pub use mock::MockWallet;
 #[cfg(feature = "turnkey")]
-pub use turnkey::{OrganizationId, OrganizationIdError};
+pub use turnkey::{OrganizationId, OrganizationIdError, WalletId};
 #[cfg(feature = "turnkey")]
 pub use turnkey_evm::{TurnkeyEvmWallet, TurnkeyEvmWalletError};
 #[cfg(feature = "turnkey")]

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -1,0 +1,41 @@
+#[cfg(feature = "mock")]
+mod mock;
+#[cfg(feature = "turnkey")]
+mod turnkey_solana;
+
+#[cfg(feature = "mock")]
+pub use mock::MockWallet;
+#[cfg(feature = "turnkey")]
+pub use turnkey_solana::{OrganizationId, TurnkeySolanaWallet, TurnkeyWalletError};
+
+/// Domain capability for transaction signing and address retrieval.
+///
+/// Each implementation targets a single chain and address. A Turnkey
+/// organization with Solana + EVM accounts produces two wallet instances.
+///
+/// Consumers constrain to their chain via associated types:
+/// `W: Wallet<Address = solana_pubkey::Pubkey>`.
+#[async_trait::async_trait]
+pub trait Wallet: Send + Sync {
+    /// Chain-specific address type (e.g., `solana_pubkey::Pubkey` for Solana,
+    /// `alloy_primitives::Address` for EVM).
+    type Address: Clone + Send + Sync;
+
+    /// Raw bytes to be signed. Implementations extract bytes via `AsRef<[u8]>`.
+    /// Callers are responsible for chain-specific encoding (a serialized Solana
+    /// message, EIP-712, etc.) before passing the payload.
+    type Payload: AsRef<[u8]> + Send + Sync;
+
+    /// Chain-specific signature type (e.g., `solana_signature::Signature`
+    /// for Solana, `alloy_primitives::Signature` for EVM).
+    type Signature: Send + Sync;
+
+    /// Implementation-specific error (e.g., `TurnkeyWalletError`).
+    type Error: std::error::Error + Send + Sync;
+
+    /// Returns the on-chain address managed by this wallet instance.
+    async fn address(&self) -> Result<Self::Address, Self::Error>;
+
+    /// Signs the given payload and returns a chain-valid signature.
+    async fn sign(&self, payload: &Self::Payload) -> Result<Self::Signature, Self::Error>;
+}

--- a/crates/wallet/src/mock.rs
+++ b/crates/wallet/src/mock.rs
@@ -1,3 +1,5 @@
+use tracing::debug;
+
 use crate::Wallet;
 
 /// Deterministic wallet for testing. Uses a fixed 32-byte "address" derived
@@ -28,12 +30,14 @@ impl Wallet for MockWallet {
     type Error = MockWalletError;
 
     async fn address(&self) -> Result<Self::Address, Self::Error> {
+        debug!("mock wallet address resolved");
         Ok(self.address)
     }
 
     async fn sign(&self, payload: &Self::Payload) -> Result<Self::Signature, Self::Error> {
         let mut signature = b"sig:".to_vec();
         signature.extend_from_slice(payload.as_ref());
+        debug!("mock wallet payload signed");
         Ok(signature)
     }
 }
@@ -41,15 +45,19 @@ impl Wallet for MockWallet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_test::traced_test;
 
+    #[traced_test]
     #[tokio::test]
     async fn address_returns_seed_filled_bytes() {
         let wallet = MockWallet::new(0xAB);
         let address = wallet.address().await.ok();
 
         assert_eq!(address, Some([0xAB; 32]));
+        assert!(logs_contain("mock wallet address resolved"));
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn sign_prepends_sig_prefix() {
         let wallet = MockWallet::new(1);
@@ -57,16 +65,20 @@ mod tests {
         let signature = wallet.sign(&payload).await.ok();
 
         assert_eq!(signature, Some(b"sig:hello".to_vec()));
+        assert!(logs_contain("mock wallet payload signed"));
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn sign_empty_payload() {
         let wallet = MockWallet::new(0);
         let signature = wallet.sign(&vec![]).await.ok();
 
         assert_eq!(signature, Some(b"sig:".to_vec()));
+        assert!(logs_contain("mock wallet payload signed"));
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn different_seeds_produce_different_addresses() {
         let wallet_a = MockWallet::new(1);
@@ -76,5 +88,6 @@ mod tests {
         let addr_b = wallet_b.address().await.ok();
 
         assert_ne!(addr_a, addr_b);
+        assert!(logs_contain("mock wallet address resolved"));
     }
 }

--- a/crates/wallet/src/mock.rs
+++ b/crates/wallet/src/mock.rs
@@ -1,0 +1,80 @@
+use crate::Wallet;
+
+/// Deterministic wallet for testing. Uses a fixed 32-byte "address" derived
+/// from the seed, and produces signatures by prepending `b"sig:"` to the
+/// payload bytes.
+pub struct MockWallet {
+    address: [u8; 32],
+}
+
+impl MockWallet {
+    /// Creates a mock wallet whose address is `[seed; 32]`.
+    pub fn new(seed: u8) -> Self {
+        Self {
+            address: [seed; 32],
+        }
+    }
+}
+
+/// Mock never fails -- errors are uninhabitable.
+#[derive(Debug, thiserror::Error)]
+pub enum MockWalletError {}
+
+#[async_trait::async_trait]
+impl Wallet for MockWallet {
+    type Address = [u8; 32];
+    type Payload = Vec<u8>;
+    type Signature = Vec<u8>;
+    type Error = MockWalletError;
+
+    async fn address(&self) -> Result<Self::Address, Self::Error> {
+        Ok(self.address)
+    }
+
+    async fn sign(&self, payload: &Self::Payload) -> Result<Self::Signature, Self::Error> {
+        let mut signature = b"sig:".to_vec();
+        signature.extend_from_slice(payload.as_ref());
+        Ok(signature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn address_returns_seed_filled_bytes() {
+        let wallet = MockWallet::new(0xAB);
+        let address = wallet.address().await.ok();
+
+        assert_eq!(address, Some([0xAB; 32]));
+    }
+
+    #[tokio::test]
+    async fn sign_prepends_sig_prefix() {
+        let wallet = MockWallet::new(1);
+        let payload = b"hello".to_vec();
+        let signature = wallet.sign(&payload).await.ok();
+
+        assert_eq!(signature, Some(b"sig:hello".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn sign_empty_payload() {
+        let wallet = MockWallet::new(0);
+        let signature = wallet.sign(&vec![]).await.ok();
+
+        assert_eq!(signature, Some(b"sig:".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn different_seeds_produce_different_addresses() {
+        let wallet_a = MockWallet::new(1);
+        let wallet_b = MockWallet::new(2);
+
+        let addr_a = wallet_a.address().await.ok();
+        let addr_b = wallet_b.address().await.ok();
+
+        assert_ne!(addr_a, addr_b);
+    }
+}

--- a/crates/wallet/src/turnkey.rs
+++ b/crates/wallet/src/turnkey.rs
@@ -1,0 +1,45 @@
+use uuid::Uuid;
+
+/// Turnkey organization identifier.
+///
+/// Wraps the UUID string that Turnkey uses to scope all API operations to a
+/// single organization. Constructed only through [`OrganizationId::new`], so an
+/// instance is always a syntactically valid UUID. Shared by every chain-specific
+/// Turnkey wallet.
+#[derive(Debug, Clone)]
+pub struct OrganizationId(pub(crate) String);
+
+impl OrganizationId {
+    /// Parses a Turnkey organization id, rejecting anything that is not a UUID
+    /// so an invalid id cannot reach an API call and fail late.
+    pub fn new(id: impl Into<String>) -> Result<Self, OrganizationIdError> {
+        let id = id.into();
+        Uuid::parse_str(&id).map_err(|_| OrganizationIdError::NotAUuid)?;
+        Ok(Self(id))
+    }
+}
+
+/// Error from constructing an [`OrganizationId`].
+#[derive(Debug, thiserror::Error)]
+pub enum OrganizationIdError {
+    #[error("organization id is not a valid UUID")]
+    NotAUuid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn organization_id_accepts_a_valid_uuid() {
+        assert!(OrganizationId::new("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn organization_id_rejects_a_non_uuid() {
+        assert!(matches!(
+            OrganizationId::new("not-a-uuid"),
+            Err(OrganizationIdError::NotAUuid)
+        ));
+    }
+}

--- a/crates/wallet/src/turnkey.rs
+++ b/crates/wallet/src/turnkey.rs
@@ -2,26 +2,26 @@ use uuid::Uuid;
 
 /// Turnkey organization identifier.
 ///
-/// Wraps the UUID string that Turnkey uses to scope all API operations to a
-/// single organization. Constructed only through [`OrganizationId::new`], so an
-/// instance is always a syntactically valid UUID. Shared by every chain-specific
-/// Turnkey wallet.
+/// Wraps the UUID that Turnkey uses to scope all API operations to a single
+/// organization. Constructed only through [`OrganizationId::new`], which parses
+/// and stores a real [`Uuid`], so an instance is always a valid UUID and the raw
+/// string is never retained. Shared by every chain-specific Turnkey wallet.
 #[derive(Debug, Clone)]
-pub struct OrganizationId(String);
+pub struct OrganizationId(Uuid);
 
 impl OrganizationId {
     /// Parses a Turnkey organization id, rejecting anything that is not a UUID
-    /// so an invalid id cannot reach an API call and fail late.
+    /// so an invalid id cannot reach an API call and fail late. The parsed
+    /// [`Uuid`] is stored directly.
     pub fn new(id: impl Into<String>) -> Result<Self, OrganizationIdError> {
-        let id = id.into();
-        Uuid::parse_str(&id)?;
-        Ok(Self(id))
+        Ok(Self(Uuid::parse_str(&id.into())?))
     }
+}
 
-    /// Borrows the validated UUID string to scope a Turnkey API call to this
-    /// organization. Crate-internal so the raw id never escapes the newtype.
-    pub(crate) fn as_str(&self) -> &str {
-        &self.0
+impl std::fmt::Display for OrganizationId {
+    /// Renders the canonical hyphenated UUID to scope a Turnkey API call.
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, formatter)
     }
 }
 

--- a/crates/wallet/src/turnkey.rs
+++ b/crates/wallet/src/turnkey.rs
@@ -26,6 +26,22 @@ pub enum OrganizationIdError {
     NotAUuid,
 }
 
+/// Turnkey wallet identifier.
+///
+/// Wraps the id Turnkey assigns to a wallet at creation. Unlike
+/// [`OrganizationId`], a `WalletId` is produced by Turnkey rather than supplied
+/// by a caller, so it is trusted output and carries no construction-time
+/// validation; the newtype exists to keep wallet ids from being confused with
+/// other strings as they flow through provisioning and persistence.
+#[derive(Debug, Clone)]
+pub struct WalletId(pub String);
+
+impl std::fmt::Display for WalletId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/wallet/src/turnkey.rs
+++ b/crates/wallet/src/turnkey.rs
@@ -7,15 +7,21 @@ use uuid::Uuid;
 /// instance is always a syntactically valid UUID. Shared by every chain-specific
 /// Turnkey wallet.
 #[derive(Debug, Clone)]
-pub struct OrganizationId(pub(crate) String);
+pub struct OrganizationId(String);
 
 impl OrganizationId {
     /// Parses a Turnkey organization id, rejecting anything that is not a UUID
     /// so an invalid id cannot reach an API call and fail late.
     pub fn new(id: impl Into<String>) -> Result<Self, OrganizationIdError> {
         let id = id.into();
-        Uuid::parse_str(&id).map_err(|_| OrganizationIdError::NotAUuid)?;
+        Uuid::parse_str(&id)?;
         Ok(Self(id))
+    }
+
+    /// Borrows the validated UUID string to scope a Turnkey API call to this
+    /// organization. Crate-internal so the raw id never escapes the newtype.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -23,7 +29,7 @@ impl OrganizationId {
 #[derive(Debug, thiserror::Error)]
 pub enum OrganizationIdError {
     #[error("organization id is not a valid UUID")]
-    NotAUuid,
+    Uuid(#[from] uuid::Error),
 }
 
 /// Turnkey wallet identifier.
@@ -63,7 +69,7 @@ mod tests {
     fn organization_id_rejects_a_non_uuid() {
         assert!(matches!(
             OrganizationId::new("not-a-uuid"),
-            Err(OrganizationIdError::NotAUuid)
+            Err(OrganizationIdError::Uuid(_))
         ));
     }
 }

--- a/crates/wallet/src/turnkey.rs
+++ b/crates/wallet/src/turnkey.rs
@@ -34,7 +34,15 @@ pub enum OrganizationIdError {
 /// validation; the newtype exists to keep wallet ids from being confused with
 /// other strings as they flow through provisioning and persistence.
 #[derive(Debug, Clone)]
-pub struct WalletId(pub String);
+pub struct WalletId(String);
+
+impl WalletId {
+    /// Wraps the id Turnkey returns when a wallet is created. Crate-internal so
+    /// only provisioning, which receives the id from Turnkey, can mint one.
+    pub(crate) fn new(id: String) -> Self {
+        Self(id)
+    }
+}
 
 impl std::fmt::Display for WalletId {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/wallet/src/turnkey_evm.rs
+++ b/crates/wallet/src/turnkey_evm.rs
@@ -67,7 +67,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeyEvmWallet<S> {
         let result = self
             .client
             .sign_raw_payload(
-                self.organization_id.as_str().to_owned(),
+                self.organization_id.to_string(),
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
                     sign_with: self.account.to_checksum(None),

--- a/crates/wallet/src/turnkey_evm.rs
+++ b/crates/wallet/src/turnkey_evm.rs
@@ -67,7 +67,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeyEvmWallet<S> {
         let result = self
             .client
             .sign_raw_payload(
-                self.organization_id.0.clone(),
+                self.organization_id.as_str().to_owned(),
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
                     sign_with: self.account.to_checksum(None),

--- a/crates/wallet/src/turnkey_evm.rs
+++ b/crates/wallet/src/turnkey_evm.rs
@@ -1,0 +1,154 @@
+use std::num::ParseIntError;
+
+use alloy_primitives::hex::FromHex;
+use alloy_primitives::{Address, B256, Signature, hex, normalize_v};
+use tracing::debug;
+use turnkey_api_key_stamper::Stamp;
+use turnkey_client::generated::immutable::activity::v1::SignRawPayloadIntentV2;
+use turnkey_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
+use turnkey_client::{TurnkeyClient, TurnkeyClientError};
+
+use crate::Wallet;
+use crate::turnkey::OrganizationId;
+
+/// Errors from Turnkey EVM wallet operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TurnkeyEvmWalletError {
+    #[error(transparent)]
+    Turnkey(#[from] TurnkeyClientError),
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+    #[error("invalid recovery id: {0}")]
+    RecoveryId(u64),
+}
+
+/// EVM wallet backed by Turnkey's TEE-secured signing.
+///
+/// One instance = one EVM address. Construct via [`TurnkeyEvmWallet::new`]. The
+/// payload is a pre-hashed 32-byte digest (callers apply keccak256 first), so
+/// Turnkey signs it with no further hashing.
+pub struct TurnkeyEvmWallet<S: Stamp> {
+    client: TurnkeyClient<S>,
+    organization_id: OrganizationId,
+    account: Address,
+}
+
+impl<S: Stamp> TurnkeyEvmWallet<S> {
+    /// Creates a wallet bound to a specific Turnkey organization and EVM account
+    /// address.
+    pub fn new(
+        client: TurnkeyClient<S>,
+        organization_id: OrganizationId,
+        account: Address,
+    ) -> Self {
+        Self {
+            client,
+            organization_id,
+            account,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: Stamp + Send + Sync> Wallet for TurnkeyEvmWallet<S> {
+    type Address = Address;
+    /// Pre-hashed 32-byte digest. Callers hash with keccak256 before passing.
+    type Payload = B256;
+    type Signature = Signature;
+    type Error = TurnkeyEvmWalletError;
+
+    async fn address(&self) -> Result<Self::Address, Self::Error> {
+        Ok(self.account)
+    }
+
+    async fn sign(&self, payload: &Self::Payload) -> Result<Self::Signature, Self::Error> {
+        let result = self
+            .client
+            .sign_raw_payload(
+                self.organization_id.0.clone(),
+                self.client.current_timestamp(),
+                SignRawPayloadIntentV2 {
+                    sign_with: self.account.to_checksum(None),
+                    payload: hex::encode_prefixed(payload),
+                    encoding: PayloadEncoding::Hexadecimal,
+                    hash_function: HashFunction::NoOp,
+                },
+            )
+            .await?;
+
+        let signature = parse_signature(&result.result.r, &result.result.s, &result.result.v)?;
+        debug!(account = %self.account, "evm payload signed via turnkey");
+        Ok(signature)
+    }
+}
+
+/// Reassembles an EVM signature from Turnkey's hex-encoded `r`, `s`, and `v`
+/// components, normalizing the recovery id to a parity bit.
+fn parse_signature(
+    r_hex: &str,
+    s_hex: &str,
+    v_hex: &str,
+) -> Result<Signature, TurnkeyEvmWalletError> {
+    let r = B256::from_hex(r_hex)?;
+    let s = B256::from_hex(s_hex)?;
+
+    let v_raw = u64::from_str_radix(v_hex.strip_prefix("0x").unwrap_or(v_hex), 16)?;
+    let parity = normalize_v(v_raw).ok_or(TurnkeyEvmWalletError::RecoveryId(v_raw))?;
+
+    Ok(Signature::from_scalars_and_parity(r, s, parity))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_signature_valid_with_raw_parity() {
+        let r = "0x".to_owned() + &"ab".repeat(32);
+        let s = "0x".to_owned() + &"cd".repeat(32);
+
+        let even = parse_signature(&r, &s, "00");
+        assert!(even.is_ok_and(|sig| !sig.v()));
+
+        let odd = parse_signature(&r, &s, "01");
+        assert!(odd.is_ok_and(|sig| sig.v()));
+    }
+
+    #[test]
+    fn parse_signature_valid_with_legacy_parity() {
+        let r = "0x".to_owned() + &"ab".repeat(32);
+        let s = "0x".to_owned() + &"cd".repeat(32);
+
+        let even = parse_signature(&r, &s, "1b");
+        assert!(even.is_ok_and(|sig| !sig.v()));
+
+        let odd = parse_signature(&r, &s, "1c");
+        assert!(odd.is_ok_and(|sig| sig.v()));
+    }
+
+    #[test]
+    fn parse_signature_invalid_hex() {
+        let valid = "0x".to_owned() + &"aa".repeat(32);
+        assert!(matches!(
+            parse_signature("0xZZZZ", &valid, "00"),
+            Err(TurnkeyEvmWalletError::Hex(_))
+        ));
+    }
+
+    #[test]
+    fn parse_signature_invalid_v() {
+        let r = "0x".to_owned() + &"aa".repeat(32);
+        let s = "0x".to_owned() + &"bb".repeat(32);
+
+        assert!(matches!(
+            parse_signature(&r, &s, "02"),
+            Err(TurnkeyEvmWalletError::RecoveryId(2))
+        ));
+        assert!(matches!(
+            parse_signature(&r, &s, "zz"),
+            Err(TurnkeyEvmWalletError::ParseInt(_))
+        ));
+    }
+}

--- a/crates/wallet/src/turnkey_evm.rs
+++ b/crates/wallet/src/turnkey_evm.rs
@@ -71,7 +71,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeyEvmWallet<S> {
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
                     sign_with: self.account.to_checksum(None),
-                    payload: hex::encode_prefixed(payload),
+                    payload: crate::hex_prefixed(payload),
                     encoding: PayloadEncoding::Hexadecimal,
                     hash_function: HashFunction::NoOp,
                 },

--- a/crates/wallet/src/turnkey_evm.rs
+++ b/crates/wallet/src/turnkey_evm.rs
@@ -104,6 +104,11 @@ fn parse_signature(
 mod tests {
     use super::*;
 
+    use tracing_test::traced_test;
+    use turnkey_client::TurnkeyP256ApiKey;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
     #[test]
     fn parse_signature_valid_with_raw_parity() {
         let r = "0x".to_owned() + &"ab".repeat(32);
@@ -150,5 +155,43 @@ mod tests {
             parse_signature(&r, &s, "zz"),
             Err(TurnkeyEvmWalletError::ParseInt(_))
         ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn sign_returns_the_turnkey_signature_and_logs_completion() {
+        let r = "ab".repeat(32);
+        let s = "cd".repeat(32);
+        let expected = parse_signature(&r, &s, "1b").expect("valid signature");
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "id": "01890000-0000-7000-8000-000000000002",
+                    "organizationId": "550e8400-e29b-41d4-a716-446655440000",
+                    "fingerprint": "fp",
+                    "result": { "signRawPayloadResult": { "r": r, "s": s, "v": "1b" } }
+                }
+            })))
+            .mount(&server)
+            .await;
+        let client = TurnkeyClient::<TurnkeyP256ApiKey>::builder()
+            .api_key(TurnkeyP256ApiKey::generate())
+            .base_url(server.uri())
+            .build()
+            .expect("client builds");
+
+        let organization_id =
+            OrganizationId::new("550e8400-e29b-41d4-a716-446655440000").expect("valid uuid");
+        let account = Address::from([0x42u8; 20]);
+        let wallet = TurnkeyEvmWallet::new(client, organization_id, account);
+
+        let signature = wallet.sign(&B256::from([0x11u8; 32])).await;
+
+        assert_eq!(signature.ok(), Some(expected));
+        assert!(logs_contain("evm payload signed via turnkey"));
     }
 }

--- a/crates/wallet/src/turnkey_evm.rs
+++ b/crates/wallet/src/turnkey_evm.rs
@@ -106,7 +106,7 @@ mod tests {
 
     use tracing_test::traced_test;
     use turnkey_client::TurnkeyP256ApiKey;
-    use wiremock::matchers::method;
+    use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
@@ -164,8 +164,20 @@ mod tests {
         let s = "cd".repeat(32);
         let expected = parse_signature(&r, &s, "1b").expect("valid signature");
 
+        let account = Address::from([0x42u8; 20]);
+        let payload = B256::from([0x11u8; 32]);
+
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_raw_payload"))
+            .and(body_partial_json(serde_json::json!({
+                "parameters": {
+                    "signWith": account.to_checksum(None),
+                    "payload": hex::encode_prefixed(payload),
+                    "encoding": "PAYLOAD_ENCODING_HEXADECIMAL",
+                    "hashFunction": "HASH_FUNCTION_NO_OP"
+                }
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
                     "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
@@ -186,10 +198,9 @@ mod tests {
 
         let organization_id =
             OrganizationId::new("550e8400-e29b-41d4-a716-446655440000").expect("valid uuid");
-        let account = Address::from([0x42u8; 20]);
         let wallet = TurnkeyEvmWallet::new(client, organization_id, account);
 
-        let signature = wallet.sign(&B256::from([0x11u8; 32])).await;
+        let signature = wallet.sign(&payload).await;
 
         assert_eq!(signature.ok(), Some(expected));
         assert!(logs_contain("evm payload signed via turnkey"));

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -185,6 +185,11 @@ fn first_solana_address(addresses: Vec<String>) -> Result<Pubkey, TurnkeySolanaW
 mod tests {
     use super::*;
 
+    use tracing_test::traced_test;
+    use turnkey_client::TurnkeyP256ApiKey;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
     #[test]
     fn parse_signature_joins_r_and_s() {
         let r = "ab".repeat(32);
@@ -274,5 +279,85 @@ mod tests {
             first_solana_address(vec!["abc".to_owned()]),
             Err(TurnkeySolanaWalletError::PubkeyParse(_))
         ));
+    }
+
+    fn organization_id() -> OrganizationId {
+        OrganizationId::new("550e8400-e29b-41d4-a716-446655440000").expect("valid uuid")
+    }
+
+    async fn turnkey_returning(
+        body: serde_json::Value,
+    ) -> (TurnkeyClient<TurnkeyP256ApiKey>, MockServer) {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+        let client = TurnkeyClient::<TurnkeyP256ApiKey>::builder()
+            .api_key(TurnkeyP256ApiKey::generate())
+            .base_url(server.uri())
+            .build()
+            .expect("client builds");
+        (client, server)
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn sign_returns_the_turnkey_signature_and_logs_completion() {
+        let r = "ab".repeat(32);
+        let s = "cd".repeat(32);
+        let (client, _server) = turnkey_returning(serde_json::json!({
+            "activity": {
+                "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "id": "01890000-0000-7000-8000-000000000000",
+                "organizationId": "550e8400-e29b-41d4-a716-446655440000",
+                "fingerprint": "fp",
+                "result": { "signRawPayloadResult": { "r": r, "s": s, "v": "00" } }
+            }
+        }))
+        .await;
+
+        let account = Pubkey::new_from_array([7u8; 32]);
+        let wallet = TurnkeySolanaWallet::new(client, organization_id(), account);
+
+        let expected: [u8; 64] = std::array::from_fn(|index| if index < 32 { 0xab } else { 0xcd });
+        let signature = wallet.sign(&b"a serialized solana message".to_vec()).await;
+
+        assert_eq!(signature.ok(), Some(Signature::from(expected)));
+        assert!(logs_contain("solana payload signed via turnkey"));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn provision_returns_the_wallet_and_logs_completion() {
+        let address = Pubkey::default().to_string();
+        let (client, _server) = turnkey_returning(serde_json::json!({
+            "activity": {
+                "type": "ACTIVITY_TYPE_CREATE_WALLET",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "id": "01890000-0000-7000-8000-000000000001",
+                "organizationId": "550e8400-e29b-41d4-a716-446655440000",
+                "fingerprint": "fp",
+                "result": {
+                    "createWalletResult": {
+                        "walletId": "ac651e99-579f-5c7c-8e06-16430bc25dc1",
+                        "addresses": [address]
+                    }
+                }
+            }
+        }))
+        .await;
+
+        let provisioned = provision_solana_wallet(&client, &organization_id(), "test wallet")
+            .await
+            .expect("provisioning succeeds");
+
+        assert_eq!(
+            provisioned.wallet_id.to_string(),
+            "ac651e99-579f-5c7c-8e06-16430bc25dc1"
+        );
+        assert_eq!(provisioned.address, Pubkey::default());
+        assert!(logs_contain("provisioned solana wallet via turnkey"));
     }
 }

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
+use tracing::debug;
 use turnkey_api_key_stamper::Stamp;
 use turnkey_client::generated::immutable::activity::v1::{
     CreateWalletIntent, SignRawPayloadIntentV2, WalletAccountParams,
@@ -10,18 +11,33 @@ use turnkey_client::generated::immutable::common::v1::{
     AddressFormat, Curve, HashFunction, PathFormat, PayloadEncoding,
 };
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
+use uuid::Uuid;
 
 use crate::Wallet;
 
-/// Turnkey organization identifier. Wraps the UUID string that Turnkey uses to
-/// scope all API operations to a single organization.
+/// Turnkey organization identifier.
+///
+/// Wraps the UUID string that Turnkey uses to scope all API operations to a
+/// single organization. Constructed only through [`OrganizationId::new`], so an
+/// instance is always a syntactically valid UUID.
 #[derive(Debug, Clone)]
 pub struct OrganizationId(String);
 
 impl OrganizationId {
-    pub fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
+    /// Parses a Turnkey organization id, rejecting anything that is not a UUID
+    /// so an invalid id cannot reach an API call and fail late.
+    pub fn new(id: impl Into<String>) -> Result<Self, OrganizationIdError> {
+        let id = id.into();
+        Uuid::parse_str(&id).map_err(|_| OrganizationIdError::NotAUuid)?;
+        Ok(Self(id))
     }
+}
+
+/// Error from constructing an [`OrganizationId`].
+#[derive(Debug, thiserror::Error)]
+pub enum OrganizationIdError {
+    #[error("organization id is not a valid UUID")]
+    NotAUuid,
 }
 
 /// Errors from Turnkey Solana wallet operations.
@@ -33,6 +49,8 @@ pub enum TurnkeyWalletError {
     Hex(#[from] hex::FromHexError),
     #[error("expected a 64-byte ed25519 signature, got {0} bytes")]
     SignatureLength(usize),
+    #[error("expected ed25519 scalar {component} to be 32 bytes, got {len} bytes")]
+    ScalarLength { component: &'static str, len: usize },
     #[error("turnkey returned no address for the provisioned wallet")]
     NoAddress,
     #[error(transparent)]
@@ -91,7 +109,9 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
             )
             .await?;
 
-        parse_signature(&result.result.r, &result.result.s)
+        let signature = parse_signature(&result.result.r, &result.result.s)?;
+        debug!(account = %self.account, "solana payload signed via turnkey");
+        Ok(signature)
     }
 }
 
@@ -130,17 +150,23 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
         )
         .await?;
 
-    Ok(ProvisionedSolanaWallet {
+    let wallet = ProvisionedSolanaWallet {
         wallet_id: result.result.wallet_id,
         address: first_solana_address(result.result.addresses)?,
-    })
+    };
+    debug!(
+        wallet_id = %wallet.wallet_id,
+        address = %wallet.address,
+        "provisioned solana wallet via turnkey"
+    );
+    Ok(wallet)
 }
 
 /// Joins Turnkey's hex-encoded `r` and `s` scalars into a 64-byte ed25519
 /// Solana signature.
 fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletError> {
-    let mut bytes = decode_scalar(r_hex)?;
-    bytes.extend_from_slice(&decode_scalar(s_hex)?);
+    let mut bytes = decode_scalar("r", r_hex)?;
+    bytes.extend_from_slice(&decode_scalar("s", s_hex)?);
 
     let signature: [u8; 64] = bytes
         .as_slice()
@@ -150,8 +176,20 @@ fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletE
     Ok(Signature::from(signature))
 }
 
-fn decode_scalar(scalar_hex: &str) -> Result<Vec<u8>, hex::FromHexError> {
-    hex::decode(scalar_hex.strip_prefix("0x").unwrap_or(scalar_hex))
+/// Decodes a single hex-encoded ed25519 scalar and enforces that it is exactly
+/// 32 bytes, so a malformed split (e.g. 31 + 33) cannot pass the combined
+/// 64-byte check and produce a misaligned signature.
+fn decode_scalar(component: &'static str, scalar_hex: &str) -> Result<Vec<u8>, TurnkeyWalletError> {
+    let scalar = hex::decode(scalar_hex.strip_prefix("0x").unwrap_or(scalar_hex))?;
+
+    if scalar.len() != 32 {
+        return Err(TurnkeyWalletError::ScalarLength {
+            component,
+            len: scalar.len(),
+        });
+    }
+
+    Ok(scalar)
 }
 
 /// Parses the first address Turnkey returned for a provisioned wallet as a
@@ -201,7 +239,26 @@ mod tests {
 
         assert!(matches!(
             parse_signature(&short, &short),
-            Err(TurnkeyWalletError::SignatureLength(32))
+            Err(TurnkeyWalletError::ScalarLength {
+                component: "r",
+                len: 16
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_signature_rejects_a_misaligned_scalar_split() {
+        // 31-byte r + 33-byte s sums to 64, so a combined-length check passes,
+        // but the bytes are not a valid (32, 32) ed25519 signature.
+        let r = "ab".repeat(31);
+        let s = "cd".repeat(33);
+
+        assert!(matches!(
+            parse_signature(&r, &s),
+            Err(TurnkeyWalletError::ScalarLength {
+                component: "r",
+                len: 31
+            })
         ));
     }
 
@@ -212,6 +269,19 @@ mod tests {
         assert!(matches!(
             parse_signature("zz", &valid),
             Err(TurnkeyWalletError::Hex(_))
+        ));
+    }
+
+    #[test]
+    fn organization_id_accepts_a_valid_uuid() {
+        assert!(OrganizationId::new("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn organization_id_rejects_a_non_uuid() {
+        assert!(matches!(
+            OrganizationId::new("not-a-uuid"),
+            Err(OrganizationIdError::NotAUuid)
         ));
     }
 

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -11,38 +11,13 @@ use turnkey_client::generated::immutable::common::v1::{
     AddressFormat, Curve, HashFunction, PathFormat, PayloadEncoding,
 };
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
-use uuid::Uuid;
 
 use crate::Wallet;
-
-/// Turnkey organization identifier.
-///
-/// Wraps the UUID string that Turnkey uses to scope all API operations to a
-/// single organization. Constructed only through [`OrganizationId::new`], so an
-/// instance is always a syntactically valid UUID.
-#[derive(Debug, Clone)]
-pub struct OrganizationId(String);
-
-impl OrganizationId {
-    /// Parses a Turnkey organization id, rejecting anything that is not a UUID
-    /// so an invalid id cannot reach an API call and fail late.
-    pub fn new(id: impl Into<String>) -> Result<Self, OrganizationIdError> {
-        let id = id.into();
-        Uuid::parse_str(&id).map_err(|_| OrganizationIdError::NotAUuid)?;
-        Ok(Self(id))
-    }
-}
-
-/// Error from constructing an [`OrganizationId`].
-#[derive(Debug, thiserror::Error)]
-pub enum OrganizationIdError {
-    #[error("organization id is not a valid UUID")]
-    NotAUuid,
-}
+use crate::turnkey::OrganizationId;
 
 /// Errors from Turnkey Solana wallet operations.
 #[derive(Debug, thiserror::Error)]
-pub enum TurnkeyWalletError {
+pub enum TurnkeySolanaWalletError {
     #[error(transparent)]
     Turnkey(#[from] TurnkeyClientError),
     #[error(transparent)]
@@ -88,7 +63,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
     /// payload is signed without any client-side digest.
     type Payload = Vec<u8>;
     type Signature = Signature;
-    type Error = TurnkeyWalletError;
+    type Error = TurnkeySolanaWalletError;
 
     async fn address(&self) -> Result<Self::Address, Self::Error> {
         Ok(self.account)
@@ -132,7 +107,7 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
     client: &TurnkeyClient<S>,
     organization_id: &OrganizationId,
     wallet_name: impl Into<String> + Send,
-) -> Result<ProvisionedSolanaWallet, TurnkeyWalletError> {
+) -> Result<ProvisionedSolanaWallet, TurnkeySolanaWalletError> {
     let result = client
         .create_wallet(
             organization_id.0.clone(),
@@ -164,14 +139,14 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
 
 /// Joins Turnkey's hex-encoded `r` and `s` scalars into a 64-byte ed25519
 /// Solana signature.
-fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletError> {
+fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeySolanaWalletError> {
     let mut bytes = decode_scalar("r", r_hex)?;
     bytes.extend_from_slice(&decode_scalar("s", s_hex)?);
 
     let signature: [u8; 64] = bytes
         .as_slice()
         .try_into()
-        .map_err(|_| TurnkeyWalletError::SignatureLength(bytes.len()))?;
+        .map_err(|_| TurnkeySolanaWalletError::SignatureLength(bytes.len()))?;
 
     Ok(Signature::from(signature))
 }
@@ -179,11 +154,14 @@ fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletE
 /// Decodes a single hex-encoded ed25519 scalar and enforces that it is exactly
 /// 32 bytes, so a malformed split (e.g. 31 + 33) cannot pass the combined
 /// 64-byte check and produce a misaligned signature.
-fn decode_scalar(component: &'static str, scalar_hex: &str) -> Result<Vec<u8>, TurnkeyWalletError> {
+fn decode_scalar(
+    component: &'static str,
+    scalar_hex: &str,
+) -> Result<Vec<u8>, TurnkeySolanaWalletError> {
     let scalar = hex::decode(scalar_hex.strip_prefix("0x").unwrap_or(scalar_hex))?;
 
     if scalar.len() != 32 {
-        return Err(TurnkeyWalletError::ScalarLength {
+        return Err(TurnkeySolanaWalletError::ScalarLength {
             component,
             len: scalar.len(),
         });
@@ -194,11 +172,11 @@ fn decode_scalar(component: &'static str, scalar_hex: &str) -> Result<Vec<u8>, T
 
 /// Parses the first address Turnkey returned for a provisioned wallet as a
 /// Solana pubkey.
-fn first_solana_address(addresses: Vec<String>) -> Result<Pubkey, TurnkeyWalletError> {
+fn first_solana_address(addresses: Vec<String>) -> Result<Pubkey, TurnkeySolanaWalletError> {
     let address = addresses
         .into_iter()
         .next()
-        .ok_or(TurnkeyWalletError::NoAddress)?;
+        .ok_or(TurnkeySolanaWalletError::NoAddress)?;
 
     Ok(Pubkey::from_str(&address)?)
 }
@@ -239,7 +217,7 @@ mod tests {
 
         assert!(matches!(
             parse_signature(&short, &short),
-            Err(TurnkeyWalletError::ScalarLength {
+            Err(TurnkeySolanaWalletError::ScalarLength {
                 component: "r",
                 len: 16
             })
@@ -255,7 +233,7 @@ mod tests {
 
         assert!(matches!(
             parse_signature(&r, &s),
-            Err(TurnkeyWalletError::ScalarLength {
+            Err(TurnkeySolanaWalletError::ScalarLength {
                 component: "r",
                 len: 31
             })
@@ -268,20 +246,7 @@ mod tests {
 
         assert!(matches!(
             parse_signature("zz", &valid),
-            Err(TurnkeyWalletError::Hex(_))
-        ));
-    }
-
-    #[test]
-    fn organization_id_accepts_a_valid_uuid() {
-        assert!(OrganizationId::new("550e8400-e29b-41d4-a716-446655440000").is_ok());
-    }
-
-    #[test]
-    fn organization_id_rejects_a_non_uuid() {
-        assert!(matches!(
-            OrganizationId::new("not-a-uuid"),
-            Err(OrganizationIdError::NotAUuid)
+            Err(TurnkeySolanaWalletError::Hex(_))
         ));
     }
 
@@ -299,7 +264,7 @@ mod tests {
     fn first_solana_address_rejects_an_empty_list() {
         assert!(matches!(
             first_solana_address(vec![]),
-            Err(TurnkeyWalletError::NoAddress)
+            Err(TurnkeySolanaWalletError::NoAddress)
         ));
     }
 
@@ -307,7 +272,7 @@ mod tests {
     fn first_solana_address_rejects_an_invalid_address() {
         assert!(matches!(
             first_solana_address(vec!["abc".to_owned()]),
-            Err(TurnkeyWalletError::PubkeyParse(_))
+            Err(TurnkeySolanaWalletError::PubkeyParse(_))
         ));
     }
 }

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -1,0 +1,155 @@
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use turnkey_api_key_stamper::Stamp;
+use turnkey_client::generated::immutable::activity::v1::SignRawPayloadIntentV2;
+use turnkey_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
+use turnkey_client::{TurnkeyClient, TurnkeyClientError};
+
+use crate::Wallet;
+
+/// Turnkey organization identifier. Wraps the UUID string that Turnkey uses to
+/// scope all API operations to a single organization.
+#[derive(Debug, Clone)]
+pub struct OrganizationId(String);
+
+impl OrganizationId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// Errors from Turnkey Solana wallet operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TurnkeyWalletError {
+    #[error(transparent)]
+    Turnkey(#[from] TurnkeyClientError),
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+    #[error("expected a 64-byte ed25519 signature, got {0} bytes")]
+    SignatureLength(usize),
+}
+
+/// Solana wallet backed by Turnkey's TEE-secured signing.
+///
+/// One instance = one Solana address. Construct via [`TurnkeySolanaWallet::new`].
+/// Solana uses ed25519, which hashes internally, so payloads are signed as-is:
+/// callers pass the serialized transaction message bytes with no client-side
+/// digest.
+pub struct TurnkeySolanaWallet<S: Stamp> {
+    client: TurnkeyClient<S>,
+    organization_id: OrganizationId,
+    account: Pubkey,
+}
+
+impl<S: Stamp> TurnkeySolanaWallet<S> {
+    /// Creates a wallet bound to a specific Turnkey organization and Solana
+    /// account address.
+    pub fn new(client: TurnkeyClient<S>, organization_id: OrganizationId, account: Pubkey) -> Self {
+        Self {
+            client,
+            organization_id,
+            account,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
+    type Address = Pubkey;
+    /// Serialized Solana message bytes. ed25519 hashes internally, so the
+    /// payload is signed without any client-side digest.
+    type Payload = Vec<u8>;
+    type Signature = Signature;
+    type Error = TurnkeyWalletError;
+
+    async fn address(&self) -> Result<Self::Address, Self::Error> {
+        Ok(self.account)
+    }
+
+    async fn sign(&self, payload: &Self::Payload) -> Result<Self::Signature, Self::Error> {
+        let result = self
+            .client
+            .sign_raw_payload(
+                self.organization_id.0.clone(),
+                self.client.current_timestamp(),
+                SignRawPayloadIntentV2 {
+                    sign_with: self.account.to_string(),
+                    payload: format!("0x{}", hex::encode(payload)),
+                    encoding: PayloadEncoding::Hexadecimal,
+                    hash_function: HashFunction::NotApplicable,
+                },
+            )
+            .await?;
+
+        parse_signature(&result.result.r, &result.result.s)
+    }
+}
+
+/// Joins Turnkey's hex-encoded `r` and `s` scalars into a 64-byte ed25519
+/// Solana signature.
+fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletError> {
+    let mut bytes = decode_scalar(r_hex)?;
+    bytes.extend_from_slice(&decode_scalar(s_hex)?);
+
+    let signature: [u8; 64] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| TurnkeyWalletError::SignatureLength(bytes.len()))?;
+
+    Ok(Signature::from(signature))
+}
+
+fn decode_scalar(scalar_hex: &str) -> Result<Vec<u8>, hex::FromHexError> {
+    hex::decode(scalar_hex.strip_prefix("0x").unwrap_or(scalar_hex))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_signature_joins_r_and_s() {
+        let r = "ab".repeat(32);
+        let s = "cd".repeat(32);
+
+        let expected: [u8; 64] = std::array::from_fn(|index| if index < 32 { 0xab } else { 0xcd });
+
+        assert_eq!(
+            parse_signature(&r, &s).ok(),
+            Some(Signature::from(expected))
+        );
+    }
+
+    #[test]
+    fn parse_signature_tolerates_0x_prefix() {
+        let r = "0x".to_owned() + &"ab".repeat(32);
+        let s = "0x".to_owned() + &"cd".repeat(32);
+
+        let expected: [u8; 64] = std::array::from_fn(|index| if index < 32 { 0xab } else { 0xcd });
+
+        assert_eq!(
+            parse_signature(&r, &s).ok(),
+            Some(Signature::from(expected))
+        );
+    }
+
+    #[test]
+    fn parse_signature_rejects_short_scalars() {
+        let short = "ab".repeat(16);
+
+        assert!(matches!(
+            parse_signature(&short, &short),
+            Err(TurnkeyWalletError::SignatureLength(32))
+        ));
+    }
+
+    #[test]
+    fn parse_signature_rejects_invalid_hex() {
+        let valid = "aa".repeat(32);
+
+        assert!(matches!(
+            parse_signature("zz", &valid),
+            Err(TurnkeyWalletError::Hex(_))
+        ));
+    }
+}

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -73,7 +73,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
         let result = self
             .client
             .sign_raw_payload(
-                self.organization_id.as_str().to_owned(),
+                self.organization_id.to_string(),
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
                     sign_with: self.account.to_string(),
@@ -110,7 +110,7 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
 ) -> Result<ProvisionedSolanaWallet, TurnkeySolanaWalletError> {
     let result = client
         .create_wallet(
-            organization_id.as_str().to_owned(),
+            organization_id.to_string(),
             client.current_timestamp(),
             CreateWalletIntent {
                 wallet_name: wallet_name.into(),

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -126,7 +126,7 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
         .await?;
 
     let wallet = ProvisionedSolanaWallet {
-        wallet_id: WalletId(result.result.wallet_id),
+        wallet_id: WalletId::new(result.result.wallet_id),
         address: first_solana_address(result.result.addresses)?,
     };
     debug!(

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -73,7 +73,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
         let result = self
             .client
             .sign_raw_payload(
-                self.organization_id.0.clone(),
+                self.organization_id.as_str().to_owned(),
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
                     sign_with: self.account.to_string(),
@@ -110,7 +110,7 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
 ) -> Result<ProvisionedSolanaWallet, TurnkeySolanaWalletError> {
     let result = client
         .create_wallet(
-            organization_id.0.clone(),
+            organization_id.as_str().to_owned(),
             client.current_timestamp(),
             CreateWalletIntent {
                 wallet_name: wallet_name.into(),

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -77,7 +77,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
                     sign_with: self.account.to_string(),
-                    payload: format!("0x{}", hex::encode(payload)),
+                    payload: crate::hex_prefixed(payload),
                     encoding: PayloadEncoding::Hexadecimal,
                     hash_function: HashFunction::NotApplicable,
                 },

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -1,8 +1,14 @@
+use std::str::FromStr;
+
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use turnkey_api_key_stamper::Stamp;
-use turnkey_client::generated::immutable::activity::v1::SignRawPayloadIntentV2;
-use turnkey_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
+use turnkey_client::generated::immutable::activity::v1::{
+    CreateWalletIntent, SignRawPayloadIntentV2, WalletAccountParams,
+};
+use turnkey_client::generated::immutable::common::v1::{
+    AddressFormat, Curve, HashFunction, PathFormat, PayloadEncoding,
+};
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
 
 use crate::Wallet;
@@ -27,6 +33,10 @@ pub enum TurnkeyWalletError {
     Hex(#[from] hex::FromHexError),
     #[error("expected a 64-byte ed25519 signature, got {0} bytes")]
     SignatureLength(usize),
+    #[error("turnkey returned no address for the provisioned wallet")]
+    NoAddress,
+    #[error(transparent)]
+    PubkeyParse(#[from] solana_pubkey::ParsePubkeyError),
 }
 
 /// Solana wallet backed by Turnkey's TEE-secured signing.
@@ -85,6 +95,47 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
     }
 }
 
+/// A Solana wallet provisioned in a Turnkey organization.
+pub struct ProvisionedSolanaWallet {
+    /// Turnkey's identifier for the created wallet.
+    pub wallet_id: String,
+    /// The wallet's on-chain Solana address.
+    pub address: Pubkey,
+}
+
+/// Provisions a fresh Solana wallet in the given Turnkey organization.
+///
+/// The wallet holds a single ed25519 account derived at the standard Solana
+/// BIP44 path. Returns Turnkey's wallet id and the on-chain address, which can
+/// then back a [`TurnkeySolanaWallet`] for signing.
+pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
+    client: &TurnkeyClient<S>,
+    organization_id: &OrganizationId,
+    wallet_name: impl Into<String> + Send,
+) -> Result<ProvisionedSolanaWallet, TurnkeyWalletError> {
+    let result = client
+        .create_wallet(
+            organization_id.0.clone(),
+            client.current_timestamp(),
+            CreateWalletIntent {
+                wallet_name: wallet_name.into(),
+                accounts: vec![WalletAccountParams {
+                    curve: Curve::Ed25519,
+                    path_format: PathFormat::Bip32,
+                    path: "m/44'/501'/0'/0'".to_owned(),
+                    address_format: AddressFormat::Solana,
+                }],
+                mnemonic_length: None,
+            },
+        )
+        .await?;
+
+    Ok(ProvisionedSolanaWallet {
+        wallet_id: result.result.wallet_id,
+        address: first_solana_address(result.result.addresses)?,
+    })
+}
+
 /// Joins Turnkey's hex-encoded `r` and `s` scalars into a 64-byte ed25519
 /// Solana signature.
 fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletError> {
@@ -101,6 +152,17 @@ fn parse_signature(r_hex: &str, s_hex: &str) -> Result<Signature, TurnkeyWalletE
 
 fn decode_scalar(scalar_hex: &str) -> Result<Vec<u8>, hex::FromHexError> {
     hex::decode(scalar_hex.strip_prefix("0x").unwrap_or(scalar_hex))
+}
+
+/// Parses the first address Turnkey returned for a provisioned wallet as a
+/// Solana pubkey.
+fn first_solana_address(addresses: Vec<String>) -> Result<Pubkey, TurnkeyWalletError> {
+    let address = addresses
+        .into_iter()
+        .next()
+        .ok_or(TurnkeyWalletError::NoAddress)?;
+
+    Ok(Pubkey::from_str(&address)?)
 }
 
 #[cfg(test)]
@@ -150,6 +212,32 @@ mod tests {
         assert!(matches!(
             parse_signature("zz", &valid),
             Err(TurnkeyWalletError::Hex(_))
+        ));
+    }
+
+    #[test]
+    fn first_solana_address_parses_the_leading_address() {
+        let address = Pubkey::default().to_string();
+
+        assert_eq!(
+            first_solana_address(vec![address]).ok(),
+            Some(Pubkey::default())
+        );
+    }
+
+    #[test]
+    fn first_solana_address_rejects_an_empty_list() {
+        assert!(matches!(
+            first_solana_address(vec![]),
+            Err(TurnkeyWalletError::NoAddress)
+        ));
+    }
+
+    #[test]
+    fn first_solana_address_rejects_an_invalid_address() {
+        assert!(matches!(
+            first_solana_address(vec!["abc".to_owned()]),
+            Err(TurnkeyWalletError::PubkeyParse(_))
         ));
     }
 }

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -13,7 +13,7 @@ use turnkey_client::generated::immutable::common::v1::{
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
 
 use crate::Wallet;
-use crate::turnkey::OrganizationId;
+use crate::turnkey::{OrganizationId, WalletId};
 
 /// Errors from Turnkey Solana wallet operations.
 #[derive(Debug, thiserror::Error)]
@@ -93,7 +93,7 @@ impl<S: Stamp + Send + Sync> Wallet for TurnkeySolanaWallet<S> {
 /// A Solana wallet provisioned in a Turnkey organization.
 pub struct ProvisionedSolanaWallet {
     /// Turnkey's identifier for the created wallet.
-    pub wallet_id: String,
+    pub wallet_id: WalletId,
     /// The wallet's on-chain Solana address.
     pub address: Pubkey,
 }
@@ -126,7 +126,7 @@ pub async fn provision_solana_wallet<S: Stamp + Send + Sync>(
         .await?;
 
     let wallet = ProvisionedSolanaWallet {
-        wallet_id: result.result.wallet_id,
+        wallet_id: WalletId(result.result.wallet_id),
         address: first_solana_address(result.result.addresses)?,
     };
     debug!(

--- a/crates/wallet/src/turnkey_solana.rs
+++ b/crates/wallet/src/turnkey_solana.rs
@@ -187,7 +187,7 @@ mod tests {
 
     use tracing_test::traced_test;
     use turnkey_client::TurnkeyP256ApiKey;
-    use wiremock::matchers::method;
+    use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
@@ -286,10 +286,14 @@ mod tests {
     }
 
     async fn turnkey_returning(
+        route: &str,
+        expected_request: serde_json::Value,
         body: serde_json::Value,
     ) -> (TurnkeyClient<TurnkeyP256ApiKey>, MockServer) {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path(route))
+            .and(body_partial_json(expected_request))
             .respond_with(ResponseTemplate::new(200).set_body_json(body))
             .mount(&server)
             .await;
@@ -306,23 +310,36 @@ mod tests {
     async fn sign_returns_the_turnkey_signature_and_logs_completion() {
         let r = "ab".repeat(32);
         let s = "cd".repeat(32);
-        let (client, _server) = turnkey_returning(serde_json::json!({
-            "activity": {
-                "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
-                "status": "ACTIVITY_STATUS_COMPLETED",
-                "id": "01890000-0000-7000-8000-000000000000",
-                "organizationId": "550e8400-e29b-41d4-a716-446655440000",
-                "fingerprint": "fp",
-                "result": { "signRawPayloadResult": { "r": r, "s": s, "v": "00" } }
-            }
-        }))
+        let account = Pubkey::new_from_array([7u8; 32]);
+        let message = b"a serialized solana message".to_vec();
+
+        let (client, _server) = turnkey_returning(
+            "/public/v1/submit/sign_raw_payload",
+            serde_json::json!({
+                "parameters": {
+                    "signWith": account.to_string(),
+                    "payload": format!("0x{}", hex::encode(&message)),
+                    "encoding": "PAYLOAD_ENCODING_HEXADECIMAL",
+                    "hashFunction": "HASH_FUNCTION_NOT_APPLICABLE"
+                }
+            }),
+            serde_json::json!({
+                "activity": {
+                    "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "id": "01890000-0000-7000-8000-000000000000",
+                    "organizationId": "550e8400-e29b-41d4-a716-446655440000",
+                    "fingerprint": "fp",
+                    "result": { "signRawPayloadResult": { "r": r, "s": s, "v": "00" } }
+                }
+            }),
+        )
         .await;
 
-        let account = Pubkey::new_from_array([7u8; 32]);
         let wallet = TurnkeySolanaWallet::new(client, organization_id(), account);
 
         let expected: [u8; 64] = std::array::from_fn(|index| if index < 32 { 0xab } else { 0xcd });
-        let signature = wallet.sign(&b"a serialized solana message".to_vec()).await;
+        let signature = wallet.sign(&message).await;
 
         assert_eq!(signature.ok(), Some(Signature::from(expected)));
         assert!(logs_contain("solana payload signed via turnkey"));
@@ -332,21 +349,35 @@ mod tests {
     #[tokio::test]
     async fn provision_returns_the_wallet_and_logs_completion() {
         let address = Pubkey::default().to_string();
-        let (client, _server) = turnkey_returning(serde_json::json!({
-            "activity": {
-                "type": "ACTIVITY_TYPE_CREATE_WALLET",
-                "status": "ACTIVITY_STATUS_COMPLETED",
-                "id": "01890000-0000-7000-8000-000000000001",
-                "organizationId": "550e8400-e29b-41d4-a716-446655440000",
-                "fingerprint": "fp",
-                "result": {
-                    "createWalletResult": {
-                        "walletId": "ac651e99-579f-5c7c-8e06-16430bc25dc1",
-                        "addresses": [address]
+        let (client, _server) = turnkey_returning(
+            "/public/v1/submit/create_wallet",
+            serde_json::json!({
+                "parameters": {
+                    "walletName": "test wallet",
+                    "accounts": [{
+                        "curve": "CURVE_ED25519",
+                        "pathFormat": "PATH_FORMAT_BIP32",
+                        "path": "m/44'/501'/0'/0'",
+                        "addressFormat": "ADDRESS_FORMAT_SOLANA"
+                    }]
+                }
+            }),
+            serde_json::json!({
+                "activity": {
+                    "type": "ACTIVITY_TYPE_CREATE_WALLET",
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "id": "01890000-0000-7000-8000-000000000001",
+                    "organizationId": "550e8400-e29b-41d4-a716-446655440000",
+                    "fingerprint": "fp",
+                    "result": {
+                        "createWalletResult": {
+                            "walletId": "ac651e99-579f-5c7c-8e06-16430bc25dc1",
+                            "addresses": [address]
+                        }
                     }
                 }
-            }
-        }))
+            }),
+        )
         .await;
 
         let provisioned = provision_solana_wallet(&client, &organization_id(), "test wallet")

--- a/rust.nix
+++ b/rust.nix
@@ -64,10 +64,13 @@ in {
   });
 
   # CI check derivations -- lighter than buildPackage (no final link step)
-  test = craneLib.cargoTest (commonArgs // { inherit cargoArtifacts; });
+  test = craneLib.cargoTest (commonArgs // {
+    inherit cargoArtifacts;
+    cargoTestExtraArgs = "--workspace";
+  });
 
   clippy = craneLib.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
-    cargoClippyExtraArgs = "--all-targets -- -D clippy::all";
+    cargoClippyExtraArgs = "--workspace --all-targets -- -D clippy::all";
   });
 }

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -914,12 +914,14 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn recover_with_no_running_runs_is_a_noop() {
+        let log_offset = crate::capture_log_offset();
         let (store, projection) = ingestion_store().await;
 
         let recovered = recover_abandoned_runs(&store, &projection).await.unwrap();
 
         assert_eq!(recovered, 0);
-        assert!(!logs_contain_at(
+        assert!(!crate::logs_contain_at_since(
+            log_offset,
             Level::WARN,
             &["abandoned ingestion runs on startup"]
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,14 +987,33 @@ pub async fn rocket(
         ))
 }
 
+/// Byte offset into the shared `tracing_test` buffer at the start of a test.
+///
+/// Capture this before exercising code when parallel tests might append unrelated
+/// log lines to the same global buffer.
+#[cfg(test)]
+pub(crate) fn capture_log_offset() -> usize {
+    tracing_test::internal::global_buf().lock().unwrap().len()
+}
+
 /// Asserts that a log line at the given level contains all snippets.
 ///
 /// Use with `tracing_test::traced_test` to verify observability.
 #[cfg(test)]
 pub(crate) fn logs_contain_at(level: tracing::Level, snippets: &[&str]) -> bool {
+    logs_contain_at_since(0, level, snippets)
+}
+
+/// Like [`logs_contain_at`], but only inspects log bytes appended after `since`.
+#[cfg(test)]
+pub(crate) fn logs_contain_at_since(
+    since: usize,
+    level: tracing::Level,
+    snippets: &[&str],
+) -> bool {
     let logs = {
         let buf = tracing_test::internal::global_buf().lock().unwrap();
-        String::from_utf8_lossy(&buf).into_owned()
+        String::from_utf8_lossy(&buf[since..]).into_owned()
     };
 
     let level_str = match level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1722,6 +1722,20 @@ mod tests {
             body["drawdown"]["peakToTroughPeriods"].as_u64().is_some(),
             "peakToTroughPeriods is an integer"
         );
+
+        let correlation_rows = body["correlation"]["matrix"]
+            .as_array()
+            .expect("correlation matrix is an array of rows");
+        assert_eq!(correlation_rows.len(), 2);
+        assert_eq!(
+            body["correlation"]["matrix"][0][0].as_f64(),
+            Some(1.0),
+            "correlation diagonal is exactly 1"
+        );
+        assert!(
+            body["correlation"]["shrinkageIntensity"].as_f64().is_some(),
+            "shrinkageIntensity is a number"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1736,6 +1736,14 @@ mod tests {
             body["correlation"]["shrinkageIntensity"].as_f64().is_some(),
             "shrinkageIntensity is a number"
         );
+
+        for bets_key in ["meucci", "stressedMeucci", "inverseHerfindahl"] {
+            let count = body["effectiveBets"][bets_key].as_f64().unwrap_or(f64::NAN);
+            assert!(
+                (1.0 - 1e-9..=2.0 + 1e-9).contains(&count),
+                "effectiveBets.{bets_key} must be a number within [1, 2], got {count}"
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,6 +850,57 @@ fn spawn_ingestion_scheduler(
     });
 }
 
+async fn connect_database_pool(
+    database_url: &str,
+) -> Result<SqlitePool, Box<dyn std::error::Error + Send + Sync>> {
+    let database_options = SqliteConnectOptions::from_str(database_url)?
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(std::time::Duration::from_secs(5));
+    let pool = SqlitePool::connect_with(database_options).await?;
+    debug!("database connected");
+
+    // We own the apalis `Jobs`/`Workers` tables as consumer migrations rather
+    // than calling apalis-sqlite's own migrator, which would compete with ours
+    // over the shared `_sqlx_migrations` table. `ignore_missing` tolerates the
+    // apalis-sql 0.7 migration records left in databases provisioned before the
+    // upgrade, so those rows do not fail the migrator.
+    let mut migrations = sqlx::migrate!("./migrations");
+    migrations.set_ignore_missing(true).run(&pool).await?;
+    debug!(count = migrations.iter().count(), "migrations applied");
+
+    Ok(pool)
+}
+
+fn mount_api_routes(rocket: Rocket<rocket::Build>) -> Rocket<rocket::Build> {
+    rocket.mount(
+        "/",
+        routes![
+            health,
+            get_candles,
+            get_factors,
+            post_portfolio_create,
+            post_portfolio_target,
+            get_portfolio,
+            list_portfolios,
+            post_portfolio_rename,
+            post_portfolio_archive,
+            post_screener,
+            post_portfolio_compare,
+            post_portfolio_simulate,
+            post_risk,
+            start_ingestion,
+            get_ingestion_status,
+            post_market_disable,
+            post_market_enable,
+            get_markets,
+            get_markets_leverage,
+            post_beta,
+            post_portfolio_readonly_btc,
+            post_portfolio_exposure
+        ],
+    )
+}
+
 /// Build and configure the Rocket HTTP server for the moneymentum backend.
 ///
 /// # Errors
@@ -869,20 +920,7 @@ pub async fn rocket(
         ..RocketConfig::default()
     };
 
-    let database_options = SqliteConnectOptions::from_str(&config.database_url)?
-        .journal_mode(SqliteJournalMode::Wal)
-        .busy_timeout(std::time::Duration::from_secs(5));
-    let pool = SqlitePool::connect_with(database_options).await?;
-    debug!("database connected");
-
-    // We own the apalis `Jobs`/`Workers` tables as consumer migrations rather
-    // than calling apalis-sqlite's own migrator, which would compete with ours
-    // over the shared `_sqlx_migrations` table. `ignore_missing` tolerates the
-    // apalis-sql 0.7 migration records left in databases provisioned before the
-    // upgrade, so those rows do not fail the migrator.
-    let mut migrations = sqlx::migrate!("./migrations");
-    migrations.set_ignore_missing(true).run(&pool).await?;
-    debug!(count = migrations.iter().count(), "migrations applied");
+    let pool = connect_database_pool(&config.database_url).await?;
 
     // One Store + Projection per event-sourced aggregate, built once here and
     // shared via Rocket state. `build()` reconciles the schema registry (clearing
@@ -947,44 +985,19 @@ pub async fn rocket(
     debug!("ingestion scheduler started");
 
     info!(port = config.port, "moneymentum ready");
-    Ok(rocket::custom(rocket_config)
-        .manage(config)
-        .manage(pool)
-        .manage(apalis_pool)
-        .manage(portfolio_store)
-        .manage(portfolio_projection)
-        .manage(ingestion_store)
-        .manage(ingestion_projection)
-        .manage(market_enablement)
-        .manage(market_enablement_projection)
-        .manage(market_catalog_projection)
-        .mount(
-            "/",
-            routes![
-                health,
-                get_candles,
-                get_factors,
-                post_portfolio_create,
-                post_portfolio_target,
-                get_portfolio,
-                list_portfolios,
-                post_portfolio_rename,
-                post_portfolio_archive,
-                post_screener,
-                post_portfolio_compare,
-                post_portfolio_simulate,
-                post_risk,
-                start_ingestion,
-                get_ingestion_status,
-                post_market_disable,
-                post_market_enable,
-                get_markets,
-                get_markets_leverage,
-                post_beta,
-                post_portfolio_readonly_btc,
-                post_portfolio_exposure
-            ],
-        ))
+    Ok(mount_api_routes(
+        rocket::custom(rocket_config)
+            .manage(config)
+            .manage(pool)
+            .manage(apalis_pool)
+            .manage(portfolio_store)
+            .manage(portfolio_projection)
+            .manage(ingestion_store)
+            .manage(ingestion_projection)
+            .manage(market_enablement)
+            .manage(market_enablement_projection)
+            .manage(market_catalog_projection),
+    ))
 }
 
 /// Byte offset into the shared `tracing_test` buffer at the start of a test.

--- a/src/portfolio_comparison.rs
+++ b/src/portfolio_comparison.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::debug;
 
+use crate::finance::Symbol;
+
 /// A request to compare target vs current portfolio weights.
 ///
 /// Weights are signed proportions (negative for shorts); a symbol absent from a
@@ -17,8 +19,8 @@ use tracing::debug;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PortfolioComparisonRequest {
-    target: HashMap<String, f64>,
-    current: HashMap<String, f64>,
+    target: HashMap<Symbol, f64>,
+    current: HashMap<Symbol, f64>,
     min_tradable_change: f64,
 }
 
@@ -26,7 +28,7 @@ pub(crate) struct PortfolioComparisonRequest {
 #[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PositionComparison {
-    symbol: String,
+    symbol: Symbol,
     target_weight: f64,
     current_weight: f64,
     delta: f64,
@@ -69,7 +71,7 @@ pub(crate) fn compare_portfolios(
         return Err(ComparisonError::InvalidThreshold);
     }
 
-    let mut symbols: Vec<&String> = request
+    let mut symbols: Vec<&Symbol> = request
         .target
         .keys()
         .chain(request.current.keys())
@@ -118,11 +120,11 @@ mod tests {
         PortfolioComparisonRequest {
             target: target
                 .iter()
-                .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+                .map(|(symbol, weight)| (Symbol::from_raw(symbol), *weight))
                 .collect(),
             current: current
                 .iter()
-                .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+                .map(|(symbol, weight)| (Symbol::from_raw(symbol), *weight))
                 .collect(),
             min_tradable_change,
         }
@@ -131,7 +133,7 @@ mod tests {
     fn row<'a>(comparisons: &'a [PositionComparison], symbol: &str) -> &'a PositionComparison {
         comparisons
             .iter()
-            .find(|row| row.symbol == symbol)
+            .find(|row| row.symbol.as_str() == symbol)
             .expect("symbol present")
     }
 

--- a/src/risk.rs
+++ b/src/risk.rs
@@ -183,6 +183,24 @@ pub(crate) struct Drawdown {
     peak_to_trough_periods: usize,
 }
 
+/// The shrunk correlation matrix across held positions over the measurement
+/// window.
+///
+/// Estimated on per-asset log returns: the sample covariance is shrunk toward
+/// the constant-correlation target with the closed-form Ledoit-Wolf intensity
+/// before converting to correlations, regularizing near-degenerate sample
+/// estimates (methodology doc, decision 2). The reported matrix is the shrunk
+/// one; `shrinkage_intensity` in `[0, 1]` says how far it moved from the
+/// sample estimate (`0` = pure sample covariance).
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CorrelationReport {
+    tickers: Vec<String>,
+    /// Row-major entries ordered like `tickers`; symmetric with unit diagonal.
+    matrix: Vec<Vec<f64>>,
+    shrinkage_intensity: f64,
+}
+
 /// Risk analytics for the active portfolio: the resolved measurement contract
 /// plus every metric computed under it.
 #[derive(Debug, Serialize)]
@@ -191,6 +209,7 @@ pub(crate) struct RiskResponse {
     contract: MeasurementContract,
     tail_risk: Vec<TailRisk>,
     drawdown: Drawdown,
+    correlation: CorrelationReport,
 }
 
 /// Errors from assessing risk: contract validation, candle data access, or a
@@ -211,6 +230,8 @@ pub(crate) enum RiskAssessmentError {
         "only {observations} portfolio returns in the window, need at least {MIN_PORTFOLIO_RETURNS}"
     )]
     InsufficientObservations { observations: usize },
+    #[error("ticker {ticker} has zero return variance in the window, correlation is undefined")]
+    ZeroVarianceTicker { ticker: String },
 }
 
 /// Assesses the active portfolio's risk: resolves the measurement contract,
@@ -227,13 +248,16 @@ pub(crate) async fn assess_risk(
         .await?
         .ok_or(RiskAssessmentError::NoData { path })?;
 
-    let portfolio_returns = portfolio_simple_returns(&candles, &contract, &request.weights)?;
+    let log_returns_by_ticker = log_returns_in_window(&candles, &contract, &request.weights)?;
+    let portfolio_returns = aggregate_in_simple_space(&log_returns_by_ticker, &request.weights)?;
     let tail_risk = compute_tail_risk(&portfolio_returns, &contract.confidence_levels)?;
     let drawdown = compute_drawdown(&portfolio_returns);
+    let correlation = compute_correlation(&log_returns_by_ticker)?;
     debug!(
         observations = portfolio_returns.len(),
         levels = tail_risk.len(),
         max_drawdown = drawdown.max_drawdown,
+        shrinkage_intensity = correlation.shrinkage_intensity,
         "risk metrics computed"
     );
 
@@ -241,6 +265,7 @@ pub(crate) async fn assess_risk(
         contract,
         tail_risk,
         drawdown,
+        correlation,
     })
 }
 
@@ -326,21 +351,307 @@ fn parse_date(value: &str) -> Result<NaiveDate, RiskError> {
     })
 }
 
-/// The portfolio's simple-return series over the contract window at the
-/// contract sampling frequency, ordered chronologically.
-///
-/// Per-asset log returns are aggregated in simple-return space
-/// (`sum_i w_i * (exp(r_i) - 1)`) on the dates where every weighted ticker has
-/// a return.
-fn portfolio_simple_returns(
+/// Each weighted ticker's log returns over the contract window at the contract
+/// sampling frequency -- the shared estimation input for every metric.
+fn log_returns_in_window(
     candles: &DataFrame,
     contract: &MeasurementContract,
     weights: &HashMap<String, f64>,
-) -> Result<Vec<f64>, RiskAssessmentError> {
+) -> Result<BTreeMap<String, BTreeMap<NaiveDate, f64>>, RiskAssessmentError> {
     let closes_by_ticker = window_closes_by_ticker(candles, contract.window, weights)?;
     let sampled_closes = sample_closes(closes_by_ticker, contract.sampling_frequency);
-    let log_returns_by_ticker = per_ticker_log_returns(sampled_closes);
-    aggregate_in_simple_space(&log_returns_by_ticker, weights)
+    Ok(per_ticker_log_returns(sampled_closes))
+}
+
+/// The Ledoit-Wolf-shrunk correlation matrix over the tickers' log returns on
+/// their common dates.
+///
+/// The sample covariance (maximum-likelihood, `1/T`) is shrunk toward the
+/// constant-correlation target with the closed-form optimal intensity
+/// (Ledoit & Wolf 2004, "Honey, I Shrunk the Sample Covariance Matrix"), then
+/// converted to a correlation matrix.
+fn compute_correlation(
+    log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+) -> Result<CorrelationReport, RiskAssessmentError> {
+    let DemeanedReturns {
+        tickers,
+        demeaned_columns,
+        observations,
+    } = demeaned_return_columns(log_returns_by_ticker)?;
+    let scale = f64::from(observations);
+
+    let covariance: Vec<Vec<f64>> = demeaned_columns
+        .iter()
+        .map(|left_column| {
+            demeaned_columns
+                .iter()
+                .map(|right_column| inner_product(left_column, right_column) / scale)
+                .collect()
+        })
+        .collect();
+    let variances: Vec<f64> = demeaned_columns
+        .iter()
+        .map(|column| inner_product(column, column) / scale)
+        .collect();
+    if let Some((ticker, _)) = tickers
+        .iter()
+        .zip(&variances)
+        .find(|(_, variance)| **variance <= 0.0)
+    {
+        return Err(RiskAssessmentError::ZeroVarianceTicker {
+            ticker: ticker.clone(),
+        });
+    }
+
+    let average_correlation = average_pairwise_correlation(&covariance, &variances);
+    let shrinkage_intensity = ledoit_wolf_intensity(
+        &demeaned_columns,
+        &covariance,
+        &variances,
+        average_correlation,
+        scale,
+    );
+
+    let matrix: Vec<Vec<f64>> = variances
+        .iter()
+        .zip(&covariance)
+        .enumerate()
+        .map(|(row_index, (left_variance, covariance_row))| {
+            variances
+                .iter()
+                .zip(covariance_row)
+                .enumerate()
+                .map(|(col_index, (right_variance, sample_entry))| {
+                    if row_index == col_index {
+                        return 1.0;
+                    }
+                    let denominator = (left_variance * right_variance).sqrt();
+                    let target_entry = average_correlation * denominator;
+                    let shrunk_entry =
+                        shrinkage_intensity.mul_add(target_entry - sample_entry, *sample_entry);
+
+                    shrunk_entry / denominator
+                })
+                .collect()
+        })
+        .collect();
+
+    Ok(CorrelationReport {
+        tickers,
+        matrix,
+        shrinkage_intensity,
+    })
+}
+
+/// Per-ticker demeaned log-return columns on the dates shared by every ticker.
+struct DemeanedReturns {
+    tickers: Vec<String>,
+    demeaned_columns: Vec<Vec<f64>>,
+    observations: u32,
+}
+
+/// Demeans each ticker's log returns on the dates shared by every ticker.
+fn demeaned_return_columns(
+    log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+) -> Result<DemeanedReturns, RiskAssessmentError> {
+    let common_dates: BTreeSet<NaiveDate> = log_returns_by_ticker
+        .values()
+        .map(|log_returns| log_returns.keys().copied().collect::<BTreeSet<NaiveDate>>())
+        .reduce(|common, dates| common.intersection(&dates).copied().collect())
+        .unwrap_or_default();
+    let observations = common_dates.len();
+    if observations < MIN_PORTFOLIO_RETURNS {
+        return Err(RiskAssessmentError::InsufficientObservations { observations });
+    }
+    let observations = u32::try_from(observations)
+        .map_err(|_| RiskAssessmentError::InsufficientObservations { observations: 0 })?;
+    let scale = f64::from(observations);
+
+    let tickers: Vec<String> = log_returns_by_ticker.keys().cloned().collect();
+    let demeaned_columns: Vec<Vec<f64>> = log_returns_by_ticker
+        .values()
+        .map(|log_returns| {
+            let column: Vec<f64> = common_dates
+                .iter()
+                .filter_map(|date| log_returns.get(date).copied())
+                .collect();
+            let mean: f64 = column.iter().sum::<f64>() / scale;
+
+            column.iter().map(|log_return| log_return - mean).collect()
+        })
+        .collect();
+
+    Ok(DemeanedReturns {
+        tickers,
+        demeaned_columns,
+        observations,
+    })
+}
+
+/// Sum of elementwise products of two equally long columns.
+fn inner_product(left_column: &[f64], right_column: &[f64]) -> f64 {
+    left_column
+        .iter()
+        .zip(right_column)
+        .map(|(left_value, right_value)| left_value * right_value)
+        .sum()
+}
+
+/// Mean of the sample correlations over distinct ticker pairs; zero for a
+/// single-ticker portfolio, where the constant-correlation target has no
+/// off-diagonal entries.
+fn average_pairwise_correlation(covariance: &[Vec<f64>], variances: &[f64]) -> f64 {
+    let pair_correlations: Vec<f64> = covariance
+        .iter()
+        .zip(variances)
+        .enumerate()
+        .flat_map(|(row_index, (covariance_row, left_variance))| {
+            covariance_row
+                .iter()
+                .zip(variances)
+                .skip(row_index + 1)
+                .map(move |(sample_entry, right_variance)| {
+                    sample_entry / (left_variance * right_variance).sqrt()
+                })
+        })
+        .collect();
+    if pair_correlations.is_empty() {
+        return 0.0;
+    }
+
+    let pair_count = u32::try_from(pair_correlations.len()).unwrap_or(u32::MAX);
+    pair_correlations.iter().sum::<f64>() / f64::from(pair_count)
+}
+
+/// The closed-form optimal shrinkage intensity toward the constant-correlation
+/// target (Ledoit & Wolf 2004): `clamp(((pi - rho) / gamma) / T, 0, 1)`, where
+/// `pi` estimates the variance of the sample covariance entries, `rho` its
+/// covariance with the target, and `gamma` the target's distance from the
+/// sample. A sample already on the target (`gamma = 0`) needs no shrinkage.
+fn ledoit_wolf_intensity(
+    demeaned_columns: &[Vec<f64>],
+    covariance: &[Vec<f64>],
+    variances: &[f64],
+    average_correlation: f64,
+    scale: f64,
+) -> f64 {
+    let pi_estimate: f64 = demeaned_columns
+        .iter()
+        .zip(covariance)
+        .map(|(left_column, covariance_row)| {
+            demeaned_columns
+                .iter()
+                .zip(covariance_row)
+                .map(|(right_column, sample_entry)| {
+                    left_column
+                        .iter()
+                        .zip(right_column)
+                        .map(|(left_value, right_value)| {
+                            (left_value * right_value - sample_entry).powi(2)
+                        })
+                        .sum::<f64>()
+                        / scale
+                })
+                .sum::<f64>()
+        })
+        .sum();
+
+    let rho_diagonal: f64 = demeaned_columns
+        .iter()
+        .zip(variances)
+        .map(|(column, variance)| {
+            column
+                .iter()
+                .map(|value| (value * value - variance).powi(2))
+                .sum::<f64>()
+                / scale
+        })
+        .sum();
+    let rho_off_diagonal: f64 = demeaned_columns
+        .iter()
+        .zip(variances)
+        .zip(covariance)
+        .enumerate()
+        .map(
+            |(row_index, ((left_column, left_variance), covariance_row))| {
+                demeaned_columns
+                    .iter()
+                    .zip(variances)
+                    .zip(covariance_row)
+                    .enumerate()
+                    .filter(|(col_index, _)| *col_index != row_index)
+                    .map(|(_, ((right_column, right_variance), sample_entry))| {
+                        let theta_left = asymptotic_covariance_with_variance(
+                            left_column,
+                            right_column,
+                            *left_variance,
+                            *sample_entry,
+                            scale,
+                        );
+                        let theta_right = asymptotic_covariance_with_variance(
+                            right_column,
+                            left_column,
+                            *right_variance,
+                            *sample_entry,
+                            scale,
+                        );
+
+                        (average_correlation / 2.0)
+                            * (right_variance / left_variance).sqrt().mul_add(
+                                theta_left,
+                                (left_variance / right_variance).sqrt() * theta_right,
+                            )
+                    })
+                    .sum::<f64>()
+            },
+        )
+        .sum();
+    let rho_estimate = rho_diagonal + rho_off_diagonal;
+
+    let gamma_estimate: f64 = variances
+        .iter()
+        .zip(covariance)
+        .enumerate()
+        .map(|(row_index, (left_variance, covariance_row))| {
+            variances
+                .iter()
+                .zip(covariance_row)
+                .enumerate()
+                .filter(|(col_index, _)| *col_index != row_index)
+                .map(|(_, (right_variance, sample_entry))| {
+                    average_correlation
+                        .mul_add((left_variance * right_variance).sqrt(), -sample_entry)
+                        .powi(2)
+                })
+                .sum::<f64>()
+        })
+        .sum();
+
+    if gamma_estimate <= f64::EPSILON {
+        return 0.0;
+    }
+
+    (((pi_estimate - rho_estimate) / gamma_estimate) / scale).clamp(0.0, 1.0)
+}
+
+/// `theta` term of the Ledoit-Wolf `rho`: the asymptotic covariance between a
+/// ticker's sample variance and a pair's sample covariance,
+/// `(1/T) sum_t (x_t^2 - s_xx)(x_t y_t - s_xy)`.
+fn asymptotic_covariance_with_variance(
+    own_column: &[f64],
+    other_column: &[f64],
+    own_variance: f64,
+    sample_entry: f64,
+    scale: f64,
+) -> f64 {
+    own_column
+        .iter()
+        .zip(other_column)
+        .map(|(own_value, other_value)| {
+            (own_value * own_value - own_variance) * (own_value * other_value - sample_entry)
+        })
+        .sum::<f64>()
+        / scale
 }
 
 /// Historical VaR and Acerbi-Tasche CVaR of the portfolio return series at
@@ -818,6 +1129,17 @@ mod tests {
         .unwrap()
     }
 
+    /// Runs the shared return pipeline (window, sampling, log returns) and the
+    /// simple-space aggregation for a request, as `assess_risk` does.
+    fn portfolio_returns_for(
+        candles: &DataFrame,
+        request: &RiskRequest,
+    ) -> Result<Vec<f64>, RiskAssessmentError> {
+        let contract = resolve_contract(request).unwrap();
+        let log_returns = log_returns_in_window(candles, &contract, &request.weights)?;
+        aggregate_in_simple_space(&log_returns, &request.weights)
+    }
+
     #[test]
     fn aggregates_portfolio_returns_in_simple_space() {
         let candles = candle_frame(&[
@@ -829,9 +1151,8 @@ mod tests {
             ("2024-01-03", "ETH", 189.0),
         ]);
         let request = request_with(&[("BTC", 0.5), ("ETH", 0.5)]);
-        let contract = resolve_contract(&request).unwrap();
 
-        let returns = portfolio_simple_returns(&candles, &contract, &request.weights).unwrap();
+        let returns = portfolio_returns_for(&candles, &request).unwrap();
 
         // Simple-space aggregation: r_p = sum_i w_i * (close_t/close_{t-1} - 1),
         // NOT exp(sum of weighted log returns) - 1.
@@ -853,9 +1174,8 @@ mod tests {
         let candles = candle_frame(&rows);
         let mut request = request_with(&[("BTC", 1.0)]);
         request.sampling_frequency = Some(SamplingFrequency::Weekly);
-        let contract = resolve_contract(&request).unwrap();
 
-        let returns = portfolio_simple_returns(&candles, &contract, &request.weights).unwrap();
+        let returns = portfolio_returns_for(&candles, &request).unwrap();
 
         // Week-end closes are Jan 7 (107), Jan 14 (114), Jan 15 (115).
         assert_eq!(returns.len(), 2);
@@ -878,9 +1198,8 @@ mod tests {
         let candles = candle_frame(&rows);
         let mut request = request_with(&[("BTC", 1.0)]);
         request.lookback_days = Some(30);
-        let contract = resolve_contract(&request).unwrap();
 
-        let returns = portfolio_simple_returns(&candles, &contract, &request.weights).unwrap();
+        let returns = portfolio_returns_for(&candles, &request).unwrap();
 
         // 30 lookback days anchored on the latest close keep 31 closes -> 30 returns.
         assert_eq!(returns.len(), 30);
@@ -902,9 +1221,8 @@ mod tests {
         let mut request = request_with(&[("BTC", 1.0)]);
         request.start_date = Some("2024-01-01".to_string());
         request.end_date = Some("2024-01-31".to_string());
-        let contract = resolve_contract(&request).unwrap();
 
-        let returns = portfolio_simple_returns(&candles, &contract, &request.weights).unwrap();
+        let returns = portfolio_returns_for(&candles, &request).unwrap();
 
         // Jan 1 through Jan 31 inclusive is 31 closes -> 30 returns.
         assert_eq!(returns.len(), 30);
@@ -914,9 +1232,8 @@ mod tests {
     fn errors_when_a_weighted_ticker_has_no_data_in_window() {
         let candles = candle_frame(&[("2024-01-01", "BTC", 100.0), ("2024-01-02", "BTC", 110.0)]);
         let request = request_with(&[("BTC", 0.5), ("DOGE", 0.5)]);
-        let contract = resolve_contract(&request).unwrap();
 
-        let result = portfolio_simple_returns(&candles, &contract, &request.weights);
+        let result = portfolio_returns_for(&candles, &request);
 
         assert!(matches!(
             result,
@@ -928,9 +1245,8 @@ mod tests {
     fn errors_when_the_window_yields_too_few_returns() {
         let candles = candle_frame(&[("2024-01-01", "BTC", 100.0), ("2024-01-02", "BTC", 110.0)]);
         let request = request_with(&[("BTC", 1.0)]);
-        let contract = resolve_contract(&request).unwrap();
 
-        let result = portfolio_simple_returns(&candles, &contract, &request.weights);
+        let result = portfolio_returns_for(&candles, &request);
 
         assert!(matches!(
             result,
@@ -996,6 +1312,191 @@ mod tests {
                 prop_assert!(
                     pair[1].conditional_value_at_risk >= pair[0].conditional_value_at_risk - 1e-12
                 );
+            }
+        }
+    }
+
+    /// Builds the per-ticker log-return map [`compute_correlation`] consumes,
+    /// with each series keyed on consecutive dates from 2024-01-01.
+    fn log_returns_map(series: &[(&str, &[f64])]) -> BTreeMap<String, BTreeMap<NaiveDate, f64>> {
+        series
+            .iter()
+            .map(|(ticker, log_returns)| {
+                let by_date = log_returns
+                    .iter()
+                    .enumerate()
+                    .map(|(day_offset, log_return)| {
+                        let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
+                            + chrono::Days::new(u64::try_from(day_offset).unwrap());
+                        (date, *log_return)
+                    })
+                    .collect();
+                ((*ticker).to_string(), by_date)
+            })
+            .collect()
+    }
+
+    /// Pearson correlation with maximum-likelihood (`1/T`) normalization, as a
+    /// reference for the two-asset case where shrinkage is a no-op.
+    fn sample_correlation(left: &[f64], right: &[f64]) -> f64 {
+        let observations = u32::try_from(left.len()).unwrap();
+        let scale = f64::from(observations);
+        let left_mean: f64 = left.iter().sum::<f64>() / scale;
+        let right_mean: f64 = right.iter().sum::<f64>() / scale;
+        let covariance: f64 = left
+            .iter()
+            .zip(right)
+            .map(|(left_value, right_value)| (left_value - left_mean) * (right_value - right_mean))
+            .sum::<f64>()
+            / scale;
+        let left_variance: f64 = left
+            .iter()
+            .map(|value| (value - left_mean).powi(2))
+            .sum::<f64>()
+            / scale;
+        let right_variance: f64 = right
+            .iter()
+            .map(|value| (value - right_mean).powi(2))
+            .sum::<f64>()
+            / scale;
+
+        covariance / (left_variance * right_variance).sqrt()
+    }
+
+    #[test]
+    fn two_asset_shrunk_correlation_equals_sample_correlation() {
+        // With two assets the constant-correlation target equals the sample
+        // covariance, so shrinkage cannot move the estimate.
+        let btc_returns = [0.01, 0.02, -0.01, 0.03];
+        let eth_returns = [0.02, 0.01, -0.02, 0.01];
+        let log_returns = log_returns_map(&[("BTC", &btc_returns), ("ETH", &eth_returns)]);
+
+        let report = compute_correlation(&log_returns).unwrap();
+
+        let expected = sample_correlation(&btc_returns, &eth_returns);
+        assert_eq!(report.tickers, vec!["BTC", "ETH"]);
+        assert!((report.matrix[0][1] - expected).abs() < 1e-12);
+        assert!((report.matrix[1][0] - expected).abs() < 1e-12);
+        assert!((report.matrix[0][0] - 1.0).abs() < 1e-12);
+        assert!((report.matrix[1][1] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn identical_assets_report_unit_correlation_without_shrinkage() {
+        let shared_returns = [0.01, -0.02, 0.03, 0.005];
+        let log_returns = log_returns_map(&[
+            ("AAA", &shared_returns),
+            ("BBB", &shared_returns),
+            ("CCC", &shared_returns),
+        ]);
+
+        let report = compute_correlation(&log_returns).unwrap();
+
+        // Perfectly correlated assets already sit on the constant-correlation
+        // target, so the intensity is zero and every entry is 1.
+        assert!(report.shrinkage_intensity.abs() < 1e-12);
+        for row in &report.matrix {
+            for entry in row {
+                assert!(
+                    (entry - 1.0).abs() < 1e-9,
+                    "expected unit correlation, got {entry}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn zero_variance_ticker_makes_correlation_undefined() {
+        let btc_returns = [0.01, 0.02, -0.01, 0.03];
+        let flat_returns = [0.0, 0.0, 0.0, 0.0];
+        let log_returns = log_returns_map(&[("BTC", &btc_returns), ("USDC", &flat_returns)]);
+
+        let result = compute_correlation(&log_returns);
+
+        assert!(matches!(
+            result,
+            Err(RiskAssessmentError::ZeroVarianceTicker { ticker }) if ticker == "USDC"
+        ));
+    }
+
+    #[test]
+    fn shrinkage_intensity_scales_inversely_with_observations() {
+        let first = [0.02, -0.01, 0.03, -0.02, 0.01, 0.04, -0.03, 0.02];
+        let second = [-0.01, 0.02, -0.02, 0.03, -0.01, 0.01, 0.02, -0.02];
+        let third = [0.03, 0.01, -0.01, 0.02, -0.03, 0.02, 0.01, -0.01];
+        let log_returns = log_returns_map(&[("AAA", &first), ("BBB", &second), ("CCC", &third)]);
+        let intensity = compute_correlation(&log_returns)
+            .unwrap()
+            .shrinkage_intensity;
+        assert!(
+            intensity > 0.0 && intensity < 1.0,
+            "fixture must produce an interior intensity, got {intensity}"
+        );
+
+        // Duplicating the sample tenfold leaves every moment estimate unchanged
+        // but divides the optimal intensity kappa/T by ten.
+        let repeat = |values: &[f64]| -> Vec<f64> { values.repeat(10) };
+        let duplicated = log_returns_map(&[
+            ("AAA", &repeat(&first)),
+            ("BBB", &repeat(&second)),
+            ("CCC", &repeat(&third)),
+        ]);
+        let duplicated_intensity = compute_correlation(&duplicated)
+            .unwrap()
+            .shrinkage_intensity;
+
+        assert!(
+            (duplicated_intensity - intensity / 10.0).abs() < 1e-12,
+            "expected {}, got {duplicated_intensity}",
+            intensity / 10.0
+        );
+    }
+
+    proptest! {
+        /// The shrunk correlation matrix is symmetric with a unit diagonal,
+        /// every entry within [-1, 1], and an intensity within [0, 1].
+        #[test]
+        fn shrunk_correlation_is_symmetric_bounded_with_unit_diagonal(
+            first in prop::collection::vec(-0.2_f64..0.2, 6..30),
+            jitter in prop::collection::vec(-0.05_f64..0.05, 6..30),
+        ) {
+            let observations = first.len().min(jitter.len());
+            prop_assume!(observations >= 6);
+            let first: Vec<f64> = first.iter().copied().take(observations).collect();
+            prop_assume!(
+                first.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6)
+            );
+            // Derive two more series with index-dependent tilts so every
+            // column varies and no pair is exactly collinear.
+            let second: Vec<f64> = first
+                .iter()
+                .zip(&jitter)
+                .map(|(base, noise)| -base + noise + 0.001)
+                .collect();
+            let third: Vec<f64> = first
+                .iter()
+                .zip(jitter.iter().rev())
+                .map(|(base, noise)| 0.5 * base + 2.0 * noise - 0.002)
+                .collect();
+            prop_assume!(second.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+            prop_assume!(third.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+
+            let log_returns =
+                log_returns_map(&[("AAA", &first), ("BBB", &second), ("CCC", &third)]);
+            let report = compute_correlation(&log_returns).unwrap();
+
+            prop_assert!((0.0..=1.0).contains(&report.shrinkage_intensity));
+            for (row_index, row) in report.matrix.iter().enumerate() {
+                for (col_index, entry) in row.iter().enumerate() {
+                    if row_index == col_index {
+                        prop_assert!((entry - 1.0).abs() < 1e-12);
+                    } else {
+                        prop_assert!(entry.abs() <= 1.0 + 1e-9);
+                        prop_assert!(
+                            (entry - report.matrix[col_index][row_index]).abs() < 1e-12
+                        );
+                    }
+                }
             }
         }
     }
@@ -1073,6 +1574,13 @@ mod tests {
             "the fixture's oscillating closes must produce a real drawdown, got {}",
             response.drawdown.max_drawdown
         );
+        assert_eq!(response.correlation.tickers, vec!["BTC", "ETH"]);
+        assert!(
+            response.correlation.matrix[0][1].abs() <= 1.0,
+            "off-diagonal correlation must be within [-1, 1], got {}",
+            response.correlation.matrix[0][1]
+        );
+        assert!((0.0..=1.0).contains(&response.correlation.shrinkage_intensity));
         assert!(logs_contain_at(
             Level::DEBUG,
             &["risk metrics computed", "observations=", "max_drawdown="]

--- a/src/risk.rs
+++ b/src/risk.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 use tracing::{debug, instrument};
 
 use crate::dataframe::DataFrameError;
+use crate::finance::Symbol;
 use crate::timeframe::Timeframe;
 
 /// Inclusive lower bound on the measurement window, in days (story 0x01b).
@@ -42,8 +43,6 @@ pub(crate) enum RiskError {
     LookbackOutOfRange { days: u16 },
     #[error("start_date and end_date must be provided together")]
     IncompleteDateRange,
-    #[error("invalid date {value}, expected YYYY-MM-DD")]
-    InvalidDate { value: String },
     #[error("start_date must be strictly earlier than end_date")]
     NonChronologicalRange,
     #[error("window span {days} days is outside the [{MIN_WINDOW_DAYS}, {MAX_WINDOW_DAYS}] range")]
@@ -129,18 +128,19 @@ pub(crate) enum MeasurementWindow {
 
 /// A request for the active portfolio's risk analytics.
 ///
-/// Dates are `YYYY-MM-DD` strings. When `start_date`/`end_date` are present they
-/// take precedence over `lookback_days`. Weights are signed active-position
-/// proportions and must sum to 1 in absolute value.
+/// Dates arrive as `YYYY-MM-DD` and parse to `NaiveDate` at the serde boundary.
+/// When `start_date`/`end_date` are present they take precedence over
+/// `lookback_days`. Weights are signed active-position proportions, keyed by
+/// `Symbol`, and must sum to 1 in absolute value.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RiskRequest {
     lookback_days: Option<u16>,
-    start_date: Option<String>,
-    end_date: Option<String>,
+    start_date: Option<NaiveDate>,
+    end_date: Option<NaiveDate>,
     sampling_frequency: Option<SamplingFrequency>,
     confidence_levels: Option<Vec<f64>>,
-    weights: HashMap<String, f64>,
+    weights: HashMap<Symbol, f64>,
 }
 
 /// The validated measurement contract every metric shares.
@@ -195,7 +195,7 @@ pub(crate) struct Drawdown {
 #[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CorrelationReport {
-    tickers: Vec<String>,
+    tickers: Vec<Symbol>,
     /// Row-major entries ordered like `tickers`; symmetric with unit diagonal.
     matrix: Vec<Vec<f64>>,
     shrinkage_intensity: f64,
@@ -244,14 +244,14 @@ pub(crate) enum RiskAssessmentError {
     Polars(#[from] polars::prelude::PolarsError),
     #[error("no candle data at {path}")]
     NoData { path: PathBuf },
-    #[error("no candle data for {ticker} in the measurement window")]
-    MissingTickerData { ticker: String },
+    #[error("no candle data for {} in the measurement window", .ticker.as_str())]
+    MissingTickerData { ticker: Symbol },
     #[error(
         "only {observations} portfolio returns in the window, need at least {MIN_PORTFOLIO_RETURNS}"
     )]
     InsufficientObservations { observations: usize },
-    #[error("ticker {ticker} has zero return variance in the window, correlation is undefined")]
-    ZeroVarianceTicker { ticker: String },
+    #[error("ticker {} has zero return variance in the window, correlation is undefined", .ticker.as_str())]
+    ZeroVarianceTicker { ticker: Symbol },
     #[error("portfolio variance is zero under the estimated covariance, effective bets undefined")]
     DegenerateCovariance,
 }
@@ -319,10 +319,8 @@ fn resolve_contract(request: &RiskRequest) -> Result<MeasurementContract, RiskEr
 }
 
 fn resolve_window(request: &RiskRequest) -> Result<MeasurementWindow, RiskError> {
-    match (&request.start_date, &request.end_date) {
-        (Some(start), Some(end)) => {
-            let start_date = parse_date(start)?;
-            let end_date = parse_date(end)?;
+    match (request.start_date, request.end_date) {
+        (Some(start_date), Some(end_date)) => {
             if start_date >= end_date {
                 return Err(RiskError::NonChronologicalRange);
             }
@@ -360,7 +358,7 @@ fn resolve_confidence_levels(levels: Option<&[f64]>) -> Result<Vec<ConfidenceLev
 
 /// Validates active-position weights: non-empty and summing to 1 in absolute
 /// value. The weights themselves are consumed by the metrics as they land.
-fn validate_weights(weights: &HashMap<String, f64>) -> Result<(), RiskError> {
+fn validate_weights(weights: &HashMap<Symbol, f64>) -> Result<(), RiskError> {
     if weights.is_empty() {
         return Err(RiskError::EmptyWeights);
     }
@@ -371,19 +369,13 @@ fn validate_weights(weights: &HashMap<String, f64>) -> Result<(), RiskError> {
     Ok(())
 }
 
-fn parse_date(value: &str) -> Result<NaiveDate, RiskError> {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| RiskError::InvalidDate {
-        value: value.to_string(),
-    })
-}
-
 /// Each weighted ticker's log returns over the contract window at the contract
 /// sampling frequency -- the shared estimation input for every metric.
 fn log_returns_in_window(
     candles: &DataFrame,
     contract: &MeasurementContract,
-    weights: &HashMap<String, f64>,
-) -> Result<BTreeMap<String, BTreeMap<NaiveDate, f64>>, RiskAssessmentError> {
+    weights: &HashMap<Symbol, f64>,
+) -> Result<BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>, RiskAssessmentError> {
     let closes_by_ticker = window_closes_by_ticker(candles, contract.window, weights)?;
     let sampled_closes = sample_closes(closes_by_ticker, contract.sampling_frequency);
     Ok(per_ticker_log_returns(sampled_closes))
@@ -429,7 +421,7 @@ fn compute_correlation(shrunk: &ShrunkCovariance) -> CorrelationReport {
 /// common dates -- the regularized estimate shared by the correlation matrix
 /// and the effective-number-of-bets calculation.
 struct ShrunkCovariance {
-    tickers: Vec<String>,
+    tickers: Vec<Symbol>,
     /// Row-major shrunk covariance entries ordered like `tickers`; the
     /// diagonal carries the sample variances (the constant-correlation target
     /// leaves variances untouched), all strictly positive.
@@ -439,7 +431,7 @@ struct ShrunkCovariance {
 
 /// Estimates the Ledoit-Wolf-shrunk covariance of the tickers' log returns.
 fn shrunk_covariance(
-    log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+    log_returns_by_ticker: &BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
 ) -> Result<ShrunkCovariance, RiskAssessmentError> {
     let DemeanedReturns {
         tickers,
@@ -523,7 +515,7 @@ const RELATIVE_EIGENVALUE_FLOOR: f64 = 1e-12;
 /// and the inverse-Herfindahl cross-check.
 fn compute_effective_bets(
     shrunk: &ShrunkCovariance,
-    weights: &HashMap<String, f64>,
+    weights: &HashMap<Symbol, f64>,
 ) -> Result<EffectiveBets, RiskAssessmentError> {
     let weight_vector: Vec<f64> = shrunk
         .tickers
@@ -646,14 +638,14 @@ fn covariance_diagonal(covariance: &[Vec<f64>]) -> Vec<f64> {
 
 /// Per-ticker demeaned log-return columns on the dates shared by every ticker.
 struct DemeanedReturns {
-    tickers: Vec<String>,
+    tickers: Vec<Symbol>,
     demeaned_columns: Vec<Vec<f64>>,
     observations: u32,
 }
 
 /// Demeans each ticker's log returns on the dates shared by every ticker.
 fn demeaned_return_columns(
-    log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+    log_returns_by_ticker: &BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
 ) -> Result<DemeanedReturns, RiskAssessmentError> {
     let common_dates: BTreeSet<NaiveDate> = log_returns_by_ticker
         .values()
@@ -668,7 +660,7 @@ fn demeaned_return_columns(
         .map_err(|_| RiskAssessmentError::InsufficientObservations { observations: 0 })?;
     let scale = f64::from(observations);
 
-    let tickers: Vec<String> = log_returns_by_ticker.keys().cloned().collect();
+    let tickers: Vec<Symbol> = log_returns_by_ticker.keys().cloned().collect();
     let demeaned_columns: Vec<Vec<f64>> = log_returns_by_ticker
         .values()
         .map(|log_returns| {
@@ -1009,15 +1001,15 @@ struct DrawdownScan {
 fn window_closes_by_ticker(
     candles: &DataFrame,
     window: MeasurementWindow,
-    weights: &HashMap<String, f64>,
-) -> Result<BTreeMap<String, BTreeMap<NaiveDate, f64>>, RiskAssessmentError> {
+    weights: &HashMap<Symbol, f64>,
+) -> Result<BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>, RiskAssessmentError> {
     let timestamp_column = candles.column("timestamp")?;
     let ticker_column = candles.column("ticker")?;
     let close_column = candles.column("close")?;
 
-    let mut closes_by_ticker: BTreeMap<String, BTreeMap<NaiveDate, f64>> = BTreeMap::new();
+    let mut closes_by_ticker: BTreeMap<Symbol, BTreeMap<NaiveDate, f64>> = BTreeMap::new();
     for row_index in 0..candles.height() {
-        let ticker = string_at(ticker_column, row_index);
+        let ticker = string_at(ticker_column, row_index).map(|raw| Symbol::from_raw(&raw));
         let Some(ticker) = ticker.filter(|ticker| weights.contains_key(ticker)) else {
             continue;
         };
@@ -1081,9 +1073,9 @@ fn window_closes_by_ticker(
 /// The alphabetically first weighted ticker without closes, for deterministic
 /// missing-data errors.
 fn first_missing_ticker(
-    closes_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
-    weights: &HashMap<String, f64>,
-) -> Option<String> {
+    closes_by_ticker: &BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
+    weights: &HashMap<Symbol, f64>,
+) -> Option<Symbol> {
     weights
         .keys()
         .filter(|ticker| !closes_by_ticker.contains_key(*ticker))
@@ -1103,9 +1095,9 @@ fn string_at(column: &polars::prelude::Column, row_index: usize) -> Option<Strin
 /// Resamples each ticker's closes to the sampling frequency: daily passes
 /// through; weekly keeps the last close of each ISO week, keyed by its date.
 fn sample_closes(
-    closes_by_ticker: BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+    closes_by_ticker: BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
     frequency: SamplingFrequency,
-) -> BTreeMap<String, BTreeMap<NaiveDate, f64>> {
+) -> BTreeMap<Symbol, BTreeMap<NaiveDate, f64>> {
     match frequency {
         SamplingFrequency::Daily => closes_by_ticker,
         SamplingFrequency::Weekly => closes_by_ticker
@@ -1133,8 +1125,8 @@ fn last_close_per_iso_week(closes: BTreeMap<NaiveDate, f64>) -> BTreeMap<NaiveDa
 /// Per-ticker log returns between consecutive sampled closes, keyed by the
 /// later close's date.
 fn per_ticker_log_returns(
-    closes_by_ticker: BTreeMap<String, BTreeMap<NaiveDate, f64>>,
-) -> BTreeMap<String, BTreeMap<NaiveDate, f64>> {
+    closes_by_ticker: BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
+) -> BTreeMap<Symbol, BTreeMap<NaiveDate, f64>> {
     closes_by_ticker
         .into_iter()
         .map(|(ticker, closes)| {
@@ -1156,8 +1148,8 @@ fn per_ticker_log_returns(
 /// Aggregates per-ticker log returns into portfolio simple returns on the
 /// dates where every weighted ticker has a return.
 fn aggregate_in_simple_space(
-    log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
-    weights: &HashMap<String, f64>,
+    log_returns_by_ticker: &BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
+    weights: &HashMap<Symbol, f64>,
 ) -> Result<Vec<f64>, RiskAssessmentError> {
     let common_dates: Vec<NaiveDate> = log_returns_by_ticker
         .values()
@@ -1211,7 +1203,7 @@ mod tests {
             confidence_levels: None,
             weights: weights
                 .iter()
-                .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+                .map(|(symbol, weight)| (Symbol::from_raw(symbol), *weight))
                 .collect(),
         }
     }
@@ -1244,8 +1236,8 @@ mod tests {
     fn explicit_range_takes_precedence_and_is_validated() {
         let mut request = request_with(&[("BTC", 1.0)]);
         request.lookback_days = Some(90);
-        request.start_date = Some("2024-01-01".to_string());
-        request.end_date = Some("2024-03-01".to_string());
+        request.start_date = Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        request.end_date = Some(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap());
 
         let contract = resolve_contract(&request).unwrap();
         assert_eq!(
@@ -1260,8 +1252,8 @@ mod tests {
     #[test]
     fn rejects_non_chronological_range() {
         let mut request = request_with(&[("BTC", 1.0)]);
-        request.start_date = Some("2024-03-01".to_string());
-        request.end_date = Some("2024-01-01".to_string());
+        request.start_date = Some(NaiveDate::from_ymd_opt(2024, 3, 1).unwrap());
+        request.end_date = Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
         assert_eq!(
             resolve_contract(&request),
             Err(RiskError::NonChronologicalRange)
@@ -1271,8 +1263,8 @@ mod tests {
     #[test]
     fn rejects_range_span_outside_bounds() {
         let mut request = request_with(&[("BTC", 1.0)]);
-        request.start_date = Some("2024-01-01".to_string());
-        request.end_date = Some("2024-01-10".to_string());
+        request.start_date = Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        request.end_date = Some(NaiveDate::from_ymd_opt(2024, 1, 10).unwrap());
         assert_eq!(
             resolve_contract(&request),
             Err(RiskError::WindowSpanOutOfRange { days: 9 })
@@ -1282,7 +1274,7 @@ mod tests {
     #[test]
     fn rejects_a_half_specified_range() {
         let mut request = request_with(&[("BTC", 1.0)]);
-        request.start_date = Some("2024-01-01".to_string());
+        request.start_date = Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
         assert_eq!(
             resolve_contract(&request),
             Err(RiskError::IncompleteDateRange)
@@ -1420,8 +1412,8 @@ mod tests {
             .collect();
         let candles = candle_frame(&rows);
         let mut request = request_with(&[("BTC", 1.0)]);
-        request.start_date = Some("2024-01-01".to_string());
-        request.end_date = Some("2024-01-31".to_string());
+        request.start_date = Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        request.end_date = Some(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap());
 
         let returns = portfolio_returns_for(&candles, &request).unwrap();
 
@@ -1438,7 +1430,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(RiskAssessmentError::MissingTickerData { ticker }) if ticker == "DOGE"
+            Err(RiskAssessmentError::MissingTickerData { ticker }) if ticker.as_str() == "DOGE"
         ));
     }
 
@@ -1519,7 +1511,7 @@ mod tests {
 
     /// Builds the per-ticker log-return map [`compute_correlation`] consumes,
     /// with each series keyed on consecutive dates from 2024-01-01.
-    fn log_returns_map(series: &[(&str, &[f64])]) -> BTreeMap<String, BTreeMap<NaiveDate, f64>> {
+    fn log_returns_map(series: &[(&str, &[f64])]) -> BTreeMap<Symbol, BTreeMap<NaiveDate, f64>> {
         series
             .iter()
             .map(|(ticker, log_returns)| {
@@ -1532,14 +1524,14 @@ mod tests {
                         (date, *log_return)
                     })
                     .collect();
-                ((*ticker).to_string(), by_date)
+                (Symbol::from_raw(ticker), by_date)
             })
             .collect()
     }
 
     /// Shrinks and converts to correlations in one step, as `assess_risk` does.
     fn correlation_for(
-        log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+        log_returns_by_ticker: &BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
     ) -> Result<CorrelationReport, RiskAssessmentError> {
         Ok(compute_correlation(&shrunk_covariance(
             log_returns_by_ticker,
@@ -1584,7 +1576,10 @@ mod tests {
         let report = correlation_for(&log_returns).unwrap();
 
         let expected = sample_correlation(&btc_returns, &eth_returns);
-        assert_eq!(report.tickers, vec!["BTC", "ETH"]);
+        assert_eq!(
+            report.tickers.iter().map(Symbol::as_str).collect::<Vec<_>>(),
+            ["BTC", "ETH"]
+        );
         assert!((report.matrix[0][1] - expected).abs() < 1e-12);
         assert!((report.matrix[1][0] - expected).abs() < 1e-12);
         assert!((report.matrix[0][0] - 1.0).abs() < 1e-12);
@@ -1625,7 +1620,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(RiskAssessmentError::ZeroVarianceTicker { ticker }) if ticker == "USDC"
+            Err(RiskAssessmentError::ZeroVarianceTicker { ticker }) if ticker.as_str() == "USDC"
         ));
     }
 
@@ -1709,12 +1704,12 @@ mod tests {
 
     /// Shrinks and computes effective bets in one step, as `assess_risk` does.
     fn effective_bets_for(
-        log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+        log_returns_by_ticker: &BTreeMap<Symbol, BTreeMap<NaiveDate, f64>>,
         weights: &[(&str, f64)],
     ) -> Result<EffectiveBets, RiskAssessmentError> {
-        let weights: HashMap<String, f64> = weights
+        let weights: HashMap<Symbol, f64> = weights
             .iter()
-            .map(|(ticker, weight)| ((*ticker).to_string(), *weight))
+            .map(|(ticker, weight)| (Symbol::from_raw(ticker), *weight))
             .collect();
 
         compute_effective_bets(&shrunk_covariance(log_returns_by_ticker)?, &weights)
@@ -1882,7 +1877,10 @@ mod tests {
             "the fixture's oscillating closes must produce a real drawdown, got {}",
             response.drawdown.max_drawdown
         );
-        assert_eq!(response.correlation.tickers, vec!["BTC", "ETH"]);
+        assert_eq!(
+            response.correlation.tickers.iter().map(Symbol::as_str).collect::<Vec<_>>(),
+            ["BTC", "ETH"]
+        );
         assert!(
             response.correlation.matrix[0][1].abs() <= 1.0,
             "off-diagonal correlation must be within [-1, 1], got {}",

--- a/src/risk.rs
+++ b/src/risk.rs
@@ -3,8 +3,8 @@
 //! Every metric shares one measurement contract -- the window, sampling
 //! frequency, and confidence levels -- so they describe the same portfolio under
 //! the same assumptions. This module owns that contract and its validation, and
-//! the metrics computed under it; remaining metric math (correlation, ENB,
-//! Monte Carlo) is added on top as it lands.
+//! the metrics computed under it; remaining metric math (Monte Carlo) is added
+//! on top as it lands.
 //!
 //! Return convention (methodology doc, "Shared foundation"): per-asset returns
 //! are log returns for estimation, but the portfolio aggregates in
@@ -201,6 +201,25 @@ pub(crate) struct CorrelationReport {
     shrinkage_intensity: f64,
 }
 
+/// Effective number of bets for the active weights -- true diversification
+/// accounting for correlations (ten assets that all move together are one
+/// bet).
+///
+/// `meucci` is the exponential entropy of the diversification distribution
+/// over the principal portfolios of the shrunk covariance (Meucci 2009): 1
+/// means all variance sits in one principal direction, the position count
+/// means an even spread. `stressed_meucci` recomputes it with every
+/// off-diagonal correlation forced to 0.85, showing the diversification left
+/// in a co-crash. `inverse_herfindahl` is the correlation-blind
+/// `1 / sum(u_i^2)` cross-check over normalized absolute weights.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EffectiveBets {
+    meucci: f64,
+    stressed_meucci: f64,
+    inverse_herfindahl: f64,
+}
+
 /// Risk analytics for the active portfolio: the resolved measurement contract
 /// plus every metric computed under it.
 #[derive(Debug, Serialize)]
@@ -210,6 +229,7 @@ pub(crate) struct RiskResponse {
     tail_risk: Vec<TailRisk>,
     drawdown: Drawdown,
     correlation: CorrelationReport,
+    effective_bets: EffectiveBets,
 }
 
 /// Errors from assessing risk: contract validation, candle data access, or a
@@ -232,6 +252,8 @@ pub(crate) enum RiskAssessmentError {
     InsufficientObservations { observations: usize },
     #[error("ticker {ticker} has zero return variance in the window, correlation is undefined")]
     ZeroVarianceTicker { ticker: String },
+    #[error("portfolio variance is zero under the estimated covariance, effective bets undefined")]
+    DegenerateCovariance,
 }
 
 /// Assesses the active portfolio's risk: resolves the measurement contract,
@@ -252,12 +274,15 @@ pub(crate) async fn assess_risk(
     let portfolio_returns = aggregate_in_simple_space(&log_returns_by_ticker, &request.weights)?;
     let tail_risk = compute_tail_risk(&portfolio_returns, &contract.confidence_levels)?;
     let drawdown = compute_drawdown(&portfolio_returns);
-    let correlation = compute_correlation(&log_returns_by_ticker)?;
+    let shrunk = shrunk_covariance(&log_returns_by_ticker)?;
+    let correlation = compute_correlation(&shrunk);
+    let effective_bets = compute_effective_bets(&shrunk, &request.weights)?;
     debug!(
         observations = portfolio_returns.len(),
         levels = tail_risk.len(),
         max_drawdown = drawdown.max_drawdown,
         shrinkage_intensity = correlation.shrinkage_intensity,
+        effective_bets = effective_bets.meucci,
         "risk metrics computed"
     );
 
@@ -266,6 +291,7 @@ pub(crate) async fn assess_risk(
         tail_risk,
         drawdown,
         correlation,
+        effective_bets,
     })
 }
 
@@ -370,9 +396,51 @@ fn log_returns_in_window(
 /// constant-correlation target with the closed-form optimal intensity
 /// (Ledoit & Wolf 2004, "Honey, I Shrunk the Sample Covariance Matrix"), then
 /// converted to a correlation matrix.
-fn compute_correlation(
+fn compute_correlation(shrunk: &ShrunkCovariance) -> CorrelationReport {
+    let variances = covariance_diagonal(&shrunk.covariance);
+    let matrix: Vec<Vec<f64>> = variances
+        .iter()
+        .zip(&shrunk.covariance)
+        .enumerate()
+        .map(|(row_index, (left_variance, covariance_row))| {
+            variances
+                .iter()
+                .zip(covariance_row)
+                .enumerate()
+                .map(|(col_index, (right_variance, entry))| {
+                    if row_index == col_index {
+                        1.0
+                    } else {
+                        entry / (left_variance * right_variance).sqrt()
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    CorrelationReport {
+        tickers: shrunk.tickers.clone(),
+        matrix,
+        shrinkage_intensity: shrunk.shrinkage_intensity,
+    }
+}
+
+/// The Ledoit-Wolf-shrunk covariance over the tickers' log returns on their
+/// common dates -- the regularized estimate shared by the correlation matrix
+/// and the effective-number-of-bets calculation.
+struct ShrunkCovariance {
+    tickers: Vec<String>,
+    /// Row-major shrunk covariance entries ordered like `tickers`; the
+    /// diagonal carries the sample variances (the constant-correlation target
+    /// leaves variances untouched), all strictly positive.
+    covariance: Vec<Vec<f64>>,
+    shrinkage_intensity: f64,
+}
+
+/// Estimates the Ledoit-Wolf-shrunk covariance of the tickers' log returns.
+fn shrunk_covariance(
     log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
-) -> Result<CorrelationReport, RiskAssessmentError> {
+) -> Result<ShrunkCovariance, RiskAssessmentError> {
     let DemeanedReturns {
         tickers,
         demeaned_columns,
@@ -412,7 +480,7 @@ fn compute_correlation(
         scale,
     );
 
-    let matrix: Vec<Vec<f64>> = variances
+    let shrunk_entries: Vec<Vec<f64>> = variances
         .iter()
         .zip(&covariance)
         .enumerate()
@@ -423,24 +491,157 @@ fn compute_correlation(
                 .enumerate()
                 .map(|(col_index, (right_variance, sample_entry))| {
                     if row_index == col_index {
-                        return 1.0;
+                        return *sample_entry;
                     }
-                    let denominator = (left_variance * right_variance).sqrt();
-                    let target_entry = average_correlation * denominator;
-                    let shrunk_entry =
-                        shrinkage_intensity.mul_add(target_entry - sample_entry, *sample_entry);
+                    let target_entry =
+                        average_correlation * (left_variance * right_variance).sqrt();
 
-                    shrunk_entry / denominator
+                    shrinkage_intensity.mul_add(target_entry - sample_entry, *sample_entry)
                 })
                 .collect()
         })
         .collect();
 
-    Ok(CorrelationReport {
+    Ok(ShrunkCovariance {
         tickers,
-        matrix,
+        covariance: shrunk_entries,
         shrinkage_intensity,
     })
+}
+
+/// Off-diagonal correlation every pair is forced to in the stressed ENB,
+/// approximating crypto's co-crash regime (methodology doc, decision 2).
+const STRESSED_CORRELATION: f64 = 0.85;
+/// Relative floor applied to eigenvalues before the entropy calculation, so a
+/// rank-deficient sample covariance (more assets than observations) cannot
+/// produce negative variance contributions (methodology must-fix: positive
+/// definiteness before eigendecomposition).
+const RELATIVE_EIGENVALUE_FLOOR: f64 = 1e-12;
+
+/// Effective number of bets for the active weights under the shrunk
+/// covariance: the Meucci entropy headline, its stressed-correlation variant,
+/// and the inverse-Herfindahl cross-check.
+fn compute_effective_bets(
+    shrunk: &ShrunkCovariance,
+    weights: &HashMap<String, f64>,
+) -> Result<EffectiveBets, RiskAssessmentError> {
+    let weight_vector: Vec<f64> = shrunk
+        .tickers
+        .iter()
+        .map(|ticker| {
+            weights
+                .get(ticker)
+                .copied()
+                .ok_or_else(|| RiskAssessmentError::MissingTickerData {
+                    ticker: ticker.clone(),
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let meucci = meucci_effective_bets(&shrunk.covariance, &weight_vector)?;
+    let stressed_meucci =
+        meucci_effective_bets(&stressed_covariance(&shrunk.covariance), &weight_vector)?;
+
+    let absolute_weight_sum: f64 = weight_vector.iter().map(|weight| weight.abs()).sum();
+    let herfindahl: f64 = weight_vector
+        .iter()
+        .map(|weight| (weight.abs() / absolute_weight_sum).powi(2))
+        .sum();
+    let inverse_herfindahl = herfindahl.recip();
+
+    Ok(EffectiveBets {
+        meucci,
+        stressed_meucci,
+        inverse_herfindahl,
+    })
+}
+
+/// Exponential Shannon entropy of the diversification distribution over the
+/// covariance's principal portfolios (Meucci 2009, "Managing Diversification").
+///
+/// Eigenvalues are floored at `RELATIVE_EIGENVALUE_FLOOR` of the largest
+/// before computing variance contributions `lambda_i * w~_i^2`.
+fn meucci_effective_bets(
+    covariance: &[Vec<f64>],
+    weight_vector: &[f64],
+) -> Result<f64, RiskAssessmentError> {
+    let dimension = weight_vector.len();
+    let matrix = nalgebra::DMatrix::from_row_iterator(
+        dimension,
+        dimension,
+        covariance.iter().flat_map(|row| row.iter().copied()),
+    );
+    let eigen = matrix.symmetric_eigen();
+    let largest_eigenvalue = eigen
+        .eigenvalues
+        .iter()
+        .fold(0.0_f64, |largest, eigenvalue| largest.max(*eigenvalue));
+    if largest_eigenvalue <= 0.0 {
+        return Err(RiskAssessmentError::DegenerateCovariance);
+    }
+    let eigenvalue_floor = largest_eigenvalue * RELATIVE_EIGENVALUE_FLOOR;
+
+    let principal_weights =
+        eigen.eigenvectors.transpose() * nalgebra::DVector::from_column_slice(weight_vector);
+    let variance_contributions: Vec<f64> = eigen
+        .eigenvalues
+        .iter()
+        .zip(principal_weights.iter())
+        .map(|(eigenvalue, principal_weight)| {
+            eigenvalue.max(eigenvalue_floor) * principal_weight * principal_weight
+        })
+        .collect();
+    let total_variance: f64 = variance_contributions.iter().sum();
+    if total_variance <= 0.0 {
+        return Err(RiskAssessmentError::DegenerateCovariance);
+    }
+
+    let entropy: f64 = variance_contributions
+        .iter()
+        .map(|contribution| {
+            let probability = contribution / total_variance;
+            if probability > 0.0 {
+                -probability * probability.ln()
+            } else {
+                0.0
+            }
+        })
+        .sum();
+
+    Ok(entropy.exp())
+}
+
+/// The covariance with every pairwise correlation forced to
+/// [`STRESSED_CORRELATION`], keeping the original variances.
+fn stressed_covariance(covariance: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    let variances = covariance_diagonal(covariance);
+
+    variances
+        .iter()
+        .enumerate()
+        .map(|(row_index, left_variance)| {
+            variances
+                .iter()
+                .enumerate()
+                .map(|(col_index, right_variance)| {
+                    if row_index == col_index {
+                        *left_variance
+                    } else {
+                        STRESSED_CORRELATION * (left_variance * right_variance).sqrt()
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// The diagonal of a row-major square matrix.
+fn covariance_diagonal(covariance: &[Vec<f64>]) -> Vec<f64> {
+    covariance
+        .iter()
+        .enumerate()
+        .filter_map(|(index, row)| row.get(index).copied())
+        .collect()
 }
 
 /// Per-ticker demeaned log-return columns on the dates shared by every ticker.
@@ -1336,6 +1537,15 @@ mod tests {
             .collect()
     }
 
+    /// Shrinks and converts to correlations in one step, as `assess_risk` does.
+    fn correlation_for(
+        log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+    ) -> Result<CorrelationReport, RiskAssessmentError> {
+        Ok(compute_correlation(&shrunk_covariance(
+            log_returns_by_ticker,
+        )?))
+    }
+
     /// Pearson correlation with maximum-likelihood (`1/T`) normalization, as a
     /// reference for the two-asset case where shrinkage is a no-op.
     fn sample_correlation(left: &[f64], right: &[f64]) -> f64 {
@@ -1371,7 +1581,7 @@ mod tests {
         let eth_returns = [0.02, 0.01, -0.02, 0.01];
         let log_returns = log_returns_map(&[("BTC", &btc_returns), ("ETH", &eth_returns)]);
 
-        let report = compute_correlation(&log_returns).unwrap();
+        let report = correlation_for(&log_returns).unwrap();
 
         let expected = sample_correlation(&btc_returns, &eth_returns);
         assert_eq!(report.tickers, vec!["BTC", "ETH"]);
@@ -1390,7 +1600,7 @@ mod tests {
             ("CCC", &shared_returns),
         ]);
 
-        let report = compute_correlation(&log_returns).unwrap();
+        let report = correlation_for(&log_returns).unwrap();
 
         // Perfectly correlated assets already sit on the constant-correlation
         // target, so the intensity is zero and every entry is 1.
@@ -1411,7 +1621,7 @@ mod tests {
         let flat_returns = [0.0, 0.0, 0.0, 0.0];
         let log_returns = log_returns_map(&[("BTC", &btc_returns), ("USDC", &flat_returns)]);
 
-        let result = compute_correlation(&log_returns);
+        let result = correlation_for(&log_returns);
 
         assert!(matches!(
             result,
@@ -1425,9 +1635,7 @@ mod tests {
         let second = [-0.01, 0.02, -0.02, 0.03, -0.01, 0.01, 0.02, -0.02];
         let third = [0.03, 0.01, -0.01, 0.02, -0.03, 0.02, 0.01, -0.01];
         let log_returns = log_returns_map(&[("AAA", &first), ("BBB", &second), ("CCC", &third)]);
-        let intensity = compute_correlation(&log_returns)
-            .unwrap()
-            .shrinkage_intensity;
+        let intensity = correlation_for(&log_returns).unwrap().shrinkage_intensity;
         assert!(
             intensity > 0.0 && intensity < 1.0,
             "fixture must produce an interior intensity, got {intensity}"
@@ -1441,9 +1649,7 @@ mod tests {
             ("BBB", &repeat(&second)),
             ("CCC", &repeat(&third)),
         ]);
-        let duplicated_intensity = compute_correlation(&duplicated)
-            .unwrap()
-            .shrinkage_intensity;
+        let duplicated_intensity = correlation_for(&duplicated).unwrap().shrinkage_intensity;
 
         assert!(
             (duplicated_intensity - intensity / 10.0).abs() < 1e-12,
@@ -1483,7 +1689,7 @@ mod tests {
 
             let log_returns =
                 log_returns_map(&[("AAA", &first), ("BBB", &second), ("CCC", &third)]);
-            let report = compute_correlation(&log_returns).unwrap();
+            let report = correlation_for(&log_returns).unwrap();
 
             prop_assert!((0.0..=1.0).contains(&report.shrinkage_intensity));
             for (row_index, row) in report.matrix.iter().enumerate() {
@@ -1497,6 +1703,108 @@ mod tests {
                         );
                     }
                 }
+            }
+        }
+    }
+
+    /// Shrinks and computes effective bets in one step, as `assess_risk` does.
+    fn effective_bets_for(
+        log_returns_by_ticker: &BTreeMap<String, BTreeMap<NaiveDate, f64>>,
+        weights: &[(&str, f64)],
+    ) -> Result<EffectiveBets, RiskAssessmentError> {
+        let weights: HashMap<String, f64> = weights
+            .iter()
+            .map(|(ticker, weight)| ((*ticker).to_string(), *weight))
+            .collect();
+
+        compute_effective_bets(&shrunk_covariance(log_returns_by_ticker)?, &weights)
+    }
+
+    #[test]
+    fn uncorrelated_equal_variance_assets_count_as_independent_bets() {
+        // Orthogonal demeaned series with equal variance: two genuine bets.
+        let first = [0.02, -0.02, 0.02, -0.02];
+        let second = [0.02, 0.02, -0.02, -0.02];
+        let log_returns = log_returns_map(&[("AAA", &first), ("BBB", &second)]);
+
+        let bets = effective_bets_for(&log_returns, &[("AAA", 0.5), ("BBB", 0.5)]).unwrap();
+
+        assert!((bets.meucci - 2.0).abs() < 1e-9, "got {}", bets.meucci);
+        assert!((bets.inverse_herfindahl - 2.0).abs() < 1e-12);
+        // Forcing the pair toward 0.85 correlation concentrates the variance
+        // in one principal direction: the stressed count must drop.
+        assert!(
+            bets.stressed_meucci < bets.meucci && bets.stressed_meucci >= 1.0,
+            "stressed {} vs meucci {}",
+            bets.stressed_meucci,
+            bets.meucci
+        );
+    }
+
+    #[test]
+    fn perfectly_correlated_assets_count_as_one_bet() {
+        let shared_returns = [0.01, -0.02, 0.03, 0.005];
+        let log_returns = log_returns_map(&[("AAA", &shared_returns), ("BBB", &shared_returns)]);
+
+        let bets = effective_bets_for(&log_returns, &[("AAA", 0.5), ("BBB", 0.5)]).unwrap();
+
+        // The SPEC's framing: assets that all move together are one bet, even
+        // though the correlation-blind cross-check still reports two.
+        assert!((bets.meucci - 1.0).abs() < 1e-6, "got {}", bets.meucci);
+        assert!((bets.inverse_herfindahl - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn inverse_herfindahl_uses_normalized_absolute_weights() {
+        let first = [0.02, -0.02, 0.02, -0.02];
+        let second = [0.02, 0.02, -0.02, -0.02];
+        let log_returns = log_returns_map(&[("AAA", &first), ("BBB", &second)]);
+
+        let bets = effective_bets_for(&log_returns, &[("AAA", 0.6), ("BBB", -0.4)]).unwrap();
+
+        // 1 / (0.6^2 + 0.4^2) = 1 / 0.52.
+        assert!((bets.inverse_herfindahl - 1.0 / 0.52).abs() < 1e-12);
+    }
+
+    proptest! {
+        /// Every effective-bets variant lies within [1, N] for any portfolio
+        /// of N varying assets.
+        #[test]
+        fn effective_bets_lie_between_one_and_position_count(
+            first in prop::collection::vec(-0.2_f64..0.2, 6..30),
+            jitter in prop::collection::vec(-0.05_f64..0.05, 6..30),
+            raw_weight in 0.05_f64..0.95,
+        ) {
+            let observations = first.len().min(jitter.len());
+            prop_assume!(observations >= 6);
+            let first: Vec<f64> = first.iter().copied().take(observations).collect();
+            prop_assume!(
+                first.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6)
+            );
+            let second: Vec<f64> = first
+                .iter()
+                .zip(&jitter)
+                .map(|(base, noise)| -base + noise + 0.001)
+                .collect();
+            let third: Vec<f64> = first
+                .iter()
+                .zip(jitter.iter().rev())
+                .map(|(base, noise)| 0.5 * base + 2.0 * noise - 0.002)
+                .collect();
+            prop_assume!(second.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+            prop_assume!(third.windows(2).any(|pair| (pair[0] - pair[1]).abs() > 1e-6));
+
+            let log_returns =
+                log_returns_map(&[("AAA", &first), ("BBB", &second), ("CCC", &third)]);
+            let remainder = (1.0 - raw_weight) / 2.0;
+            let bets = effective_bets_for(
+                &log_returns,
+                &[("AAA", raw_weight), ("BBB", remainder), ("CCC", remainder)],
+            )
+            .unwrap();
+
+            for count in [bets.meucci, bets.stressed_meucci, bets.inverse_herfindahl] {
+                prop_assert!((1.0 - 1e-9..=3.0 + 1e-9).contains(&count), "count {count}");
             }
         }
     }
@@ -1581,6 +1889,16 @@ mod tests {
             response.correlation.matrix[0][1]
         );
         assert!((0.0..=1.0).contains(&response.correlation.shrinkage_intensity));
+        for count in [
+            response.effective_bets.meucci,
+            response.effective_bets.stressed_meucci,
+            response.effective_bets.inverse_herfindahl,
+        ] {
+            assert!(
+                (1.0 - 1e-9..=2.0 + 1e-9).contains(&count),
+                "effective bets must lie within [1, 2] for two positions, got {count}"
+            );
+        }
         assert!(logs_contain_at(
             Level::DEBUG,
             &["risk metrics computed", "observations=", "max_drawdown="]

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -20,8 +20,8 @@ const BENCHMARK_TICKER: &str = "BTC";
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SimulationRequest {
-    current: HashMap<String, f64>,
-    staged: HashMap<String, f64>,
+    current: HashMap<Symbol, f64>,
+    staged: HashMap<Symbol, f64>,
 }
 
 /// Projected metrics for one portfolio. Extended as the risk engine lands.
@@ -59,11 +59,11 @@ pub(crate) async fn simulate(
 /// Projects metrics for a single set of weights.
 async fn project_metrics(
     data_dir: &Path,
-    weights: &HashMap<String, f64>,
+    weights: &HashMap<Symbol, f64>,
 ) -> Result<ProjectedMetrics, ReturnsError> {
     let weights: Vec<(Symbol, f64)> = weights
         .iter()
-        .map(|(symbol, weight)| (Symbol::from_raw(symbol), *weight))
+        .map(|(symbol, weight)| (symbol.clone(), *weight))
         .collect();
     let beta =
         compute_portfolio_beta_report(data_dir, &weights, &Symbol::from_raw(BENCHMARK_TICKER))
@@ -83,10 +83,10 @@ mod tests {
 
     use crate::logs_contain_at;
 
-    fn weights(entries: &[(&str, f64)]) -> HashMap<String, f64> {
+    fn weights(entries: &[(&str, f64)]) -> HashMap<Symbol, f64> {
         entries
             .iter()
-            .map(|(symbol, weight)| ((*symbol).to_string(), *weight))
+            .map(|(symbol, weight)| (Symbol::from_raw(symbol), *weight))
             .collect()
     }
 


### PR DESCRIPTION
## Motivation

Story 0x01b requires a correlation matrix across held positions computed over
the measurement window at the configured sampling frequency. The methodology
proposal (#294) additionally requires the reported matrix to be the
regularized (shrunk) estimate shared with the upcoming ENB and Monte Carlo
work -- a raw sample correlation off a short window is near-degenerate and
unstable. `POST /risk` computed none of this.

## Solution

Implement the closed-form Ledoit-Wolf 2004 ("Honey, I Shrunk the Sample
Covariance Matrix") estimator pinned to the constant-correlation target, as
the methodology prescribes: shrink the sample covariance of per-asset log
returns by the optimal intensity, convert to correlations, and report the
intensity alongside the matrix so consumers know how far the estimate moved
from the raw sample. The estimator is pinned by tests: with two assets the
target equals the sample (shrinkage is a no-op), perfectly correlated assets
need zero shrinkage, duplicating the sample tenfold divides the intensity by
exactly ten, and a property test holds symmetry, unit diagonal, entry bounds,
and intensity bounds. A zero-variance leg (e.g. a flat stablecoin series)
rejects loudly instead of producing NaN.

The shared pipeline now exposes per-ticker log returns so every metric
(VaR/CVaR, drawdown, correlation, and later ENB) estimates from the same
series.

Closes #347

<!-- GitButler Footer Boundary Top -->
---
This is **part 15 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348 👈
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->
