### PR TITLE
feat: show real risk metrics in the portfolio risk panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,7 +233,10 @@ Portfolio risk assessment beyond beta and crash-specific simulations.
       number of bets shipped
       ([#349](https://github.com/data-cartel/moneymentum/issues/349) /
       [#350](https://github.com/data-cartel/moneymentum/pull/350)); Monte Carlo
-      metrics and the frontend pending
+      metrics and stress tests pending
+- [x] Portfolio risk panel wired to `POST /risk` --
+      [#351](https://github.com/data-cartel/moneymentum/issues/351) /
+      [#352](https://github.com/data-cartel/moneymentum/pull/352)
 
 ---
 

--- a/frontend/src/pages/Portfolio/components/RiskPanel.test.tsx
+++ b/frontend/src/pages/Portfolio/components/RiskPanel.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@solidjs/testing-library"
+
+import { RiskPanel } from "./RiskPanel"
+import type { RiskReport, RiskResult } from "../hooks/useRisk"
+
+const riskReport: RiskReport = {
+  contract: {
+    window: { lookbackDays: 90 },
+    samplingFrequency: "daily",
+    confidenceLevels: [0.9, 0.95, 0.99],
+  },
+  tailRisk: [
+    { confidenceLevel: 0.9, var: 0.021, cvar: 0.034 },
+    { confidenceLevel: 0.95, var: 0.029, cvar: 0.041 },
+    { confidenceLevel: 0.99, var: 0.052, cvar: 0.052 },
+  ],
+  drawdown: { maxDrawdown: 0.18, peakToTroughPeriods: 12 },
+  correlation: {
+    tickers: ["BTC", "ETH"],
+    matrix: [
+      [1, 0.82],
+      [0.82, 1],
+    ],
+    shrinkageIntensity: 0.07,
+  },
+  effectiveBets: {
+    meucci: 1.4,
+    stressedMeucci: 1.1,
+    inverseHerfindahl: 1.92,
+  },
+}
+
+const riskResultWith = (overrides: Partial<RiskResult>): RiskResult => ({
+  report: null,
+  isLoading: false,
+  error: null,
+  ...overrides,
+})
+
+describe("RiskPanel", () => {
+  it("shows every shipped metric and the measurement contract", () => {
+    render(() => <RiskPanel risk={riskResultWith({ report: riskReport })} />)
+
+    // The contract baseline is visible alongside the metrics.
+    expect(screen.getByText("90d · daily")).toBeInTheDocument()
+
+    // VaR/CVaR at each configured confidence level.
+    expect(screen.getByText("90%")).toBeInTheDocument()
+    expect(screen.getByText("95%")).toBeInTheDocument()
+    expect(screen.getByText("99%")).toBeInTheDocument()
+    expect(screen.getByText("2.1%")).toBeInTheDocument()
+    expect(screen.getByText("3.4%")).toBeInTheDocument()
+    expect(screen.getByText("2.9%")).toBeInTheDocument()
+    expect(screen.getByText("4.1%")).toBeInTheDocument()
+
+    // Drawdown depth and length.
+    expect(screen.getByText("18.0%")).toBeInTheDocument()
+    expect(screen.getByText("12p")).toBeInTheDocument()
+
+    // Effective number of bets with its stressed and 1/HHI companions.
+    expect(screen.getByText("1.40")).toBeInTheDocument()
+    expect(screen.getByText("1.10")).toBeInTheDocument()
+    expect(screen.getByText("1.92")).toBeInTheDocument()
+
+    // Correlation heatmap over the held tickers, labelled as shrunk.
+    expect(screen.getByText("Correlation (shrunk 7.0%)")).toBeInTheDocument()
+    expect(screen.getAllByText("BTC")).toHaveLength(2)
+    expect(screen.getAllByText("ETH")).toHaveLength(2)
+    expect(screen.getAllByText("0.8")).toHaveLength(2)
+  })
+
+  it("shows a loading state while the risk query is in flight", () => {
+    render(() => <RiskPanel risk={riskResultWith({ isLoading: true })} />)
+
+    expect(screen.getByTestId("risk-loading")).toBeInTheDocument()
+    expect(screen.queryByTestId("risk-error")).not.toBeInTheDocument()
+  })
+
+  it("shows the failure reason when the risk query errors", () => {
+    render(() => (
+      <RiskPanel
+        risk={riskResultWith({
+          error: new Error("no candle data for DOGE in the measurement window"),
+        })}
+      />
+    ))
+
+    expect(screen.getByTestId("risk-error")).toHaveTextContent(
+      "Risk metrics unavailable: no candle data for DOGE in the measurement window",
+    )
+  })
+
+  it("prompts for positions when there is nothing to measure", () => {
+    render(() => <RiskPanel risk={riskResultWith({})} />)
+
+    expect(
+      screen.getByText("Add positions to see risk metrics"),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Portfolio/components/RiskPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/RiskPanel.tsx
@@ -1,56 +1,31 @@
-import { For } from "solid-js"
-
-const COMING_SOON = "coming soon..."
-
-const mockRiskMetrics = {
-  var95: COMING_SOON,
-  var99: COMING_SOON,
-  diversificationRatio: COMING_SOON,
-  effectiveBets: COMING_SOON,
-}
+import { For, Match, Show, Switch } from "solid-js"
+import { Skeleton } from "@/components/ui/skeleton"
+import type {
+  RiskMeasurementContract,
+  RiskReport,
+  RiskResult,
+} from "../hooks/useRisk"
 
 const mockStressTests = [
-  { scenario: "BTC -20%", portfolioImpact: COMING_SOON },
-  { scenario: "SPX -10%", portfolioImpact: COMING_SOON },
-  { scenario: "Rates +200bps", portfolioImpact: COMING_SOON },
+  { scenario: "BTC -20%", portfolioImpact: "TODO" },
+  { scenario: "SPX -10%", portfolioImpact: "TODO" },
+  { scenario: "Rates +200bps", portfolioImpact: "TODO" },
 ]
 
-const mockMonteCarlo = [
-  { bucket: -0.3, frequency: 2 },
-  { bucket: -0.2, frequency: 5 },
-  { bucket: -0.1, frequency: 9 },
-  { bucket: 0, frequency: 12 },
-  { bucket: 0.1, frequency: 8 },
-  { bucket: 0.2, frequency: 4 },
-]
+const formatPercent = (fraction: number): string =>
+  `${(fraction * 100).toFixed(1)}%`
 
-const monteCarloMaxFreq = Math.max(
-  ...mockMonteCarlo.map(monteCarloPoint => monteCarloPoint.frequency),
-)
+const formatConfidence = (confidenceLevel: number): string =>
+  `${Math.round(confidenceLevel * 100)}%`
 
-const correlationAssets = ["BTC", "ETH", "SPX", "GLD"]
+const describeContract = (contract: RiskMeasurementContract): string => {
+  const window =
+    contract.window.lookbackDays !== undefined
+      ? `${contract.window.lookbackDays}d`
+      : `${contract.window.startDate ?? "?"} → ${contract.window.endDate ?? "?"}`
 
-const correlationValues: Record<string, number> = {
-  "BTC|BTC": 1,
-  "BTC|ETH": 0.8,
-  "BTC|SPX": 0.3,
-  "BTC|GLD": 0.1,
-  "ETH|BTC": 0.8,
-  "ETH|ETH": 1,
-  "ETH|SPX": 0.25,
-  "ETH|GLD": 0.05,
-  "SPX|BTC": 0.3,
-  "SPX|ETH": 0.25,
-  "SPX|SPX": 1,
-  "SPX|GLD": -0.2,
-  "GLD|BTC": 0.1,
-  "GLD|ETH": 0.05,
-  "GLD|SPX": -0.2,
-  "GLD|GLD": 1,
+  return `${window} · ${contract.samplingFrequency}`
 }
-
-const getCorrelation = (a1: string, a2: string): number =>
-  correlationValues[`${a1}|${a2}`] ?? 0
 
 const getCorrelationColor = (value: number): string => {
   if (value >= 0.75) return "bg-emerald-500/70 text-emerald-50"
@@ -62,39 +37,167 @@ const getCorrelationColor = (value: number): string => {
   return "bg-muted text-foreground"
 }
 
-export const RiskPanel = () => {
+const RiskMetrics = (props: { report: RiskReport }) => (
+  <>
+    {/* Tail risk at each contract confidence level */}
+    <table class="w-full">
+      <thead>
+        <tr>
+          <th class="p-0.5 text-[10px] text-muted-foreground font-medium text-left">
+            Level
+          </th>
+          <th class="p-0.5 text-[10px] text-muted-foreground font-medium text-right">
+            VaR
+          </th>
+          <th class="p-0.5 text-[10px] text-muted-foreground font-medium text-right">
+            CVaR
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <For each={props.report.tailRisk}>
+          {tailRisk => (
+            <tr>
+              <td class="p-0.5 text-muted-foreground">
+                {formatConfidence(tailRisk.confidenceLevel)}
+              </td>
+              <td class="p-0.5 text-right text-red-400 font-mono">
+                {formatPercent(tailRisk.var)}
+              </td>
+              <td class="p-0.5 text-right text-red-400 font-mono">
+                {formatPercent(tailRisk.cvar)}
+              </td>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+
+    {/* Drawdown and diversification */}
+    <div class="border-t border-border/50 pt-2 grid grid-cols-2 gap-x-4 gap-y-1">
+      <div class="flex justify-between">
+        <span class="text-muted-foreground">Max DD</span>
+        <span class="text-red-400 font-mono">
+          {formatPercent(props.report.drawdown.maxDrawdown)}
+        </span>
+      </div>
+      <div class="flex justify-between">
+        <span class="text-muted-foreground">DD Length</span>
+        <span class="font-mono">
+          {props.report.drawdown.peakToTroughPeriods}p
+        </span>
+      </div>
+      <div class="flex justify-between">
+        <span class="text-muted-foreground">Bets</span>
+        <span class="font-mono">
+          {props.report.effectiveBets.meucci.toFixed(2)}
+        </span>
+      </div>
+      <div class="flex justify-between">
+        <span class="text-muted-foreground">Bets (stress)</span>
+        <span class="font-mono">
+          {props.report.effectiveBets.stressedMeucci.toFixed(2)}
+        </span>
+      </div>
+      <div class="flex justify-between">
+        <span class="text-muted-foreground">1/HHI</span>
+        <span class="font-mono">
+          {props.report.effectiveBets.inverseHerfindahl.toFixed(2)}
+        </span>
+      </div>
+    </div>
+
+    {/* Correlation heatmap (Ledoit-Wolf shrunk) */}
+    <div class="border-t border-border/50 pt-2">
+      <div class="text-[10px] text-muted-foreground font-medium mb-1.5">
+        Correlation (shrunk{" "}
+        {formatPercent(props.report.correlation.shrinkageIntensity)})
+      </div>
+      <table class="w-full">
+        <thead>
+          <tr>
+            <th class="p-0.5" />
+            <For each={props.report.correlation.tickers}>
+              {columnTicker => (
+                <th class="p-0.5 text-[10px] text-muted-foreground font-medium text-center">
+                  {columnTicker}
+                </th>
+              )}
+            </For>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={props.report.correlation.matrix}>
+            {(matrixRow, rowIndex) => (
+              <tr>
+                <td class="p-0.5 text-[10px] text-muted-foreground font-medium">
+                  {props.report.correlation.tickers[rowIndex()]}
+                </td>
+                <For each={matrixRow}>
+                  {(correlation, columnIndex) => (
+                    <td class="p-0.5 text-center">
+                      <div
+                        class={`w-full h-4 flex items-center justify-center rounded text-[9px] font-mono ${getCorrelationColor(
+                          correlation,
+                        )} ${rowIndex() === columnIndex() ? "opacity-40" : ""}`}
+                      >
+                        {correlation.toFixed(1)}
+                      </div>
+                    </td>
+                  )}
+                </For>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+    </div>
+  </>
+)
+
+export const RiskPanel = (props: { risk: RiskResult }) => {
   return (
     <div class="flex-1 border border-border rounded flex flex-col min-w-0">
-      <div class="px-2 py-1 border-b border-border bg-muted/30 font-medium">
-        RISK
+      <div class="px-2 py-1 border-b border-border bg-muted/30 font-medium flex items-center justify-between">
+        <span>RISK</span>
+        <Show when={props.risk.report}>
+          {report => (
+            <span class="text-[10px] text-muted-foreground font-normal">
+              {describeContract(report().contract)}
+            </span>
+          )}
+        </Show>
       </div>
       <div class="flex-1 flex flex-col p-2 gap-3 overflow-auto scrollbar-hide">
-        {/* Top metrics */}
-        <div class="grid grid-cols-2 gap-x-4 gap-y-1">
-          <div class="flex justify-between">
-            <span class="text-muted-foreground">VaR 95%</span>
-            <span class="text-red-400 font-mono">{mockRiskMetrics.var95}</span>
-          </div>
-          <div class="flex justify-between">
-            <span class="text-muted-foreground">VaR 99%</span>
-            <span class="text-red-400 font-mono">{mockRiskMetrics.var99}</span>
-          </div>
-          <div class="flex justify-between">
-            <span class="text-muted-foreground">Diversification</span>
-            <span class="font-mono">
-              {mockRiskMetrics.diversificationRatio}
-            </span>
-          </div>
-          <div class="flex justify-between">
-            <span class="text-muted-foreground">Effective Bets</span>
-            <span class="font-mono">{mockRiskMetrics.effectiveBets}</span>
-          </div>
-        </div>
+        <Switch>
+          <Match when={props.risk.isLoading}>
+            <div class="space-y-2" data-testid="risk-loading">
+              <Skeleton class="h-4 w-full" />
+              <Skeleton class="h-4 w-3/4" />
+              <Skeleton class="h-4 w-5/6" />
+            </div>
+          </Match>
+          <Match when={props.risk.error}>
+            {error => (
+              <div class="text-red-400" data-testid="risk-error">
+                Risk metrics unavailable: {error().message}
+              </div>
+            )}
+          </Match>
+          <Match when={props.risk.report}>
+            {report => <RiskMetrics report={report()} />}
+          </Match>
+          <Match when={true}>
+            <div class="text-muted-foreground">
+              Add positions to see risk metrics
+            </div>
+          </Match>
+        </Switch>
 
-        {/* Stress tests */}
+        {/* Stress tests (not implemented in the backend yet) */}
         <div class="border-t border-border/50 pt-2">
           <div class="text-[10px] text-muted-foreground font-medium mb-1.5">
-            Stress Tests
+            Stress Tests TODO
           </div>
           <div class="space-y-1">
             <For each={mockStressTests}>
@@ -110,77 +213,6 @@ export const RiskPanel = () => {
               )}
             </For>
           </div>
-        </div>
-
-        {/* Monte Carlo */}
-        <div class="border-t border-border/50 pt-2">
-          <div class="text-[10px] text-muted-foreground font-medium mb-1.5">
-            Monte Carlo (1 Year) — coming soon...
-          </div>
-          <div class="flex items-end gap-px h-12">
-            <For each={mockMonteCarlo}>
-              {monteCarloPoint => (
-                <div
-                  class="flex-1"
-                  style={{
-                    "height": `${
-                      (monteCarloPoint.frequency / monteCarloMaxFreq) * 100
-                    }%`,
-                    "background-color":
-                      monteCarloPoint.bucket >= 0 ? "#22c55e" : "#ef4444",
-                  }}
-                />
-              )}
-            </For>
-          </div>
-        </div>
-
-        {/* Correlation heatmap */}
-        <div class="border-t border-border/50 pt-2">
-          <div class="text-[10px] text-muted-foreground font-medium mb-1.5">
-            Correlation — coming soon...
-          </div>
-          <table class="w-full">
-            <thead>
-              <tr>
-                <th class="p-0.5" />
-                <For each={correlationAssets}>
-                  {columnAsset => (
-                    <th class="p-0.5 text-[10px] text-muted-foreground font-medium text-center">
-                      {columnAsset}
-                    </th>
-                  )}
-                </For>
-              </tr>
-            </thead>
-            <tbody>
-              <For each={correlationAssets}>
-                {rowAsset => (
-                  <tr>
-                    <td class="p-0.5 text-[10px] text-muted-foreground font-medium">
-                      {rowAsset}
-                    </td>
-                    <For each={correlationAssets}>
-                      {colAsset => {
-                        const corr = getCorrelation(rowAsset, colAsset)
-                        return (
-                          <td class="p-0.5 text-center">
-                            <div
-                              class={`w-full h-4 flex items-center justify-center rounded text-[9px] font-mono ${getCorrelationColor(
-                                corr,
-                              )} ${rowAsset === colAsset ? "opacity-40" : ""}`}
-                            >
-                              {corr.toFixed(1)}
-                            </div>
-                          </td>
-                        )
-                      }}
-                    </For>
-                  </tr>
-                )}
-              </For>
-            </tbody>
-          </table>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Portfolio/hooks/useBeta.ts
+++ b/frontend/src/pages/Portfolio/hooks/useBeta.ts
@@ -14,7 +14,7 @@ const STALE_BETA_DATA_THRESHOLD_HOURS = 24
 const symbolToTicker = (symbol: string): string =>
   symbol.includes("/") ? (symbol.split("/")[0] ?? symbol) : symbol
 
-const weightsFromPortfolio = (
+export const weightsFromPortfolio = (
   portfolio: Record<string, PortfolioInterface | undefined>,
   portfolioTotalNotional: number,
   readonlyPositions: ReadonlyBetaPosition[],
@@ -57,7 +57,7 @@ const weightsFromPortfolio = (
   return signedWeights
 }
 
-const queryKeyFromWeights = (weights: Record<string, number>): string =>
+export const queryKeyFromWeights = (weights: Record<string, number>): string =>
   Object.entries(weights)
     .sort(([leftTicker], [rightTicker]) =>
       leftTicker.localeCompare(rightTicker),

--- a/frontend/src/pages/Portfolio/hooks/useRisk.test.tsx
+++ b/frontend/src/pages/Portfolio/hooks/useRisk.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, waitFor } from "@solidjs/testing-library"
+import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
+import type { ParentProps } from "solid-js"
+
+import type { PortfolioInterface } from "./usePortfolioState"
+import { useRisk, type RiskReport } from "./useRisk"
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  return (props: ParentProps) => (
+    <QueryClientProvider client={queryClient}>
+      {props.children}
+    </QueryClientProvider>
+  )
+}
+
+const targetPortfolio = (): Record<string, PortfolioInterface | undefined> => ({
+  "BTC/USDC:USDC": {
+    symbol: "BTC/USDC:USDC",
+    side: "buy",
+    leverage: 1,
+    notional: 60,
+  },
+  "ETH/USDC:USDC": {
+    symbol: "ETH/USDC:USDC",
+    side: "sell",
+    leverage: 1,
+    notional: 40,
+  },
+})
+const targetTotalNotional = () => 100
+
+const riskReport: RiskReport = {
+  contract: {
+    window: { lookbackDays: 90 },
+    samplingFrequency: "daily",
+    confidenceLevels: [0.9, 0.95, 0.99],
+  },
+  tailRisk: [
+    { confidenceLevel: 0.9, var: 0.021, cvar: 0.034 },
+    { confidenceLevel: 0.95, var: 0.029, cvar: 0.041 },
+    { confidenceLevel: 0.99, var: 0.052, cvar: 0.052 },
+  ],
+  drawdown: { maxDrawdown: 0.18, peakToTroughPeriods: 12 },
+  correlation: {
+    tickers: ["BTC", "ETH"],
+    matrix: [
+      [1, 0.82],
+      [0.82, 1],
+    ],
+    shrinkageIntensity: 0.07,
+  },
+  effectiveBets: {
+    meucci: 1.4,
+    stressedMeucci: 1.1,
+    inverseHerfindahl: 1.92,
+  },
+}
+
+describe("useRisk", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => riskReport,
+    })
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("posts signed active-position weights and exposes the report", async () => {
+    const { result } = renderHook(
+      () => useRisk(targetPortfolio, targetTotalNotional, () => []),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.report).not.toBeNull()
+    })
+
+    const [requestUrl, requestInit] = fetchMock.mock.lastCall as [
+      string,
+      { body: string },
+    ]
+    expect(requestUrl).toContain("api/risk")
+    const callBody = JSON.parse(requestInit.body) as {
+      weights: Record<string, number>
+    }
+    expect(callBody.weights.BTC).toBeCloseTo(0.6, 6)
+    expect(callBody.weights.ETH).toBeCloseTo(-0.4, 6)
+
+    expect(result.report?.tailRisk).toHaveLength(3)
+    expect(result.report?.drawdown.maxDrawdown).toBeCloseTo(0.18, 6)
+    expect(result.report?.effectiveBets.meucci).toBeCloseTo(1.4, 6)
+    expect(result.report?.correlation.tickers).toEqual(["BTC", "ETH"])
+  })
+
+  it("does not fetch when the portfolio has no positions", async () => {
+    const { result } = renderHook(
+      () =>
+        useRisk(
+          () => ({}),
+          () => 0,
+          () => [],
+        ),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.isLoading).toBe(false)
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.report).toBeNull()
+  })
+
+  it("surfaces the backend error message on failure", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({
+        error: "no candle data for DOGE in the measurement window",
+      }),
+    })
+
+    const { result } = renderHook(
+      () => useRisk(targetPortfolio, targetTotalNotional, () => []),
+      { wrapper: createWrapper() },
+    )
+
+    // The hook retries twice with backoff before surfacing the failure.
+    await waitFor(
+      () => {
+        expect(result.error).not.toBeNull()
+      },
+      { timeout: 10_000 },
+    )
+
+    expect(String(result.error)).toContain(
+      "no candle data for DOGE in the measurement window",
+    )
+  })
+})

--- a/frontend/src/pages/Portfolio/hooks/useRisk.ts
+++ b/frontend/src/pages/Portfolio/hooks/useRisk.ts
@@ -1,0 +1,112 @@
+import { useQuery } from "@tanstack/solid-query"
+import { createMemo } from "solid-js"
+import type { PortfolioInterface } from "./usePortfolioState"
+import type { ReadonlyBetaPosition } from "./useReadonlyPortfolioState"
+import { queryKeyFromWeights, weightsFromPortfolio } from "./useBeta"
+
+export interface RiskMeasurementWindow {
+  lookbackDays?: number
+  startDate?: string
+  endDate?: string
+}
+
+export interface RiskMeasurementContract {
+  window: RiskMeasurementWindow
+  samplingFrequency: "daily" | "weekly"
+  confidenceLevels: number[]
+}
+
+export interface TailRiskMetric {
+  confidenceLevel: number
+  var: number
+  cvar: number
+}
+
+export interface RiskDrawdown {
+  maxDrawdown: number
+  peakToTroughPeriods: number
+}
+
+export interface RiskCorrelation {
+  tickers: string[]
+  matrix: number[][]
+  shrinkageIntensity: number
+}
+
+export interface RiskEffectiveBets {
+  meucci: number
+  stressedMeucci: number
+  inverseHerfindahl: number
+}
+
+export interface RiskReport {
+  contract: RiskMeasurementContract
+  tailRisk: TailRiskMetric[]
+  drawdown: RiskDrawdown
+  correlation: RiskCorrelation
+  effectiveBets: RiskEffectiveBets
+}
+
+const fetchRisk = async (
+  weights: Record<string, number>,
+  signal?: AbortSignal,
+): Promise<RiskReport> => {
+  const res = await fetch(`${import.meta.env.BASE_URL}api/risk`, {
+    method: "POST",
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
+      : AbortSignal.timeout(10_000),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ weights }),
+  })
+  if (!res.ok) {
+    const failure = (await res.json().catch(() => null)) as {
+      error?: string
+    } | null
+    throw new Error(failure?.error ?? `risk request failed: ${res.status}`)
+  }
+  return res.json() as Promise<RiskReport>
+}
+
+export const useRisk = (
+  portfolio: () => Record<string, PortfolioInterface | undefined>,
+  portfolioTotalNotional: () => number,
+  readonlyPositions: () => ReadonlyBetaPosition[],
+) => {
+  const weights = createMemo(() =>
+    weightsFromPortfolio(
+      portfolio(),
+      portfolioTotalNotional(),
+      readonlyPositions(),
+    ),
+  )
+  const weightsKey = createMemo(() => queryKeyFromWeights(weights()))
+
+  const query = useQuery(() => {
+    const currentWeights = weights()
+    const currentWeightsKey = weightsKey()
+    const hasData = Object.keys(currentWeights).length > 0
+
+    return {
+      queryKey: ["risk", currentWeightsKey] as const,
+      queryFn: (ctx: { signal: AbortSignal }) =>
+        fetchRisk(currentWeights, ctx.signal),
+      enabled: hasData,
+      retry: 2,
+    }
+  })
+
+  return {
+    get report() {
+      return query.data ?? null
+    },
+    get isLoading() {
+      return query.isLoading
+    },
+    get error() {
+      return query.error
+    },
+  }
+}
+
+export type RiskResult = ReturnType<typeof useRisk>

--- a/frontend/src/pages/Portfolio/index.tsx
+++ b/frontend/src/pages/Portfolio/index.tsx
@@ -12,6 +12,7 @@ import {
   writePreciseToggle,
 } from "./hooks/usePortfolioState"
 import { useBeta, type BetaBenchmark } from "./hooks/useBeta"
+import { useRisk } from "./hooks/useRisk"
 import {
   useHyperliquidTickers,
   useHyperliquidFundingRates,
@@ -51,6 +52,12 @@ const PortfolioPage = () => {
     () => portfolio.targetTotalNotional,
     () => portfolio.readonlyBetaPositions,
     () => bitcoinBetaBenchmark,
+  )
+
+  const riskResult = useRisk(
+    () => portfolio.targetPortfolio,
+    () => portfolio.targetTotalNotional,
+    () => portfolio.readonlyBetaPositions,
   )
 
   const tickersQuery = useHyperliquidTickers()
@@ -270,7 +277,7 @@ const PortfolioPage = () => {
                 />
               </div>
               <div class="flex-1 min-w-0">
-                <RiskPanel />
+                <RiskPanel risk={riskResult} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Motivation

Story 0x01b requires the portfolio view to show VaR/CVaR at the configured
confidence levels, historical drawdown, a correlation matrix across held
positions, and an effective number of bets, with visible loading and failure
states and the active window and frequency displayed alongside the metrics.
The backend serves all of these from `POST /risk` (#344, #346, #348, #350),
but the RiskPanel rendered hardcoded placeholders and never called it.

## Solution

Add a `useRisk` hook mirroring `useBeta` -- same signed active-position weight
derivation (shared by export), solid-query with the weights as the cache key
-- and rewire the RiskPanel to it: tail-risk table per confidence level, max
drawdown with its peak-to-trough length, the three effective-bets readings
(Meucci, stressed, 1/HHI), and the correlation heatmap over the real tickers,
labelled with the shrinkage intensity. The measurement contract (window and
sampling frequency) shows in the panel header; loading renders skeletons,
failure surfaces the backend's reason verbatim, and an empty portfolio prompts
for positions. The fabricated Monte Carlo histogram is removed -- that metric
is not implemented, and fake numbers presented as real are worse than absence
(stress tests stay as an explicit TODO placeholder).

Closes #351

<!-- GitButler Footer Boundary Top -->
---
This is **part 18 of 18 in a stack** made with GitButler:
- <kbd>&nbsp;18&nbsp;</kbd> #352 👈
- <kbd>&nbsp;17&nbsp;</kbd> #291
- <kbd>&nbsp;16&nbsp;</kbd> #350
- <kbd>&nbsp;15&nbsp;</kbd> #348
- <kbd>&nbsp;14&nbsp;</kbd> #346
- <kbd>&nbsp;13&nbsp;</kbd> #344
- <kbd>&nbsp;12&nbsp;</kbd> #342
- <kbd>&nbsp;11&nbsp;</kbd> #284
- <kbd>&nbsp;10&nbsp;</kbd> #282
- <kbd>&nbsp;9&nbsp;</kbd> #280
- <kbd>&nbsp;8&nbsp;</kbd> #278
- <kbd>&nbsp;7&nbsp;</kbd> #276
- <kbd>&nbsp;6&nbsp;</kbd> #274
- <kbd>&nbsp;5&nbsp;</kbd> #272
- <kbd>&nbsp;4&nbsp;</kbd> #270
- <kbd>&nbsp;3&nbsp;</kbd> #268
- <kbd>&nbsp;2&nbsp;</kbd> #266
- <kbd>&nbsp;1&nbsp;</kbd> #264
<!-- GitButler Footer Boundary Bottom -->
