### PR TITLE
docs: expand abbreviations on first use in SPEC and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Moneymentum makes those exposures legible and adjustable.
   perps.
 - **Frontend prototype** at `/prototype`: design reference for the target UI.
 - **Backend** (active development): Rust + Rocket API, Polars analytics,
-  SQLite-backed ingestion runs and job queue. Ingests Hyperliquid OHLCV and
-  funding rates; computes rolling beta to BTC and serves per-asset factor scores
-  via `GET /factors/<timeframe>`.
+  SQLite-backed ingestion runs and job queue. Ingests Hyperliquid
+  open-high-low-close-volume (OHLCV) and funding rates; computes rolling beta to
+  BTC and serves per-asset factor scores via `GET /factors/<timeframe>`.
 - **Vault program** (planned): Anchor program on Solana for non-custodial
   managed deposits with two-phase withdrawal.
 
@@ -25,13 +25,13 @@ See [ROADMAP.md](./ROADMAP.md) for what's next.
 
 ## Documentation
 
-| Doc                                    | Purpose                                    |
-| -------------------------------------- | ------------------------------------------ |
-| [SPEC.md](./SPEC.md)                   | Product vision and target architecture     |
-| [ROADMAP.md](./ROADMAP.md)             | Themed stories ordered by priority         |
-| [stories/](./stories/README.md)        | User and dev stories with acceptance tests |
-| [contributions.md](./contributions.md) | XP workflow for contributors               |
-| [AGENTS.md](./AGENTS.md)               | Per-repo rules for AI coding agents        |
+| Doc                                    | Purpose                                            |
+| -------------------------------------- | -------------------------------------------------- |
+| [SPEC.md](./SPEC.md)                   | Product vision and target architecture             |
+| [ROADMAP.md](./ROADMAP.md)             | Themed stories ordered by priority                 |
+| [stories/](./stories/README.md)        | User and dev stories with acceptance tests         |
+| [contributions.md](./contributions.md) | Extreme Programming (XP) workflow for contributors |
+| [AGENTS.md](./AGENTS.md)               | Per-repo rules for AI coding agents                |
 
 ## Quick start
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,8 +118,8 @@ execution but never holds raw private keys.
   operations. Withdrawal credentials are held at a higher privilege tier.
 
 The backend pre-computes global market metrics (betas, correlations, etc.) and
-returns user-specific analytics (portfolio beta, VaR, execution plans). The
-frontend is a monitoring and control dashboard.
+returns user-specific analytics (portfolio beta, Value at Risk (VaR), execution
+plans). The frontend is a monitoring and control dashboard.
 
 ## Custody & Execution
 
@@ -198,7 +198,7 @@ graph TB
 ## Fee Structure
 
 Fees are the commercialization mechanism. Personal use is free (0/0 fees).
-Revenue comes from PMs managing other people's money.
+Revenue comes from portfolio managers (PMs) managing other people's money.
 
 - **Management fee**: Annual percentage of AUM (assets under management),
   deducted at withdrawal
@@ -287,9 +287,10 @@ solidify.
 **Factor Engine**: Computes per-asset factor scores (beta, momentum, carry,
 volatility, Sharpe) over the tradable universe. The backend computes rolling
 beta to BTC and serves per-asset factor scores via `GET /factors/<timeframe>`;
-factors land incrementally as columns (rolling windows over ingested OHLCV and
-funding-rate data). Outputs feed the screener (rank/filter assets by factor) and
-the rebalancer (target factor exposures, not symbols).
+factors land incrementally as columns (rolling windows over ingested
+open-high-low-close-volume (OHLCV) and funding-rate data). Outputs feed the
+screener (rank/filter assets by factor) and the rebalancer (target factor
+exposures, not symbols).
 
 The portfolio-weighted beta is exposed via `POST /beta`, which accepts a set of
 position weights plus a benchmark symbol and returns a single beta value


### PR DESCRIPTION
## What

Spells out abbreviations on their first use in the two front-page docs:
`Value at Risk (VaR)`, `open-high-low-close-volume (OHLCV)`, and
`portfolio managers (PMs)` in SPEC.md; `OHLCV` and `Extreme Programming (XP)` in
README.md.

## Why

SPEC.md's own terminology standard says to "define terms in context when first
introduced," but several abbreviations were used before (or without) their
expansion -- `VaR` appears in the analytics summary well above the risk section
that defines it. Expanding on first use makes the front-page docs readable
without forward-referencing.

Closes #369

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 1 in a stack** made with GitButler:
- <kbd>&nbsp;1&nbsp;</kbd> #370 👈
<!-- GitButler Footer Boundary Bottom -->
