### PR TITLE
chore: rename data-cartel references to dataclique

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "moneymentum"
 version = "0.1.0"
 edition = "2024"
+authors = ["Data Clique Software Design FZCO"]
 
 [dependencies]
 apalis = "0.7.4"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [ROADMAP.md](./ROADMAP.md) for what's next.
 ### Setup
 
 ```bash
-git clone https://github.com/data-cartel/moneymentum.git
+git clone https://github.com/dataclique/moneymentum.git
 cd moneymentum
 direnv allow  # or: nix develop
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,62 +29,62 @@ engineering track that runs in parallel to the product themes below, not ahead
 of them.
 
 - [x] Point user stories at the factors module --
-      [#304](https://github.com/data-cartel/moneymentum/issues/304) /
-      [#250](https://github.com/data-cartel/moneymentum/pull/250)
+      [#304](https://github.com/dataclique/moneymentum/issues/304) /
+      [#250](https://github.com/dataclique/moneymentum/pull/250)
 - [x] Consolidate beta into a factors module --
-      [#249](https://github.com/data-cartel/moneymentum/issues/249) /
-      [#252](https://github.com/data-cartel/moneymentum/pull/252)
+      [#249](https://github.com/dataclique/moneymentum/issues/249) /
+      [#252](https://github.com/dataclique/moneymentum/pull/252)
 - [x] Add TimeframeConfig (lookback + annualization) --
-      [#251](https://github.com/data-cartel/moneymentum/issues/251) /
-      [#254](https://github.com/data-cartel/moneymentum/pull/254)
+      [#251](https://github.com/dataclique/moneymentum/issues/251) /
+      [#254](https://github.com/dataclique/moneymentum/pull/254)
 - [x] Split the factor engine into returns/beta/scores submodules --
-      [#257](https://github.com/data-cartel/moneymentum/issues/257) /
-      [#258](https://github.com/data-cartel/moneymentum/pull/258)
+      [#257](https://github.com/dataclique/moneymentum/issues/257) /
+      [#258](https://github.com/dataclique/moneymentum/pull/258)
 - [x] Factor: returns shared primitive --
       [`src/factors/returns.rs`](./src/factors/returns.rs)
 - [x] Factor: cum_return --
-      [#253](https://github.com/data-cartel/moneymentum/issues/253) /
-      [#254](https://github.com/data-cartel/moneymentum/pull/254)
+      [#253](https://github.com/dataclique/moneymentum/issues/253) /
+      [#254](https://github.com/dataclique/moneymentum/pull/254)
 - [x] Factor: volatility --
-      [#251](https://github.com/data-cartel/moneymentum/issues/251) /
-      [#254](https://github.com/data-cartel/moneymentum/pull/254)
+      [#251](https://github.com/dataclique/moneymentum/issues/251) /
+      [#254](https://github.com/dataclique/moneymentum/pull/254)
 - [x] Factor: SMA --
-      [#255](https://github.com/data-cartel/moneymentum/issues/255) /
-      [#256](https://github.com/data-cartel/moneymentum/pull/256)
+      [#255](https://github.com/dataclique/moneymentum/issues/255) /
+      [#256](https://github.com/dataclique/moneymentum/pull/256)
 - [x] Factor: mean return --
-      [#255](https://github.com/data-cartel/moneymentum/issues/255) /
-      [#256](https://github.com/data-cartel/moneymentum/pull/256)
+      [#255](https://github.com/dataclique/moneymentum/issues/255) /
+      [#256](https://github.com/dataclique/moneymentum/pull/256)
 - [x] Factor: price z-score --
-      [#255](https://github.com/data-cartel/moneymentum/issues/255) /
-      [#256](https://github.com/data-cartel/moneymentum/pull/256)
+      [#255](https://github.com/dataclique/moneymentum/issues/255) /
+      [#256](https://github.com/dataclique/moneymentum/pull/256)
 - [x] Factor: Sharpe --
-      [#259](https://github.com/data-cartel/moneymentum/issues/259) /
-      [#260](https://github.com/data-cartel/moneymentum/pull/260)
+      [#259](https://github.com/dataclique/moneymentum/issues/259) /
+      [#260](https://github.com/dataclique/moneymentum/pull/260)
 - [x] Factor: Sortino (adds MAR -- Minimum Acceptable Return -- to
       TimeframeConfig) --
-      [#261](https://github.com/data-cartel/moneymentum/issues/261) /
-      [#262](https://github.com/data-cartel/moneymentum/pull/262)
+      [#261](https://github.com/dataclique/moneymentum/issues/261) /
+      [#262](https://github.com/dataclique/moneymentum/pull/262)
 - [x] Factor: autocorrelation --
-      [#263](https://github.com/data-cartel/moneymentum/issues/263) /
-      [#264](https://github.com/data-cartel/moneymentum/pull/264)
+      [#263](https://github.com/dataclique/moneymentum/issues/263) /
+      [#264](https://github.com/dataclique/moneymentum/pull/264)
 - [x] Factor: information discreteness --
-      [#265](https://github.com/data-cartel/moneymentum/issues/265) /
-      [#266](https://github.com/data-cartel/moneymentum/pull/266)
+      [#265](https://github.com/dataclique/moneymentum/issues/265) /
+      [#266](https://github.com/dataclique/moneymentum/pull/266)
 - [x] Factor: carry (signed funding) --
-      [#267](https://github.com/data-cartel/moneymentum/issues/267) /
-      [#268](https://github.com/data-cartel/moneymentum/pull/268)
+      [#267](https://github.com/dataclique/moneymentum/issues/267) /
+      [#268](https://github.com/dataclique/moneymentum/pull/268)
 - [x] Factor: beta (per-asset, to benchmark) --
-      [#269](https://github.com/data-cartel/moneymentum/issues/269) /
-      [#270](https://github.com/data-cartel/moneymentum/pull/270)
+      [#269](https://github.com/dataclique/moneymentum/issues/269) /
+      [#270](https://github.com/dataclique/moneymentum/pull/270)
 - [x] Factor: 24h volume (screener tie-break) --
-      [#271](https://github.com/data-cartel/moneymentum/issues/271) /
-      [#272](https://github.com/data-cartel/moneymentum/pull/272)
+      [#271](https://github.com/dataclique/moneymentum/issues/271) /
+      [#272](https://github.com/dataclique/moneymentum/pull/272)
 - [x] Markets metadata + persisted disable flag --
-      [#275](https://github.com/data-cartel/moneymentum/issues/275) /
-      [#276](https://github.com/data-cartel/moneymentum/pull/276)
+      [#275](https://github.com/dataclique/moneymentum/issues/275) /
+      [#276](https://github.com/dataclique/moneymentum/pull/276)
 - [x] Tradable filter wired into ingestion --
-      [#277](https://github.com/data-cartel/moneymentum/issues/277) /
-      [#278](https://github.com/data-cartel/moneymentum/pull/278)
+      [#277](https://github.com/dataclique/moneymentum/issues/277) /
+      [#278](https://github.com/dataclique/moneymentum/pull/278)
 
 ---
 
@@ -158,8 +158,8 @@ result before sending trades.
 - [ ] [Compare Target vs Current Portfolio](./stories/0x01a.compare-target-vs-current-portfolio.md)
 - [ ] [Screen Perps By Factor](./stories/0x01c.screen-perps-by-factor.md) --
       backend rank API shipped
-      ([#273](https://github.com/data-cartel/moneymentum/issues/273) /
-      [#274](https://github.com/data-cartel/moneymentum/pull/274)); frontend
+      ([#273](https://github.com/dataclique/moneymentum/issues/273) /
+      [#274](https://github.com/dataclique/moneymentum/pull/274)); frontend
       filter integration pending
 - [ ] [Simulate Staged Portfolio Metrics](./stories/0x01d.simulate-staged-portfolio-metrics.md)
 
@@ -237,23 +237,23 @@ to DigitalOcean via NixOS + deploy-rs.
 ## Completed: GitButler CLI for stacked PRs
 
 - [x] Package the GitButler CLI via Nix --
-      [#243](https://github.com/data-cartel/moneymentum/issues/243) /
-      [#238](https://github.com/data-cartel/moneymentum/pull/238)
+      [#243](https://github.com/dataclique/moneymentum/issues/243) /
+      [#238](https://github.com/dataclique/moneymentum/pull/238)
 - [x] Add a GitButler skill for coding agents --
-      [#244](https://github.com/data-cartel/moneymentum/issues/244) /
-      [#240](https://github.com/data-cartel/moneymentum/pull/240)
+      [#244](https://github.com/dataclique/moneymentum/issues/244) /
+      [#240](https://github.com/dataclique/moneymentum/pull/240)
 
 ## Completed: Finish Python/Spark removal
 
 - [x] Remove dead Python linter tooling --
-      [#245](https://github.com/data-cartel/moneymentum/issues/245) /
-      [#241](https://github.com/data-cartel/moneymentum/pull/241)
+      [#245](https://github.com/dataclique/moneymentum/issues/245) /
+      [#241](https://github.com/dataclique/moneymentum/pull/241)
 - [x] Strip unused JVM/Spark deps from the dev shell --
-      [#246](https://github.com/data-cartel/moneymentum/issues/246) /
-      [#242](https://github.com/data-cartel/moneymentum/pull/242)
+      [#246](https://github.com/dataclique/moneymentum/issues/246) /
+      [#242](https://github.com/dataclique/moneymentum/pull/242)
 
 ## Completed: Per-PR issue and roadmap tracking
 
 - [x] Document and automate the issue-and-roadmap-per-PR rule --
-      [#247](https://github.com/data-cartel/moneymentum/issues/247) /
-      [#248](https://github.com/data-cartel/moneymentum/pull/248)
+      [#247](https://github.com/dataclique/moneymentum/issues/247) /
+      [#248](https://github.com/dataclique/moneymentum/pull/248)

--- a/flake.lock
+++ b/flake.lock
@@ -799,13 +799,13 @@
       "locked": {
         "lastModified": 1781119917,
         "narHash": "sha256-Z7YYJLfTXtnTzTerGktEsmCaffOEamgBNUY1mrEIdls=",
-        "owner": "data-cartel",
+        "owner": "dataclique",
         "repo": "fund",
         "rev": "d6e791b4e527da86f8a7da62039aafa2ca98d2f3",
         "type": "github"
       },
       "original": {
-        "owner": "data-cartel",
+        "owner": "dataclique",
         "repo": "fund",
         "rev": "d6e791b4e527da86f8a7da62039aafa2ca98d2f3",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,9 @@
     # cannot use, so it stays in its own repository; all we consume is its
     # `packages.idl` output (the Anchor IDL json client bindings are
     # generated from). Pinned to the feat/idl-flake-output head until
-    # data-cartel/fund#22 merges, then this can track the default branch.
+    # dataclique/fund#22 merges, then this can track the default branch.
     fund.url =
-      "github:data-cartel/fund/d6e791b4e527da86f8a7da62039aafa2ca98d2f3";
+      "github:dataclique/fund/d6e791b4e527da86f8a7da62039aafa2ca98d2f3";
   };
 
   outputs = { self, nixpkgs, flake-utils, git-hooks, devenv, rust-overlay, crane

--- a/frontend/default.nix
+++ b/frontend/default.nix
@@ -28,7 +28,7 @@ in {
 
     meta = {
       description = "moneymentum frontend";
-      homepage = "https://github.com/data-cartel/moneymentum";
+      homepage = "https://github.com/dataclique/moneymentum";
     };
   });
 

--- a/stories/0x005.execute-rebalance.md
+++ b/stories/0x005.execute-rebalance.md
@@ -28,5 +28,5 @@ positions move toward the target portfolio.
 
 ## Related Work
 
-- PR [#142](https://github.com/data-cartel/moneymentum/pull/142) -- placing
+- PR [#142](https://github.com/dataclique/moneymentum/pull/142) -- placing
   order + rendering logic fixes

--- a/stories/0x006.protect-invalid-rebalances.md
+++ b/stories/0x006.protect-invalid-rebalances.md
@@ -32,5 +32,5 @@ portfolio model.
 
 ## Related Work
 
-- PR [#142](https://github.com/data-cartel/moneymentum/pull/142) -- placing
+- PR [#142](https://github.com/dataclique/moneymentum/pull/142) -- placing
   order + rendering logic fixes

--- a/stories/0x00f.authenticate-portfolio-ownership-by-solana-pubkey.md
+++ b/stories/0x00f.authenticate-portfolio-ownership-by-solana-pubkey.md
@@ -45,7 +45,7 @@ my portfolio can be identified by my public key.
 
 ## Related Work
 
-- PR [#120](https://github.com/data-cartel/moneymentum/pull/120) -- wallet trait
+- PR [#120](https://github.com/dataclique/moneymentum/pull/120) -- wallet trait
   and mock (DRAFT, preparatory infra)
-- PR [#121](https://github.com/data-cartel/moneymentum/pull/121) -- Turnkey EVM
+- PR [#121](https://github.com/dataclique/moneymentum/pull/121) -- Turnkey EVM
   wallet (DRAFT, preparatory infra)

--- a/stories/0x017.deposit-into-vault.md
+++ b/stories/0x017.deposit-into-vault.md
@@ -20,8 +20,8 @@ so that my capital is allocated by the vault strategy without giving up custody.
 
 ## Related Work
 
-- PR [#122](https://github.com/dataclique/moneymentum/pull/122) -- vault
-  program architecture (DRAFT)
+- PR [#122](https://github.com/dataclique/moneymentum/pull/122) -- vault program
+  architecture (DRAFT)
 - Issues [#123](https://github.com/dataclique/moneymentum/issues/123),
   [#124](https://github.com/dataclique/moneymentum/issues/124),
   [#131](https://github.com/dataclique/moneymentum/issues/131) -- vault

--- a/stories/0x017.deposit-into-vault.md
+++ b/stories/0x017.deposit-into-vault.md
@@ -20,9 +20,9 @@ so that my capital is allocated by the vault strategy without giving up custody.
 
 ## Related Work
 
-- PR [#122](https://github.com/data-cartel/moneymentum/pull/122) -- vault
+- PR [#122](https://github.com/dataclique/moneymentum/pull/122) -- vault
   program architecture (DRAFT)
-- Issues [#123](https://github.com/data-cartel/moneymentum/issues/123),
-  [#124](https://github.com/data-cartel/moneymentum/issues/124),
-  [#131](https://github.com/data-cartel/moneymentum/issues/131) -- vault
+- Issues [#123](https://github.com/dataclique/moneymentum/issues/123),
+  [#124](https://github.com/dataclique/moneymentum/issues/124),
+  [#131](https://github.com/dataclique/moneymentum/issues/131) -- vault
   scaffold, initialize + deposit instructions, deposit UI

--- a/stories/0x018.withdraw-from-vault.md
+++ b/stories/0x018.withdraw-from-vault.md
@@ -32,9 +32,9 @@ capital out of the strategy when I choose to.
 
 ## Related Work
 
-- PR [#122](https://github.com/data-cartel/moneymentum/pull/122) -- vault
+- PR [#122](https://github.com/dataclique/moneymentum/pull/122) -- vault
   program architecture (DRAFT)
-- Issues [#127](https://github.com/data-cartel/moneymentum/issues/127),
-  [#128](https://github.com/data-cartel/moneymentum/issues/128),
-  [#132](https://github.com/data-cartel/moneymentum/issues/132) -- fee math,
+- Issues [#127](https://github.com/dataclique/moneymentum/issues/127),
+  [#128](https://github.com/dataclique/moneymentum/issues/128),
+  [#132](https://github.com/dataclique/moneymentum/issues/132) -- fee math,
   two-phase withdrawal, withdraw UI

--- a/stories/0x018.withdraw-from-vault.md
+++ b/stories/0x018.withdraw-from-vault.md
@@ -32,8 +32,8 @@ capital out of the strategy when I choose to.
 
 ## Related Work
 
-- PR [#122](https://github.com/dataclique/moneymentum/pull/122) -- vault
-  program architecture (DRAFT)
+- PR [#122](https://github.com/dataclique/moneymentum/pull/122) -- vault program
+  architecture (DRAFT)
 - Issues [#127](https://github.com/dataclique/moneymentum/issues/127),
   [#128](https://github.com/dataclique/moneymentum/issues/128),
   [#132](https://github.com/dataclique/moneymentum/issues/132) -- fee math,

--- a/stories/0x019.use-derive-options-for-protective-puts.md
+++ b/stories/0x019.use-derive-options-for-protective-puts.md
@@ -44,5 +44,5 @@ than only manually tracked entries.
 
 ## Related Work
 
-- PR [#158](https://github.com/data-cartel/moneymentum/pull/158) -- Derive
+- PR [#158](https://github.com/dataclique/moneymentum/pull/158) -- Derive
   integration (DRAFT)

--- a/stories/0x01a.compare-target-vs-current-portfolio.md
+++ b/stories/0x01a.compare-target-vs-current-portfolio.md
@@ -26,5 +26,5 @@ when I do.
 
 ## Related Work
 
-- Issue [#52](https://github.com/data-cartel/moneymentum/issues/52) -- original
+- Issue [#52](https://github.com/dataclique/moneymentum/issues/52) -- original
   problem statement and proposed solution

--- a/stories/0x01b.show-risk-analytics-for-active-portfolio.md
+++ b/stories/0x01b.show-risk-analytics-for-active-portfolio.md
@@ -47,5 +47,5 @@ metrics so the reader knows the baseline.
 
 ## Related Work
 
-- Issue [#74](https://github.com/data-cartel/moneymentum/issues/74) -- risk
+- Issue [#74](https://github.com/dataclique/moneymentum/issues/74) -- risk
   analytics scope

--- a/stories/0x01c.screen-perps-by-factor.md
+++ b/stories/0x01c.screen-perps-by-factor.md
@@ -27,7 +27,7 @@ direction and tie-break order are exposed on the ranking API (e.g.
 explicitly.
 
 The backend rank API (`POST /screener/<timeframe>`) ships these via
-[#274](https://github.com/data-cartel/moneymentum/pull/274); the final item is
+[#274](https://github.com/dataclique/moneymentum/pull/274); the final item is
 frontend portfolio-construction work that consumes the API.
 
 - [x] The screener can rank perps by beta to BTC (or another benchmark).
@@ -44,5 +44,5 @@ frontend portfolio-construction work that consumes the API.
 
 ## Related Work
 
-- Issue [#75](https://github.com/data-cartel/moneymentum/issues/75) -- screener
+- Issue [#75](https://github.com/dataclique/moneymentum/issues/75) -- screener
   scope

--- a/stories/0x01d.simulate-staged-portfolio-metrics.md
+++ b/stories/0x01d.simulate-staged-portfolio-metrics.md
@@ -25,5 +25,5 @@ send any trades.
 
 ## Related Work
 
-- Issue [#76](https://github.com/data-cartel/moneymentum/issues/76) -- staged
+- Issue [#76](https://github.com/dataclique/moneymentum/issues/76) -- staged
   simulation scope

--- a/stories/0x01e.trade-hyperliquid-spot-positions.md
+++ b/stories/0x01e.trade-hyperliquid-spot-positions.md
@@ -26,5 +26,5 @@ workflows.
 
 ## Related Work
 
-- Issue [#77](https://github.com/data-cartel/moneymentum/issues/77) -- spot
+- Issue [#77](https://github.com/dataclique/moneymentum/issues/77) -- spot
   integration scope

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -101,7 +101,7 @@ async fn poll_for_status(
 }
 
 // Temporarily skipped: fails due to OneWeek timeframe overflow when using a
-// 5000-entry window; see https://github.com/data-cartel/moneymentum/issues/64.
+// 5000-entry window; see https://github.com/dataclique/moneymentum/issues/64.
 #[ignore = "OneWeek timeframe window overflows when requesting 5000 candles (see issue #64)"]
 #[rocket::async_test]
 async fn ingest_and_query_candles() {


### PR DESCRIPTION
## What
Update `data-cartel` references to `dataclique` and set package author to Data Clique Software Design FZCO.

## Why
Org renamed `data-cartel` → `dataclique` (legal entity: Data Clique Software Design FZCO).

## How
- Issue/PR URLs across ROADMAP, stories, ADRs, `tests/api.rs`, `frontend/default.nix` homepage → `dataclique`.
- `fund` flake input + `flake.lock` owner → `dataclique` (pinned rev unchanged).
- Added `authors = ["Data Clique Software Design FZCO"]` to root `Cargo.toml`.

## Testing
Reference/metadata-only; no residual `data-cartel` references.