### PR TITLE
chore: add the scripts/*.nu convention with gitbutler-stack and pr-stack-footer tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,6 +417,26 @@ predictable quoting/word-splitting. Bash files accumulate footguns (unquoted
 expansions, `set -e` corner cases, IFS surprises) that nushell avoids by
 construction.
 
+A reusable script is not a throwaway snippet -- treat it like code:
+
+- **Live in `scripts/`**: a standalone reusable script is `scripts/<name>.nu`,
+  not a one-off pasted into a shell or buried in `.tmp/`. Parameterize it with
+  typed flags/subcommands (`def main [--start: string]`) instead of hardcoding
+  the values you happened to need; keep a pure, importable function for the
+  logic and a thin `main` that wires I/O to it.
+- **Has a test module**: ship `scripts/<name>.test.nu` alongside it that `use`s
+  the script's exported functions and asserts (via `std assert`) against a
+  realistic fixture. Exit nonzero on failure so the build can gate it.
+- **Exposed via a nix derivation**: wrap it with `mkNuScript` in `flake.nix` so
+  it lands on `PATH` (in the dev shell and as `nix run .#<name>`), declares its
+  runtime deps, and runs its `.test.nu` in `checkPhase` -- the script is gated
+  by `nix flake check` exactly like compiled code. `scripts/gitbutler-stack.nu`
+  is the reference example.
+
+Ad-hoc one-liners for a single inspection are still fine inline; the moment a
+script is worth keeping or reusing, it earns its `scripts/` file, test, and
+derivation.
+
 ---
 
 ## Rust Code Style

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,24 @@ of them.
 
 ---
 
+## Dev: repository, CI, and docs housekeeping
+
+Keep the development pipeline and the repo's front page healthy: CI that gates
+on code rather than a throttled cache, the PR-footer tooling `AGENTS.md` already
+mandates, and a README that shows the product instead of a deprecated embed.
+
+- [ ] Replace magic-nix-cache with cachix + a per-runner store cache --
+      [#359](https://github.com/data-cartel/moneymentum/issues/359) /
+      [#368](https://github.com/data-cartel/moneymentum/pull/368)
+- [ ] Add the scripts/*.nu convention with gitbutler-stack + pr-stack-footer --
+      [#358](https://github.com/data-cartel/moneymentum/issues/358) /
+      [#367](https://github.com/data-cartel/moneymentum/pull/367)
+- [ ] Replace the deprecated Big Short embed with a prototype screenshot --
+      [#365](https://github.com/data-cartel/moneymentum/issues/365) /
+      [#366](https://github.com/data-cartel/moneymentum/pull/366)
+
+---
+
 ## Usable production deployment
 
 Users need to reach the app before any portfolio feature matters. Deployment is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,7 +92,8 @@ of them.
 
 Keep the development pipeline and the repo's front page healthy: CI that gates
 on code rather than a throttled cache, the PR-footer tooling `AGENTS.md` already
-mandates, and a README that shows the product instead of a deprecated embed.
+mandates, a README that shows the product instead of a deprecated embed, and
+front-page docs that spell out their abbreviations on first use.
 
 - [ ] Replace magic-nix-cache with cachix + a per-runner store cache --
       [#359](https://github.com/data-cartel/moneymentum/issues/359) /
@@ -103,6 +104,9 @@ mandates, and a README that shows the product instead of a deprecated embed.
 - [ ] Replace the deprecated Big Short embed with a prototype screenshot --
       [#365](https://github.com/data-cartel/moneymentum/issues/365) /
       [#366](https://github.com/data-cartel/moneymentum/pull/366)
+- [ ] Expand abbreviations on first use in SPEC and README --
+      [#369](https://github.com/data-cartel/moneymentum/issues/369) /
+      [#370](https://github.com/data-cartel/moneymentum/pull/370)
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,12 @@
           runtimeInputs = [ gitbutler-cli ];
         };
 
+        # Refresh the GitButler stack footer on every stacked PR.
+        pr-stack-footer = mkNuScript {
+          name = "pr-stack-footer";
+          runtimeInputs = [ gitbutler-cli pkgs.gh ];
+        };
+
         hooks = {
           # Nix
           nil.enable = true;
@@ -197,6 +203,7 @@
                   git
                   gitbutler-cli
                   gitbutler-stack
+                  pr-stack-footer
                   nushell
                   ragenix.packages.${system}.default
                   sqlx-cli
@@ -260,6 +267,7 @@
           };
 
           inherit gitbutler-stack;
+          inherit pr-stack-footer;
         };
         packages = {
           default = rustPkgs.package;
@@ -269,6 +277,7 @@
 
           inherit gitbutler-cli;
           inherit gitbutler-stack;
+          inherit pr-stack-footer;
 
           frontend = frontendPkgs.package;
           frontend-lint = frontendPkgs.lint;

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,42 @@
             localSystem = system;
           };
 
+        # Package a scripts/<name>.nu as an executable on PATH, running
+        # its scripts/<name>.test.nu in checkPhase so `nix build`/`nix
+        # flake check` gate the script the same as compiled code. The
+        # wrapper puts nushell and any runtime deps on PATH.
+        mkNuScript = { name, runtimeInputs ? [ ] }:
+          pkgs.stdenvNoCC.mkDerivation {
+            inherit name;
+            src = ./scripts;
+            nativeBuildInputs = [ pkgs.makeWrapper pkgs.nushell ];
+            dontConfigure = true;
+            dontBuild = true;
+            doCheck = true;
+            checkPhase = ''
+              runHook preCheck
+              nu ${name}.test.nu
+              runHook postCheck
+            '';
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/bin
+              install -m755 ${name}.nu $out/bin/${name}
+              wrapProgram $out/bin/${name} \
+                --prefix PATH : ${
+                  pkgs.lib.makeBinPath ([ pkgs.nushell ] ++ runtimeInputs)
+                }
+              runHook postInstall
+            '';
+            meta.mainProgram = name;
+          };
+
+        # Enumerate a GitButler workspace's branches in sweep order.
+        gitbutler-stack = mkNuScript {
+          name = "gitbutler-stack";
+          runtimeInputs = [ gitbutler-cli ];
+        };
+
         hooks = {
           # Nix
           nil.enable = true;
@@ -160,6 +196,8 @@
                 deps ++ [
                   git
                   gitbutler-cli
+                  gitbutler-stack
+                  nushell
                   ragenix.packages.${system}.default
                   sqlx-cli
                   doctl
@@ -220,6 +258,8 @@
             hooks = hooksForChecks;
             src = self;
           };
+
+          inherit gitbutler-stack;
         };
         packages = {
           default = rustPkgs.package;
@@ -228,6 +268,7 @@
           moneymentum-clippy = rustPkgs.clippy;
 
           inherit gitbutler-cli;
+          inherit gitbutler-stack;
 
           frontend = frontendPkgs.package;
           frontend-lint = frontendPkgs.lint;

--- a/scripts/gitbutler-stack.nu
+++ b/scripts/gitbutler-stack.nu
@@ -1,0 +1,117 @@
+#!/usr/bin/env nu
+# Enumerate a GitButler workspace's branches in sweep order -- every
+# applied stack walked from its base commit up to its tip, so a caller
+# visits each branch parent-before-child. Built for stack-wide tooling
+# (review sweeps, fmt/clippy gates) that scopes and acts on one branch
+# at a time.
+#
+# `but status -j` lists stacks tip-first; this flips each stack to
+# base-first and flattens the workspace into one ordered table:
+#
+#   stack   branch                      pr     commits
+#   0       feat/factor-sma-zscore             1
+#   0       chore/factors-submodules           1
+#   ...
+#   1       feat/risk-frontend          352    1
+#
+# Usage:
+#   gitbutler-stack                          # whole workspace, base -> tip
+#   gitbutler-stack --start feat/risk-var    # subrange from a branch upward
+#   gitbutler-stack --end feat/risk-frontend # subrange up to a branch
+#   gitbutler-stack --json-file status.json  # parse a saved `but status -j`
+
+# Order the branches of a parsed `but status -j` record into a sweep
+# table, base-first within each stack. Columns: stack (0-based stack
+# index), branch, pr (PR number or null), commits (count ahead of base).
+export def parse-stacks [status: record]: nothing -> table {
+  $status.stacks
+  | enumerate
+  | each {|stack|
+      $stack.item.branches
+      | reverse
+      | each {|branch| {
+          stack: $stack.index
+          branch: $branch.name
+          pr: ($branch.reviewId? | parse-pr-number)
+          commits: ($branch.commits | length)
+        }}
+    }
+  | flatten
+}
+
+# Trim an ordered sweep table to the inclusive [start, end] subrange,
+# matched by branch name against the flat sweep order. An empty bound
+# is unbounded on that side. Errors if a named branch is absent or the
+# end precedes the start.
+export def trim-range [
+  --start: string = ""
+  --end: string = ""
+]: table -> table {
+  let branches = $in
+
+  # An empty workspace with no bounds is a valid no-op sweep. With a bound,
+  # fall through so the named branch is reported as not-in-stack rather than
+  # silently swallowed.
+  if (($branches | is-empty) and ($start | is-empty) and ($end | is-empty)) {
+    return $branches
+  }
+
+  let names = ($branches | get branch)
+
+  let start_idx = if ($start | is-empty) {
+    0
+  } else {
+    $names | index-of $start "--start"
+  }
+
+  let end_idx = if ($end | is-empty) {
+    ($branches | length) - 1
+  } else {
+    $names | index-of $end "--end"
+  }
+
+  if $start_idx > $end_idx {
+    error make {msg: "--end precedes --start in sweep order"}
+  }
+
+  $branches | enumerate | where index >= $start_idx and index <= $end_idx | get item
+}
+
+# Position of a branch name in the sweep order, or a labelled error.
+def index-of [name: string, flag: string]: list -> int {
+  let found = ($in | enumerate | where item == $name)
+
+  if ($found | is-empty) {
+    error make {msg: $"($flag) branch not in stack: ($name)"}
+  }
+
+  $found.0.index
+}
+
+# Extract the integer PR number from a GitButler reviewId like "(#352)".
+# Null or unmatched input yields null.
+def parse-pr-number []: any -> any {
+  let review_id = $in
+
+  if ($review_id | is-empty) {
+    return null
+  }
+
+  let matched = ($review_id | parse --regex '#(?<num>\d+)')
+
+  if ($matched | is-empty) { null } else { $matched.0.num | into int }
+}
+
+def main [
+  --start: string = ""      # first branch of the sweep subrange (inclusive)
+  --end: string = ""        # last branch of the sweep subrange (inclusive)
+  --json-file: string = ""  # read `but status -j` output from a file instead of running it
+]: nothing -> table {
+  let status = if ($json_file | is-empty) {
+    ^but status -j | from json
+  } else {
+    open --raw $json_file | from json
+  }
+
+  parse-stacks $status | trim-range --start $start --end $end
+}

--- a/scripts/gitbutler-stack.test.nu
+++ b/scripts/gitbutler-stack.test.nu
@@ -1,0 +1,65 @@
+#!/usr/bin/env nu
+# Tests for gitbutler-stack.nu. Run directly: `nu gitbutler-stack.test.nu`
+# (also runs in the package's checkPhase). Exits nonzero on the first
+# failed assertion.
+
+use std assert
+use ./gitbutler-stack.nu *
+
+# Mirrors `but status -j`: stacks tip-first, branches tip-first, reviewId
+# rendered as "(#NNN)" or null, commits a list whose length is the count
+# ahead of base.
+const STATUS_JSON = '{
+  "stacks": [
+    { "branches": [
+        { "name": "feat/tip",  "reviewId": "(#103)", "commits": [ {"message": "c"} ] },
+        { "name": "feat/mid",  "reviewId": null,     "commits": [ {"message": "c"}, {"message": "d"} ] },
+        { "name": "feat/base", "reviewId": "(#101)", "commits": [ {"message": "c"} ] }
+    ] },
+    { "branches": [
+        { "name": "other/tip",  "reviewId": "(#205)", "commits": [ {"message": "c"} ] },
+        { "name": "other/base", "reviewId": null,     "commits": [ {"message": "c"} ] }
+    ] }
+  ]
+}'
+
+def fixture []: nothing -> record {
+  $STATUS_JSON | from json
+}
+
+# parse-stacks flips each stack base-first, numbers stacks, and pulls PR
+# numbers and commit counts.
+let parsed = (parse-stacks (fixture))
+
+assert equal ($parsed | get branch) [feat/base feat/mid feat/tip other/base other/tip]
+assert equal ($parsed | get stack) [0 0 0 1 1]
+assert equal ($parsed | get pr) [101 null 103 null 205]
+assert equal ($parsed | get commits) [1 2 1 1 1]
+
+# trim-range with no bounds is the identity.
+assert equal (parse-stacks (fixture) | trim-range | get branch) [feat/base feat/mid feat/tip other/base other/tip]
+
+# --start keeps the sweep from the named branch upward, crossing stacks.
+assert equal (parse-stacks (fixture) | trim-range --start feat/mid | get branch) [feat/mid feat/tip other/base other/tip]
+
+# --end stops at the named branch.
+assert equal (parse-stacks (fixture) | trim-range --end feat/tip | get branch) [feat/base feat/mid feat/tip]
+
+# both bounds select the inclusive subrange.
+assert equal (parse-stacks (fixture) | trim-range --start feat/mid --end feat/tip | get branch) [feat/mid feat/tip]
+
+# an unknown bound is a hard error, not a silent empty sweep.
+assert error {|| parse-stacks (fixture) | trim-range --start nope }
+
+# end before start in sweep order is rejected.
+assert error {|| parse-stacks (fixture) | trim-range --start feat/tip --end feat/base }
+
+# An empty workspace (no applied stacks) is a valid no-op sweep, not a range error.
+assert equal (parse-stacks {stacks: []}) []
+assert equal (parse-stacks {stacks: []} | trim-range) []
+
+# But a bound named against an empty workspace is still a hard error -- a typo'd
+# --start is reported, not silently swallowed by the no-op shortcut.
+assert error {|| parse-stacks {stacks: []} | trim-range --start nope }
+
+print "gitbutler-stack: all tests passed"

--- a/scripts/pr-stack-footer.nu
+++ b/scripts/pr-stack-footer.nu
@@ -1,0 +1,148 @@
+#!/usr/bin/env nu
+# Rebuild the GitButler stack-navigation footer on every PR in each
+# multi-branch stack and splice it into the PR bodies. GitButler writes
+# the footer when it opens or pushes a PR, but a no-op push never rewrites
+# it, so after a rebase or a branch add/remove the footers go stale (list
+# merged PRs, wrong position/total) or are missing entirely. This
+# recomputes each stack's footer from the live `but status` and updates
+# the PRs via gh.
+#
+# Usage:
+#   pr-stack-footer            # dry run: print the planned footer per PR
+#   pr-stack-footer --apply    # write the footers to the PRs via gh
+
+const TOP_MARKER = "<!-- GitButler Footer Boundary Top -->"
+const BOTTOM_MARKER = "<!-- GitButler Footer Boundary Bottom -->"
+
+# Build the footer block for one PR, given its stack's PR numbers ordered
+# base -> tip (position 1 is the bottom of the stack). The list runs
+# top-first, the current PR carries the pointer, matching GitButler's
+# own output.
+export def build-footer [prs: list, current: int]: nothing -> string {
+  let total = ($prs | length)
+  let current_index = ($prs | enumerate | where item == $current | get index)
+
+  if ($current_index | is-empty) {
+    error make {msg: $"PR #($current) not found in stack PR list: ($prs)"}
+  }
+
+  let current_position = (($current_index | first) + 1)
+
+  let rows = (
+    $prs
+    | enumerate
+    | reverse
+    | each {|entry|
+        let position = ($entry.index + 1)
+        let pointer = if ($entry.item == $current) { " 👈" } else { "" }
+        $"- <kbd>&nbsp;($position)&nbsp;</kbd> #($entry.item)($pointer)"
+      }
+  )
+
+  [
+    $TOP_MARKER
+    "---"
+    $"This is **part ($current_position) of ($total) in a stack** made with GitButler:"
+  ]
+  | append $rows
+  | append $BOTTOM_MARKER
+  | str join "\n"
+}
+
+# Replace the footer region of a PR body with a fresh footer, or append
+# the footer when the body has none. Content outside the boundary markers
+# is preserved verbatim.
+export def splice-footer [body: string, footer: string]: nothing -> string {
+  let has_top = ($body | str contains $TOP_MARKER)
+  let has_bottom = ($body | str contains $BOTTOM_MARKER)
+
+  if ($has_top and $has_bottom) {
+    let before = ($body | split row $TOP_MARKER | first)
+    let after = ($body | split row $BOTTOM_MARKER | last)
+    $"($before)($footer)($after)"
+  } else if $has_top {
+    # Truncated footer: a top marker but no bottom. The footer always sits at
+    # the end of the body, so everything from the orphan top marker onward is
+    # the broken footer -- drop it whole (the marker and its `---` rule alike),
+    # then re-append a clean footer.
+    let before = ($body | split row $TOP_MARKER | first | str trim --right)
+    $"($before)\n\n($footer)\n"
+  } else if $has_bottom {
+    # Orphan bottom marker with no top: we cannot tell where the broken footer
+    # began without risking real prose, so conservatively drop just the
+    # dangling marker line, then append a clean footer.
+    let cleaned = ($body | lines | where {|line| $line != $BOTTOM_MARKER} | str join "\n" | str trim --right)
+    $"($cleaned)\n\n($footer)\n"
+  } else {
+    $"($body | str trim --right)\n\n($footer)\n"
+  }
+}
+
+# PR numbers per stack, ordered base -> tip, for stacks carrying at least
+# two PRs (a single-PR lane is not a stack and gets no footer).
+export def stacks-with-prs []: record -> list {
+  $in.stacks
+  | each {|stack|
+      $stack.branches
+      | reverse
+      | each {|branch| $branch.reviewId? | parse-pr-number }
+      | compact
+    }
+  | where {|prs| ($prs | length) >= 2}
+}
+
+# Extract the integer PR number from a GitButler reviewId like "(#352)".
+def parse-pr-number []: any -> any {
+  let review_id = $in
+
+  if ($review_id | is-empty) {
+    return null
+  }
+
+  let matched = ($review_id | parse --regex '#(?<num>\d+)')
+
+  if ($matched | is-empty) { null } else { $matched.0.num | into int }
+}
+
+def main [--apply]: nothing -> any {
+  let stacks = (^but status -j | from json | stacks-with-prs)
+
+  mut updated = []
+  mut failed = []
+
+  for prs in $stacks {
+    for pr in $prs {
+      let footer = (build-footer $prs $pr)
+
+      if $apply {
+        let view = (^gh pr view $pr --json body | complete)
+        if $view.exit_code != 0 {
+          print -e $"failed to read #($pr): ($view.stderr | str trim)"
+          $failed = ($failed | append $pr)
+          continue
+        }
+
+        let body = ($view.stdout | from json | get body)
+        let new_body = (splice-footer $body $footer)
+
+        let edit = (^gh pr edit $pr --body $new_body | complete)
+        if $edit.exit_code != 0 {
+          print -e $"failed to update #($pr): ($edit.stderr | str trim)"
+          $failed = ($failed | append $pr)
+          continue
+        }
+
+        $updated = ($updated | append $pr)
+        print $"updated #($pr)"
+      } else {
+        let position = (($prs | enumerate | where item == $pr | get index | first) + 1)
+        print $"would update #($pr): part ($position) of ($prs | length)"
+      }
+    }
+  }
+
+  if ($apply and (not ($failed | is-empty))) {
+    let failed_str = ($failed | each {|pr| $"#($pr)"} | str join ", ")
+    print -e $"($updated | length) updated, ($failed | length) failed: ($failed_str). Re-run to retry the failed PRs."
+  }
+}

--- a/scripts/pr-stack-footer.nu
+++ b/scripts/pr-stack-footer.nu
@@ -78,8 +78,9 @@ export def splice-footer [body: string, footer: string]: nothing -> string {
   }
 }
 
-# PR numbers per stack, ordered base -> tip, for stacks carrying at least
-# two PRs (a single-PR lane is not a stack and gets no footer).
+# PR numbers per stack, ordered base -> tip. Every stack carrying at least
+# one PR gets a footer -- including single-PR lanes, which render as a
+# "part 1 of 1" footer so every PR in the forest carries the section.
 export def stacks-with-prs []: record -> list {
   $in.stacks
   | each {|stack|
@@ -88,7 +89,7 @@ export def stacks-with-prs []: record -> list {
       | each {|branch| $branch.reviewId? | parse-pr-number }
       | compact
     }
-  | where {|prs| ($prs | length) >= 2}
+  | where {|prs| ($prs | length) >= 1}
 }
 
 # Extract the integer PR number from a GitButler reviewId like "(#352)".

--- a/scripts/pr-stack-footer.test.nu
+++ b/scripts/pr-stack-footer.test.nu
@@ -28,6 +28,11 @@ assert ((build-footer [264 266 268] 268) | str contains "part 3 of 3")
 assert equal ((build-footer [264 266 268] 266) | split row "👈" | length) 2
 assert ((build-footer [264 266 268] 268) | str contains "#268 👈")
 
+# A single-PR lane renders as a 1-of-1 footer so every forest PR carries one.
+assert ((build-footer [286] 286) | str contains "part 1 of 1")
+assert ((build-footer [286] 286) | str contains "#286 👈")
+assert equal ((build-footer [286] 286) | lines | where ($it | str starts-with "- ") | length) 1
+
 # splice-footer replaces an existing footer region and keeps the prose.
 let body_with_footer = "## Motivation
 

--- a/scripts/pr-stack-footer.test.nu
+++ b/scripts/pr-stack-footer.test.nu
@@ -1,0 +1,109 @@
+#!/usr/bin/env nu
+# Tests for pr-stack-footer.nu. Run directly: `nu pr-stack-footer.test.nu`
+# (also runs in the package's checkPhase). Exits nonzero on the first
+# failed assertion. Only the pure footer functions are exercised; the
+# `but`/`gh` I/O in `main` is not invoked.
+
+use std assert
+use ./pr-stack-footer.nu *
+
+# build-footer numbers the stack base-first (position 1 = bottom), lists
+# it top-first, and points at the current PR -- byte-for-byte the shape
+# GitButler emits.
+const EXPECTED = "<!-- GitButler Footer Boundary Top -->
+---
+This is **part 2 of 3 in a stack** made with GitButler:
+- <kbd>&nbsp;3&nbsp;</kbd> #268
+- <kbd>&nbsp;2&nbsp;</kbd> #266 👈
+- <kbd>&nbsp;1&nbsp;</kbd> #264
+<!-- GitButler Footer Boundary Bottom -->"
+
+assert equal (build-footer [264 266 268] 266) $EXPECTED
+
+# The bottom PR is part 1; the top PR is part N.
+assert ((build-footer [264 266 268] 264) | str contains "part 1 of 3")
+assert ((build-footer [264 266 268] 268) | str contains "part 3 of 3")
+
+# Exactly one pointer, on the current PR.
+assert equal ((build-footer [264 266 268] 266) | split row "👈" | length) 2
+assert ((build-footer [264 266 268] 268) | str contains "#268 👈")
+
+# splice-footer replaces an existing footer region and keeps the prose.
+let body_with_footer = "## Motivation
+
+Some prose.
+
+<!-- GitButler Footer Boundary Top -->
+---
+This is **part 5 of 17 in a stack** made with GitButler:
+- <kbd>&nbsp;1&nbsp;</kbd> #256
+<!-- GitButler Footer Boundary Bottom -->"
+let fresh = (build-footer [264 266 268] 264)
+let spliced = (splice-footer $body_with_footer $fresh)
+
+assert ($spliced | str contains "## Motivation")
+assert ($spliced | str contains "Some prose.")
+assert ($spliced | str contains "part 1 of 3")
+assert (not ($spliced | str contains "part 5 of 17"))
+assert (not ($spliced | str contains "#256"))
+# The boundary markers appear exactly once after a splice.
+assert equal ($spliced | split row "<!-- GitButler Footer Boundary Top -->" | length) 2
+
+# splice-footer appends when the body has no footer yet, keeping the body.
+let bare_body = "## Motivation
+
+No footer here."
+let appended = (splice-footer $bare_body $fresh)
+
+assert ($appended | str starts-with "## Motivation")
+assert ($appended | str contains "part 1 of 3")
+assert ($appended | str contains "<!-- GitButler Footer Boundary Bottom -->")
+
+# build-footer errors loudly when the current PR is absent from the stack
+# list, instead of crashing on an empty stream.
+assert error {|| build-footer [264 266 268] 999 }
+
+# splice-footer repairs a body left with a single dangling boundary marker
+# instead of appending a second footer beside the orphan. A truncated footer
+# (top marker, no bottom) is dropped whole -- markers and stray lines alike --
+# while the real prose above it survives.
+let orphan_top = "## Motivation
+
+Prose.
+
+<!-- GitButler Footer Boundary Top -->
+---
+a truncated footer with no bottom marker"
+let repaired = (splice-footer $orphan_top (build-footer [286] 286))
+assert equal ($repaired | split row "<!-- GitButler Footer Boundary Top -->" | length) 2
+assert equal ($repaired | split row "<!-- GitButler Footer Boundary Bottom -->" | length) 2
+assert (not ($repaired | str contains "a truncated footer"))
+assert ($repaired | str contains "## Motivation")
+assert ($repaired | str contains "Prose.")
+
+# An orphan bottom marker (no top) is repaired conservatively: the dangling
+# marker line is dropped, the prose is kept, and a clean footer is appended.
+let orphan_bottom = "## Motivation
+
+Prose.
+<!-- GitButler Footer Boundary Bottom -->"
+let repaired_bottom = (splice-footer $orphan_bottom (build-footer [286] 286))
+assert equal ($repaired_bottom | split row "<!-- GitButler Footer Boundary Top -->" | length) 2
+assert equal ($repaired_bottom | split row "<!-- GitButler Footer Boundary Bottom -->" | length) 2
+assert ($repaired_bottom | str contains "Prose.")
+
+# stacks-with-prs flips each stack base-first, extracts PR numbers, drops
+# null-reviewId branches, and omits stacks carrying no PR at all.
+let status = {stacks: [
+  {branches: [
+    {name: "tip", reviewId: "(#103)", commits: [{}]}
+    {name: "mid", reviewId: null, commits: [{}]}
+    {name: "base", reviewId: "(#101)", commits: [{}]}
+  ]}
+  {branches: [
+    {name: "solo", reviewId: null, commits: [{}]}
+  ]}
+]}
+assert equal ($status | stacks-with-prs) [[101 103]]
+
+print "pr-stack-footer: all tests passed"


### PR DESCRIPTION
## Motivation

Closes #358. AGENTS.md on master already tells agents to keep PR footers fresh
by running `nix run .#pr-stack-footer`, but neither that script, any
`scripts/*.nu` file, nor the flake derivation exist on master -- they lived
only in unmerged commits, so an agent following the instruction hits
"attribute pr-stack-footer not found". The documentation shipped ahead of its
tooling; this lands the tooling and the convention it follows.

## Solution

- Establish the `scripts/*.nu` convention in AGENTS.md: each reusable script is
  `scripts/<name>.nu` with a pure, importable function plus a thin `main`; a
  colocated `scripts/<name>.test.nu` asserts against realistic fixtures; and a
  `mkNuScript` derivation puts it on `PATH` and runs its test in `checkPhase`,
  so `nix flake check` gates the script like compiled code.
- Ship `gitbutler-stack.nu` -- enumerates the workspace's stacks from
  `but status`, the sweep primitive (`nix run .#gitbutler-stack`).
- Ship `pr-stack-footer.nu` -- recomputes each stack's GitButler navigation
  footer from `but status -j` and replaces only the region between the boundary
  markers, preserving the rest of the body; single-PR lanes render as a
  "part 1 of 1" footer so every PR in the forest carries the section
  (`nix run .#pr-stack-footer`).

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #372
- <kbd>&nbsp;1&nbsp;</kbd> #367 👈
<!-- GitButler Footer Boundary Bottom -->
