### PR TITLE
feat: fetchMarkets on server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,9 +2248,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -3234,6 +3245,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "getrandom 0.4.3",
  "hyperliquid_rust_sdk",
  "polars",
  "proptest",
@@ -4601,6 +4613,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,8 @@ serde_json = "1.0.149"
 tempfile = "3.24.0"
 tracing-test = "0.2.5"
 wiremock = "0.6.5"
+
+# Single-package crate: declaring the workspace root keeps cargo from walking up
+# into an outer workspace when this repo is checked out inside one (e.g. a git
+# worktree under another project), which otherwise breaks cargo metadata.
+[workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bitcoin = "0.32.8"
 chrono = { version = "0.4.43", features = ["serde"] }
 clap = { version = "4.5.57", features = ["derive", "env"] }
 futures = "0.3.31"
+getrandom = "0.4.3"
 hyperliquid_rust_sdk = "0.6.0"
 polars = { version = "0.51", features = [
   "parquet",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ of them.
 - [x] Factor: 24h volume (screener tie-break) --
       [#271](https://github.com/dataclique/moneymentum/issues/271) /
       [#272](https://github.com/dataclique/moneymentum/pull/272)
-- [x] Markets metadata + persisted disable flag --
+- [x] Markets metadata ledger --
       [#275](https://github.com/dataclique/moneymentum/issues/275) /
       [#276](https://github.com/dataclique/moneymentum/pull/276)
 - [x] Tradable filter wired into ingestion --

--- a/ai/skills/gitbutler/SKILL.md
+++ b/ai/skills/gitbutler/SKILL.md
@@ -213,9 +213,9 @@ GitButler snapshots everything, including uncommitted changes:
 
 - **Pre-commit hooks (prek):** `prek` is the repo's pre-commit hook runner;
   `but commit` runs the hooks (nixfmt-classic, nil, eslint, prettier, taplo,
-  denofmt, rustfmt). If you must `but amend`/`but rub` (which skip hooks), run
-  `prek run --all-files` afterward and fold in any formatting fixes before
-  pushing. Markdown is formatted by `deno fmt`.
+  denofmt, rustfmt, clippy). If you must `but amend`/`but rub` (which skip
+  hooks), run `prek run --all-files` afterward and fold in any formatting fixes
+  before pushing. Markdown is formatted by `deno fmt`.
 - **Commit messages:** conventional, lowercase -- `feat:`, `fix:`, `docs:`,
   `chore:`, `refactor:`, `test:`. Explain _why_ in the body. Never add
   "Generated with ..." or co-author trailers.

--- a/config.toml
+++ b/config.toml
@@ -18,4 +18,5 @@ log_level = "info"
 
 # Concurrency and retry settings for Hyperliquid requests.
 max_concurrent_requests = 1
-max_retries = 5             # so that Rust patiently retries on 429
+max_retries = 5                                       # so that Rust patiently retries on 429
+markets_refresh_token = "local-markets-refresh-token"

--- a/config/moneymentum.toml
+++ b/config/moneymentum.toml
@@ -4,4 +4,3 @@ database_url = "sqlite:///mnt/data/prod/moneymentum.db?mode=rwc"
 log_level = "info"
 max_concurrent_requests = 3
 max_retries = 5
-markets_refresh_token = "prod-markets-refresh-token"

--- a/config/moneymentum.toml
+++ b/config/moneymentum.toml
@@ -4,3 +4,4 @@ database_url = "sqlite:///mnt/data/prod/moneymentum.db?mode=rwc"
 log_level = "info"
 max_concurrent_requests = 3
 max_retries = 5
+markets_refresh_token = "prod-markets-refresh-token"

--- a/config/secrets.nix
+++ b/config/secrets.nix
@@ -1,2 +1,6 @@
-let inherit (import ../keys.nix) roles;
-in { "server.toml.age".publicKeys = roles.service; }
+let
+  inherit (import ../keys.nix) roles;
+in
+{
+  "server.toml.age".publicKeys = roles.service;
+}

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -4,3 +4,4 @@ database_url = "sqlite:///mnt/data/staging/moneymentum.db?mode=rwc"
 log_level = "debug"
 max_concurrent_requests = 3
 max_retries = 5
+markets_refresh_token = "staging-markets-refresh-token"

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -4,4 +4,3 @@ database_url = "sqlite:///mnt/data/staging/moneymentum.db?mode=rwc"
 log_level = "debug"
 max_concurrent_requests = 3
 max_retries = 5
-markets_refresh_token = "staging-markets-refresh-token"

--- a/deploy.nix
+++ b/deploy.nix
@@ -8,25 +8,30 @@ let
   moneymentumPackage = self.packages.${system}.moneymentum;
 
   services = import ./services.nix;
-  enabledServices = builtins.filter (name: services.${name}.enabled)
-    (builtins.attrNames services);
+  enabledServices = builtins.filter (name: services.${name}.enabled) (builtins.attrNames services);
 
-  mkServiceProfile = name:
-    let markerFile = "/run/moneymentum/${name}.ready";
-    in activate.custom moneymentumPackage (builtins.concatStringsSep " && " [
-      "systemctl stop ${name} || true"
-      "rm -f ${markerFile}"
-      "mkdir -p /run/moneymentum"
-      "touch ${markerFile}"
-      "systemctl restart ${name}"
-    ]);
+  mkServiceProfile =
+    name:
+    let
+      markerFile = "/run/moneymentum/${name}.ready";
+    in
+    activate.custom moneymentumPackage (
+      builtins.concatStringsSep " && " [
+        "systemctl stop ${name} || true"
+        "rm -f ${markerFile}"
+        "mkdir -p /run/moneymentum"
+        "touch ${markerFile}"
+        "systemctl restart ${name}"
+      ]
+    );
 
   mkProfile = name: {
     path = mkServiceProfile name;
     profilePath = "${profileBase}/${name}";
   };
 
-in {
+in
+{
   config = {
     nodes.moneymentum = {
       hostname = "MUST_OVERRIDE_HOSTNAME";
@@ -37,20 +42,31 @@ in {
 
       profiles = {
         system.path = activate.nixos self.nixosConfigurations.moneymentum;
-      } // builtins.listToAttrs (map (name: {
-        inherit name;
-        value = mkProfile name;
-      }) enabledServices);
+      }
+      // builtins.listToAttrs (
+        map (name: {
+          inherit name;
+          value = mkProfile name;
+        }) enabledServices
+      );
     };
   };
 
-  wrappers = { pkgs, infraPkgs, localSystem }:
+  wrappers =
+    {
+      pkgs,
+      infraPkgs,
+      localSystem,
+    }:
     let
       # Only rage (decrypt state) + jq (parse IP) + deploy-rs are needed.
       # infraPkgs.buildInputs also includes terraform and ragenix which
       # deploy scripts never use.
-      deployInputs =
-        [ pkgs.rage pkgs.jq deploy-rs.packages.${localSystem}.deploy-rs ];
+      deployInputs = [
+        pkgs.rage
+        pkgs.jq
+        deploy-rs.packages.${localSystem}.deploy-rs
+      ];
 
       resolvePreamble = ''
         ${infraPkgs.resolveIp}
@@ -71,15 +87,15 @@ in {
         fi
       '';
 
-      deployFlags = if localSystem == "x86_64-linux" then
-        "--skip-checks"
-      else
-        "--remote-build --skip-checks";
+      deployFlags =
+        if localSystem == "x86_64-linux" then "--skip-checks" else "--remote-build --skip-checks";
 
-      serviceCleanup = builtins.concatStringsSep "; "
-        (map (name: "systemctl reset-failed ${name} || true") enabledServices);
+      serviceCleanup = builtins.concatStringsSep "; " (
+        map (name: "systemctl reset-failed ${name} || true") enabledServices
+      );
 
-    in {
+    in
+    {
       deployNixos = pkgs.writeShellApplication {
         name = "deploy-nixos";
         runtimeInputs = deployInputs;
@@ -114,7 +130,10 @@ in {
 
       deployFrontend = pkgs.writeShellApplication {
         name = "deploy-frontend";
-        runtimeInputs = deployInputs ++ [ pkgs.openssh pkgs.rsync ];
+        runtimeInputs = deployInputs ++ [
+          pkgs.openssh
+          pkgs.rsync
+        ];
         text = ''
           if [ "$#" -ne 0 ] && [ "''${1:-}" != "-i" ]; then
             echo "usage: deploy-frontend [-i identity]" >&2

--- a/example.toml
+++ b/example.toml
@@ -7,6 +7,9 @@ database_url = "sqlite:./moneymentum.db?mode=rwc"
 
 log_level = "debug"
 
+# Shared secret for POST /hyperliquid/markets/refresh (systemd midnight job).
+markets_refresh_token = "local-markets-refresh-token"
+
 # Ingestion tuning - balance speed vs rate limiting
 max_concurrent_requests = 3
 max_retries = 5

--- a/example.toml
+++ b/example.toml
@@ -7,7 +7,8 @@ database_url = "sqlite:./moneymentum.db?mode=rwc"
 
 log_level = "debug"
 
-# Shared secret for POST /hyperliquid/markets/refresh (systemd midnight job).
+# Optional for local dev. On NixOS the server generates a token at startup and
+# publishes it for the midnight refresh timer.
 markets_refresh_token = "local-markets-refresh-token"
 
 # Ingestion tuning - balance speed vs rate limiting

--- a/flake.lock
+++ b/flake.lock
@@ -27,7 +27,6 @@
     "bun2nix": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "import-tree": "import-tree",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -35,11 +34,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1770895533,
-        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
         "type": "github"
       },
       "original": {
@@ -67,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760971495,
-        "narHash": "sha256-IwnNtbNVrlZIHh7h4Wz6VP0Furxg9Hh0ycighvL5cZc=",
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "c5bfd933d1033672f51a863c47303fc0e093c2d2",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
         "type": "github"
       },
       "original": {
@@ -182,11 +181,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1772560058,
-        "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "db590d9286ed5ce22017541e36132eab4e8b3045",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -211,6 +210,23 @@
       }
     },
     "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "crate2nix_2": {
       "inputs": {
         "cachix": "cachix_3",
         "crate2nix_stable": "crate2nix_stable",
@@ -303,11 +319,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1770019181,
-        "narHash": "sha256-hwsYgDnby50JNVpTRYlF3UR/Rrpt01OrxVuryF40CFY=",
+        "lastModified": 1781627888,
+        "narHash": "sha256-5yHuAh9k7rT7rtf3uRaXkiUyYvQE9oaCgzhprLm2mr8=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "77c906c0ba56aabdbc72041bf9111b565cdd6171",
+        "rev": "6d3087eedff75a715b40c0e124ba15d2dd7bec28",
         "type": "github"
       },
       "original": {
@@ -319,8 +335,10 @@
     "devenv": {
       "inputs": {
         "cachix": "cachix",
+        "crate2nix": "crate2nix",
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
+        "ghostty": "ghostty",
         "git-hooks": [
           "git-hooks"
         ],
@@ -328,14 +346,15 @@
         "nixd": "nixd",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772605794,
-        "narHash": "sha256-DYjrRYXbUyOyPZO3JBRw8spex/W7R+q+QAdcCF0olhA=",
+        "lastModified": 1782492839,
+        "narHash": "sha256-j9wrcB4al5QhMelEghJ0Qs+RQPT+wyCcI4070NEgPLQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "8586acc009123797858e33bbc4a379769a62da79",
+        "rev": "3d39d0817d62069f7b18821c34a617b5141cb278",
         "type": "github"
       },
       "original": {
@@ -347,10 +366,10 @@
     "devenv_2": {
       "inputs": {
         "cachix": "cachix_2",
-        "crate2nix": "crate2nix",
+        "crate2nix": "crate2nix_2",
         "flake-compat": "flake-compat_5",
         "flake-parts": "flake-parts_5",
-        "ghostty": "ghostty",
+        "ghostty": "ghostty_2",
         "git-hooks": [
           "fund",
           "git-hooks"
@@ -361,7 +380,7 @@
           "fund",
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1778546030,
@@ -431,11 +450,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772420042,
-        "narHash": "sha256-naZz40TUFMa0E0CutvwWsSPhgD5JldyTUDEgP9ADpfU=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5af7af10f14706e4095bd6bc0d9373eb097283c6",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -452,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769524058,
-        "narHash": "sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "71a3fc97d80881e91710fe721f1158d3b96ae14d",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -485,11 +504,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -592,14 +611,17 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "bun2nix",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
@@ -616,11 +638,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760948891,
-        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -698,42 +720,6 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1723604017,
-        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems_3"
@@ -794,7 +780,7 @@
         "flake-utils": "flake-utils_2",
         "git-hooks": "git-hooks_3",
         "nixpkgs": "nixpkgs_6",
-        "rust-overlay": "rust-overlay_2"
+        "rust-overlay": "rust-overlay_3"
       },
       "locked": {
         "lastModified": 1781119917,
@@ -812,6 +798,22 @@
       }
     },
     "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779069789,
+        "narHash": "sha256-ojo+gso45/6CVSuqfSVnlWpQ4d0QeLgwok+v/g3yu0E=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "4b7bf0b20e3baf9c1ba10c63f2ad1fd853faea8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "ghostty_2": {
       "inputs": {
         "flake-compat": "flake-compat_6",
         "home-manager": "home-manager",
@@ -932,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772024342,
-        "narHash": "sha256-+eXlIc4/7dE6EcPs9a2DaSY3fTA9AE526hGqkNID3Wg=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6e34e97ed9788b17796ee43ccdbaf871a5c2b476",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -1133,21 +1135,6 @@
         "type": "github"
       }
     },
-    "import-tree": {
-      "locked": {
-        "lastModified": 1763762820,
-        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
-        "owner": "vic",
-        "repo": "import-tree",
-        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vic",
-        "repo": "import-tree",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "flake-compat": [
@@ -1174,16 +1161,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1771532737,
-        "narHash": "sha256-H26FQmOyvIGnedfAioparJQD8Oe+/byD6OpUpnI/hkE=",
+        "lastModified": 1779748925,
+        "narHash": "sha256-meIhqGC04O5VXbKSFXSQoOKp+XCq5RMnwAk1Guo0VQo=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "7eb6c427c7a86fdc3ebf9e6cbf2a84e80e8974fd",
+        "rev": "0bc443c8ff235c3547d09327b48aaa2ab98b15f2",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.32",
+        "ref": "devenv-2.34",
         "repo": "nix",
         "type": "github"
       }
@@ -1228,16 +1215,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1769079217,
-        "narHash": "sha256-R6qzhu+YJolxE2vUsPQWWwUKMbAG5nXX3pBtg8BNX38=",
-        "owner": "Enzime",
+        "lastModified": 1781506385,
+        "narHash": "sha256-kvTBHLiqB911yf2D9VThIRfB6Ai/E2H9+mVF0wR+9AY=",
+        "owner": "numtide",
         "repo": "nix-vm-test",
-        "rev": "58c15f78947b431d6c206e0966500c7e9139bd2f",
+        "rev": "2071ebc1f5b2a2e0211a2ca38c4e678092df76a5",
         "type": "github"
       },
       "original": {
-        "owner": "Enzime",
-        "ref": "pr-105-latest",
+        "owner": "numtide",
         "repo": "nix-vm-test",
         "type": "github"
       }
@@ -1294,7 +1280,6 @@
           "devenv",
           "flake-parts"
         ],
-        "flake-root": "flake-root",
         "nixpkgs": [
           "devenv",
           "nixpkgs"
@@ -1302,11 +1287,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1763964548,
-        "narHash": "sha256-JTRoaEWvPsVIMFJWeS4G2isPo15wqXY/otsiHPN0zww=",
+        "lastModified": 1778381404,
+        "narHash": "sha256-FqhdOTA8vyoIpkHhbs2cCT7h6EWM7nsLeOYJc1ifQLE=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "d4bf15e56540422e2acc7bc26b20b0a0934e3f5e",
+        "rev": "e3e45eb76663f522e196b7f0cf34cab201db7779",
         "type": "github"
       },
       "original": {
@@ -1342,7 +1327,6 @@
     "nixos-anywhere": {
       "inputs": {
         "disko": "disko_2",
-        "flake-parts": "flake-parts_6",
         "nix-vm-test": "nix-vm-test",
         "nixos-images": "nixos-images",
         "nixos-stable": "nixos-stable",
@@ -1352,11 +1336,11 @@
         "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
-        "lastModified": 1769956140,
-        "narHash": "sha256-D+RQ+DaIC/GVwv5lUs7e8jSmh8aPc77Kg/gRjaS25Zk=",
+        "lastModified": 1782285665,
+        "narHash": "sha256-ISUNn+z9+BIDGRrNAmEfghvzFmDgKtGHGEYqIDvGeWk=",
         "owner": "nix-community",
         "repo": "nixos-anywhere",
-        "rev": "92f82c5196a5f8588be4967e535c4cfd35e85902",
+        "rev": "4b74194d2927a7741d023b3fd2a0d252059f75ee",
         "type": "github"
       },
       "original": {
@@ -1377,11 +1361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766770015,
-        "narHash": "sha256-kUmVBU+uBUPl/v3biPiWrk680b8N9rRMhtY97wsxiJc=",
+        "lastModified": 1781778781,
+        "narHash": "sha256-CYnhWtKIr0xbxQT6N0X1j0FsmCG+cDV498jyO0xevwQ=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "e4dba54ddb6b2ad9c6550e5baaed2fa27938a5d2",
+        "rev": "94cbd4c8da5f130f188af04293514926a947b380",
         "type": "github"
       },
       "original": {
@@ -1392,16 +1376,16 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1769598131,
-        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1419,21 +1403,6 @@
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -1513,16 +1482,16 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1770136044,
-        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
+        "lastModified": 1782375420,
+        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
+        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1597,7 +1566,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_3"
+        "rust-overlay": "rust-overlay_4"
       },
       "locked": {
         "lastModified": 1761832913,
@@ -1626,10 +1595,31 @@
         "nixos-anywhere": "nixos-anywhere",
         "nixpkgs": "nixpkgs_7",
         "ragenix": "ragenix",
-        "rust-overlay": "rust-overlay_4"
+        "rust-overlay": "rust-overlay_5"
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779074409,
+        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "fund",
@@ -1651,7 +1641,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_2": {
+    "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
           "fund",
@@ -1672,7 +1662,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_3": {
+    "rust-overlay_4": {
       "inputs": {
         "nixpkgs": [
           "ragenix",
@@ -1693,18 +1683,18 @@
         "type": "github"
       }
     },
-    "rust-overlay_4": {
+    "rust-overlay_5": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1772593411,
-        "narHash": "sha256-47WOnCSyOL6AghZiMIJaTLWM359DHe3be9R1cNCdGUE=",
+        "lastModified": 1782530211,
+        "narHash": "sha256-Zn5H2VVMaP79C+bvaUQD+SBXSKoTnURMZGiUrG00zII=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a741b36b77440f5db15fcf2ab6d7d592d2f9ee8f",
+        "rev": "06ba695dfefc4afc513b49dfc41c4bf0dd2eaeb1",
         "type": "github"
       },
       "original": {
@@ -1827,11 +1817,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {
@@ -1849,11 +1839,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {
@@ -1893,11 +1883,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769691507,
-        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
 
     git-hooks.url = "github:cachix/git-hooks.nix";
@@ -37,27 +37,47 @@
     # `packages.idl` output (the Anchor IDL json client bindings are
     # generated from). Pinned to the feat/idl-flake-output head until
     # dataclique/fund#22 merges, then this can track the default branch.
-    fund.url =
-      "github:dataclique/fund/d6e791b4e527da86f8a7da62039aafa2ca98d2f3";
+    fund.url = "github:dataclique/fund/d6e791b4e527da86f8a7da62039aafa2ca98d2f3";
   };
 
-  outputs = { self, nixpkgs, flake-utils, git-hooks, devenv, rust-overlay, crane
-    , ragenix, disko, nixos-anywhere, deploy-rs, bun2nix, fund, ... }@inputs:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      git-hooks,
+      devenv,
+      rust-overlay,
+      crane,
+      ragenix,
+      disko,
+      nixos-anywhere,
+      deploy-rs,
+      bun2nix,
+      fund,
+      ...
+    }@inputs:
     {
       nixosConfigurations.moneymentum = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
 
-        modules =
-          [ disko.nixosModules.disko ragenix.nixosModules.default ./os.nix ];
+        modules = [
+          disko.nixosModules.disko
+          ragenix.nixosModules.default
+          ./os.nix
+        ];
       };
 
       deploy = (import ./deploy.nix { inherit deploy-rs self; }).config;
-    } // flake-utils.lib.eachDefaultSystem (system:
+    }
+    // flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
-          config.allowUnfreePredicate = pkg:
+          config.allowUnfreePredicate =
+            pkg:
             builtins.elem (pkgs.lib.getName pkg) [
               "terraform"
               "gitbutler-cli"
@@ -77,14 +97,19 @@
           bun2nix = bun2nix.packages.${system}.default;
         };
 
-        infraPkgs =
-          import ./infra { inherit pkgs ragenix nixos-anywhere system; };
+        infraPkgs = import ./infra {
+          inherit
+            pkgs
+            ragenix
+            nixos-anywhere
+            system
+            ;
+        };
 
-        deployPkgs =
-          (import ./deploy.nix { inherit deploy-rs self; }).wrappers {
-            inherit pkgs infraPkgs;
-            localSystem = system;
-          };
+        deployPkgs = (import ./deploy.nix { inherit deploy-rs self; }).wrappers {
+          inherit pkgs infraPkgs;
+          localSystem = system;
+        };
 
         cargoClippyHook = pkgs.writeShellScript "moneymentum-cargo-clippy" ''
           set -euo pipefail
@@ -100,14 +125,13 @@
         hooks = {
           # Nix
           nil.enable = true;
-          nixfmt-classic.enable = true;
+          nixfmt.enable = true;
 
           # TypeScript
           eslint = {
             enable = true;
             files = "^frontend/.*\\.(ts|tsx|js|jsx)$";
-            entry =
-              "${pkgs.bash}/bin/bash -c 'cd frontend && ${pkgs.bun}/bin/bun run lint'";
+            entry = "${pkgs.bash}/bin/bash -c 'cd frontend && ${pkgs.bun}/bin/bun run lint'";
             pass_filenames = false;
           };
           prettier = {
@@ -135,7 +159,7 @@
             pass_filenames = true;
           };
           clippy = {
-            enable = true;
+            enable = false; # clippy is way too fucking slow to be a pre-commit hook
             entry = "${cargoClippyHook}";
             files = "\\.(rs|toml)$|^Cargo\\.lock$";
             pass_filenames = false;
@@ -155,22 +179,29 @@
           };
         };
 
-        deps = with pkgs; [ cacert openssl.dev pkg-config sqlite.dev ];
+        deps = with pkgs; [
+          cacert
+          openssl.dev
+          pkg-config
+          sqlite.dev
+        ];
 
         frontendShell = devenv.lib.mkShell {
           inherit inputs pkgs;
-          modules = [{
-            languages.javascript = {
-              enable = true;
-              directory = "frontend";
-              bun = {
+          modules = [
+            {
+              languages.javascript = {
                 enable = true;
-                install.enable = true;
+                directory = "frontend";
+                bun = {
+                  enable = true;
+                  install.enable = true;
+                };
               };
-            };
 
-            git-hooks = { inherit hooks; };
-          }];
+              git-hooks = { inherit hooks; };
+            }
+          ];
         };
 
         devShell = devenv.lib.mkShell {
@@ -178,8 +209,10 @@
           modules = [
             ({ config, ... }: {
               # https://devenv.sh/reference/options/
-              packages = with pkgs;
-                deps ++ [
+              packages =
+                with pkgs;
+                deps
+                ++ [
                   git
                   gitbutler-cli
                   ragenix.packages.${system}.default
@@ -226,14 +259,14 @@
 
               # Use pre-commit instead of git-hooks
               git-hooks = { inherit hooks; };
-
               difftastic.enable = true;
               cachix.enable = true;
             })
           ];
         };
 
-      in {
+      in
+      {
         devShells.default = devShell;
         devShells.frontend = frontendShell;
 
@@ -243,38 +276,56 @@
             src = self;
           };
         };
+
         packages = {
+          inherit gitbutler-cli;
+          inherit (infraPkgs)
+            tfInit
+            tfPlan
+            tfApply
+            tfImport
+            tfEditVars
+            tfCreateVars
+            tfRekey
+            rekey
+            bootstrap
+            remote
+            ;
+          inherit (deployPkgs)
+            deployNixos
+            deployService
+            deployServer
+            deployFrontend
+            ;
+
           default = rustPkgs.package;
           moneymentum = rustPkgs.package;
           moneymentum-test = rustPkgs.test;
           moneymentum-clippy = rustPkgs.clippy;
-
-          inherit gitbutler-cli;
-
           frontend = frontendPkgs.package;
           frontend-lint = frontendPkgs.lint;
           frontend-test = frontendPkgs.test;
 
           resolveIp = pkgs.writeShellApplication {
             name = "resolve-ip";
-            runtimeInputs = [ pkgs.rage pkgs.jq ];
+            runtimeInputs = [
+              pkgs.rage
+              pkgs.jq
+            ];
             text = ''
               ${infraPkgs.resolveIp}
               echo "$host_ip"
             '';
           };
-
-          inherit (infraPkgs)
-            tfInit tfPlan tfApply tfImport tfEditVars tfCreateVars tfRekey rekey
-            bootstrap remote;
-          inherit (deployPkgs)
-            deployNixos deployService deployServer deployFrontend;
         };
-      });
+      }
+    );
 
   nixConfig = {
-    extra-substituters =
-      [ "https://devenv.cachix.org" "https://nix-community.cachix.org" ];
+    extra-substituters = [
+      "https://devenv.cachix.org"
+      "https://nix-community.cachix.org"
+    ];
     extra-trusted-public-keys = [
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="

--- a/flake.nix
+++ b/flake.nix
@@ -128,19 +128,16 @@
           nixfmt.enable = true;
 
           # TypeScript
+          prettier.enable = true;
+          prettier.excludes = [ "\\.md$" ];
           eslint = {
             enable = true;
             files = "^frontend/.*\\.(ts|tsx|js|jsx)$";
-            entry = "${pkgs.bash}/bin/bash -c 'cd frontend && ${pkgs.bun}/bin/bun run lint'";
             pass_filenames = false;
+            entry = ''
+              ${pkgs.bash}/bin/bash -c 'cd frontend && ${pkgs.bun}/bin/bun run lint'
+            '';
           };
-          prettier = {
-            enable = true;
-            excludes = [ "\\.md$" ];
-          };
-
-          # TOML
-          taplo.enable = true;
 
           # Markdown
           denofmt = {
@@ -151,6 +148,8 @@
             pass_filenames = true;
           };
 
+          # TOML
+          taplo.enable = true;
           # Rust - custom entry to avoid git-hooks.nix/nixpkgs version mismatch
           rustfmt = {
             enable = true;
@@ -165,6 +164,7 @@
             pass_filenames = false;
           };
         };
+
         hooksForChecks = hooks // {
           eslint = hooks.eslint // {
             # The CI frontend job runs eslint inside the frontend shell with Bun

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,17 @@
             localSystem = system;
           };
 
+        cargoClippyHook = pkgs.writeShellScript "moneymentum-cargo-clippy" ''
+          set -euo pipefail
+          export RUSTFLAGS="-D warnings"
+          export DATABASE_URL="''${DATABASE_URL:-sqlite::memory:}"
+          export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          export NIX_SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          export FUND_IDL="${fund.packages.${system}.idl}/idl/fund.json"
+          exec ${rustToolchain}/bin/cargo clippy --all-targets --locked -- \
+            -D clippy::all
+        '';
+
         hooks = {
           # Nix
           nil.enable = true;
@@ -123,12 +134,23 @@
             files = "\\.rs$";
             pass_filenames = true;
           };
+          clippy = {
+            enable = true;
+            entry = "${cargoClippyHook}";
+            files = "\\.(rs|toml)$|^Cargo\\.lock$";
+            pass_filenames = false;
+          };
         };
         hooksForChecks = hooks // {
           eslint = hooks.eslint // {
             # The CI frontend job runs eslint inside the frontend shell with Bun
             # dependencies installed. Keeping eslint in this pure Nix hook check
             # forces a cold bun2nix dependency build and duplicates that gate.
+            enable = false;
+          };
+          clippy = hooks.clippy // {
+            # Same gate as moneymentum-clippy in the backend CI job; the pure
+            # hook check cannot compile the crate graph in its sandbox.
             enable = false;
           };
         };

--- a/frontend/bun.nix
+++ b/frontend/bun.nix
@@ -5,2865 +5,2100 @@
 # Consume this with `fetchBunDeps` (recommended)
 # or `pkgs.callPackage` if you wish to handle
 # it manually.
-{ copyPathToStore, fetchFromGitHub, fetchgit, fetchurl, ... }: {
+{
+  copyPathToStore,
+  fetchFromGitHub,
+  fetchgit,
+  fetchurl,
+  ...
+}:
+{
   "@adobe/css-tools@4.4.4" = fetchurl {
     url = "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz";
-    hash =
-      "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==";
+    hash = "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==";
   };
   "@babel/code-frame@7.29.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz";
-    hash =
-      "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==";
+    url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz";
+    hash = "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==";
   };
   "@babel/compat-data@7.29.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz";
-    hash =
-      "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==";
+    url = "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz";
+    hash = "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==";
   };
   "@babel/core@7.29.0" = fetchurl {
     url = "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz";
-    hash =
-      "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==";
+    hash = "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==";
   };
   "@babel/generator@7.29.1" = fetchurl {
     url = "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz";
-    hash =
-      "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==";
+    hash = "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==";
   };
   "@babel/helper-compilation-targets@7.28.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz";
-    hash =
-      "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==";
+    url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz";
+    hash = "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==";
   };
   "@babel/helper-globals@7.28.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz";
-    hash =
-      "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==";
+    url = "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz";
+    hash = "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==";
   };
   "@babel/helper-module-imports@7.18.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz";
-    hash =
-      "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==";
+    url = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz";
+    hash = "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==";
   };
   "@babel/helper-module-imports@7.28.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz";
-    hash =
-      "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==";
+    url = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz";
+    hash = "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==";
   };
   "@babel/helper-module-transforms@7.28.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz";
-    hash =
-      "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==";
+    url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz";
+    hash = "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==";
   };
   "@babel/helper-plugin-utils@7.28.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz";
-    hash =
-      "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==";
+    url = "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz";
+    hash = "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==";
   };
   "@babel/helper-string-parser@7.27.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz";
-    hash =
-      "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==";
+    url = "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz";
+    hash = "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==";
   };
   "@babel/helper-validator-identifier@7.28.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz";
-    hash =
-      "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==";
+    url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz";
+    hash = "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==";
   };
   "@babel/helper-validator-option@7.27.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz";
-    hash =
-      "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==";
+    url = "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz";
+    hash = "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==";
   };
   "@babel/helpers@7.28.6" = fetchurl {
     url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz";
-    hash =
-      "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==";
+    hash = "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==";
   };
   "@babel/parser@7.29.0" = fetchurl {
     url = "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz";
-    hash =
-      "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==";
+    hash = "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==";
   };
   "@babel/plugin-syntax-jsx@7.28.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz";
-    hash =
-      "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==";
+    url = "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz";
+    hash = "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==";
   };
   "@babel/runtime@7.28.6" = fetchurl {
     url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz";
-    hash =
-      "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==";
+    hash = "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==";
   };
   "@babel/template@7.28.6" = fetchurl {
     url = "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz";
-    hash =
-      "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==";
+    hash = "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==";
   };
   "@babel/traverse@7.29.0" = fetchurl {
     url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz";
-    hash =
-      "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==";
+    hash = "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==";
   };
   "@babel/types@7.29.0" = fetchurl {
     url = "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz";
-    hash =
-      "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==";
+    hash = "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==";
   };
   "@bcoe/v8-coverage@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz";
-    hash =
-      "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==";
+    url = "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz";
+    hash = "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==";
   };
   "@corvu/utils@0.4.2" = fetchurl {
     url = "https://registry.npmjs.org/@corvu/utils/-/utils-0.4.2.tgz";
-    hash =
-      "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==";
+    hash = "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==";
   };
   "@emnapi/core@1.8.1" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz";
-    hash =
-      "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==";
+    hash = "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==";
   };
   "@emnapi/runtime@1.8.1" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz";
-    hash =
-      "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==";
+    hash = "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==";
   };
   "@emnapi/wasi-threads@1.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz";
-    hash =
-      "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==";
+    url = "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz";
+    hash = "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==";
   };
   "@esbuild/aix-ppc64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz";
-    hash =
-      "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==";
+    url = "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz";
+    hash = "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==";
   };
   "@esbuild/android-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz";
-    hash =
-      "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==";
+    url = "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz";
+    hash = "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==";
   };
   "@esbuild/android-arm@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz";
-    hash =
-      "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==";
+    url = "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz";
+    hash = "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==";
   };
   "@esbuild/android-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz";
-    hash =
-      "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==";
+    url = "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz";
+    hash = "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==";
   };
   "@esbuild/darwin-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz";
-    hash =
-      "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==";
+    url = "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz";
+    hash = "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==";
   };
   "@esbuild/darwin-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz";
-    hash =
-      "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==";
+    url = "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz";
+    hash = "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==";
   };
   "@esbuild/freebsd-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz";
-    hash =
-      "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==";
+    url = "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz";
+    hash = "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==";
   };
   "@esbuild/freebsd-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz";
-    hash =
-      "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==";
+    url = "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz";
+    hash = "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==";
   };
   "@esbuild/linux-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz";
-    hash =
-      "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==";
+    url = "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz";
+    hash = "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==";
   };
   "@esbuild/linux-arm@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz";
-    hash =
-      "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==";
+    url = "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz";
+    hash = "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==";
   };
   "@esbuild/linux-ia32@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz";
-    hash =
-      "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==";
+    url = "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz";
+    hash = "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==";
   };
   "@esbuild/linux-loong64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz";
-    hash =
-      "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==";
+    url = "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz";
+    hash = "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==";
   };
   "@esbuild/linux-mips64el@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz";
-    hash =
-      "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==";
+    url = "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz";
+    hash = "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==";
   };
   "@esbuild/linux-ppc64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz";
-    hash =
-      "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==";
+    url = "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz";
+    hash = "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==";
   };
   "@esbuild/linux-riscv64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz";
-    hash =
-      "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==";
+    url = "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz";
+    hash = "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==";
   };
   "@esbuild/linux-s390x@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz";
-    hash =
-      "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==";
+    url = "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz";
+    hash = "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==";
   };
   "@esbuild/linux-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz";
-    hash =
-      "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==";
+    url = "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz";
+    hash = "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==";
   };
   "@esbuild/netbsd-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz";
-    hash =
-      "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==";
+    url = "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz";
+    hash = "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==";
   };
   "@esbuild/netbsd-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz";
-    hash =
-      "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==";
+    url = "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz";
+    hash = "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==";
   };
   "@esbuild/openbsd-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz";
-    hash =
-      "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==";
+    url = "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz";
+    hash = "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==";
   };
   "@esbuild/openbsd-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz";
-    hash =
-      "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==";
+    url = "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz";
+    hash = "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==";
   };
   "@esbuild/openharmony-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz";
-    hash =
-      "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==";
+    url = "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz";
+    hash = "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==";
   };
   "@esbuild/sunos-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz";
-    hash =
-      "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==";
+    url = "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz";
+    hash = "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==";
   };
   "@esbuild/win32-arm64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz";
-    hash =
-      "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==";
+    url = "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz";
+    hash = "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==";
   };
   "@esbuild/win32-ia32@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz";
-    hash =
-      "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==";
+    url = "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz";
+    hash = "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==";
   };
   "@esbuild/win32-x64@0.25.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz";
-    hash =
-      "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==";
+    url = "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz";
+    hash = "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==";
   };
   "@eslint-community/eslint-utils@4.9.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz";
-    hash =
-      "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==";
+    url = "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz";
+    hash = "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==";
   };
   "@eslint-community/regexpp@4.12.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz";
-    hash =
-      "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==";
+    url = "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz";
+    hash = "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==";
   };
   "@eslint/config-array@0.21.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz";
-    hash =
-      "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==";
+    url = "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz";
+    hash = "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==";
   };
   "@eslint/config-helpers@0.4.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz";
-    hash =
-      "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==";
+    url = "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz";
+    hash = "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==";
   };
   "@eslint/core@0.17.0" = fetchurl {
     url = "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz";
-    hash =
-      "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==";
+    hash = "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==";
   };
   "@eslint/eslintrc@3.3.5" = fetchurl {
     url = "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz";
-    hash =
-      "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==";
+    hash = "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==";
   };
   "@eslint/js@9.39.4" = fetchurl {
     url = "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz";
-    hash =
-      "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==";
+    hash = "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==";
   };
   "@eslint/object-schema@2.1.7" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz";
-    hash =
-      "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==";
+    url = "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz";
+    hash = "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==";
   };
   "@eslint/plugin-kit@0.4.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz";
-    hash =
-      "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==";
+    url = "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz";
+    hash = "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==";
   };
   "@floating-ui/core@1.7.5" = fetchurl {
     url = "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz";
-    hash =
-      "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==";
+    hash = "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==";
   };
   "@floating-ui/dom@1.7.6" = fetchurl {
     url = "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz";
-    hash =
-      "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==";
+    hash = "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==";
   };
   "@floating-ui/utils@0.2.11" = fetchurl {
     url = "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz";
-    hash =
-      "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==";
+    hash = "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==";
   };
   "@humanfs/core@0.19.1" = fetchurl {
     url = "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz";
-    hash =
-      "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==";
+    hash = "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==";
   };
   "@humanfs/node@0.16.7" = fetchurl {
     url = "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz";
-    hash =
-      "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==";
+    hash = "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==";
   };
   "@humanwhocodes/module-importer@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz";
-    hash =
-      "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==";
+    url = "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz";
+    hash = "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==";
   };
   "@humanwhocodes/retry@0.4.3" = fetchurl {
     url = "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz";
-    hash =
-      "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==";
+    hash = "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==";
   };
   "@internationalized/date@3.12.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz";
-    hash =
-      "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==";
+    url = "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz";
+    hash = "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==";
   };
   "@internationalized/number@3.6.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz";
-    hash =
-      "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==";
+    url = "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz";
+    hash = "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==";
   };
   "@jridgewell/gen-mapping@0.3.13" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz";
-    hash =
-      "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==";
+    url = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz";
+    hash = "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==";
   };
   "@jridgewell/remapping@2.3.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz";
-    hash =
-      "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==";
+    url = "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz";
+    hash = "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==";
   };
   "@jridgewell/resolve-uri@3.1.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz";
-    hash =
-      "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==";
+    url = "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz";
+    hash = "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==";
   };
   "@jridgewell/sourcemap-codec@1.5.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz";
-    hash =
-      "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==";
+    url = "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz";
+    hash = "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==";
   };
   "@jridgewell/trace-mapping@0.3.31" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz";
-    hash =
-      "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==";
+    url = "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz";
+    hash = "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==";
   };
   "@kobalte/core@0.13.11" = fetchurl {
     url = "https://registry.npmjs.org/@kobalte/core/-/core-0.13.11.tgz";
-    hash =
-      "sha512-hK7TYpdib/XDb/r/4XDBFaO9O+3ZHz4ZWryV4/3BfES+tSQVgg2IJupDnztKXB0BqbSRy/aWlHKw1SPtNPYCFQ==";
+    hash = "sha512-hK7TYpdib/XDb/r/4XDBFaO9O+3ZHz4ZWryV4/3BfES+tSQVgg2IJupDnztKXB0BqbSRy/aWlHKw1SPtNPYCFQ==";
   };
   "@kobalte/utils@0.9.1" = fetchurl {
     url = "https://registry.npmjs.org/@kobalte/utils/-/utils-0.9.1.tgz";
-    hash =
-      "sha512-eeU60A3kprIiBDAfv9gUJX1tXGLuZiKMajUfSQURAF2pk4ZoMYiqIzmrMBvzcxP39xnYttgTyQEVLwiTZnrV4w==";
+    hash = "sha512-eeU60A3kprIiBDAfv9gUJX1tXGLuZiKMajUfSQURAF2pk4ZoMYiqIzmrMBvzcxP39xnYttgTyQEVLwiTZnrV4w==";
   };
   "@napi-rs/wasm-runtime@1.1.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz";
-    hash =
-      "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==";
+    url = "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz";
+    hash = "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==";
   };
   "@polka/url@1.0.0-next.29" = fetchurl {
     url = "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz";
-    hash =
-      "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==";
+    hash = "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==";
   };
   "@protobufjs/aspromise@1.1.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz";
-    hash =
-      "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==";
+    url = "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz";
+    hash = "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==";
   };
   "@protobufjs/base64@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz";
-    hash =
-      "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==";
+    hash = "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==";
   };
   "@protobufjs/codegen@2.0.4" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz";
-    hash =
-      "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==";
+    hash = "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==";
   };
   "@protobufjs/eventemitter@1.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz";
-    hash =
-      "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==";
+    url = "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz";
+    hash = "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==";
   };
   "@protobufjs/fetch@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz";
-    hash =
-      "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==";
+    hash = "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==";
   };
   "@protobufjs/float@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz";
-    hash =
-      "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==";
+    hash = "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==";
   };
   "@protobufjs/inquire@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz";
-    hash =
-      "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==";
+    hash = "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==";
   };
   "@protobufjs/path@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz";
-    hash =
-      "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==";
+    hash = "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==";
   };
   "@protobufjs/pool@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz";
-    hash =
-      "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==";
+    hash = "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==";
   };
   "@protobufjs/utf8@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz";
-    hash =
-      "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==";
+    hash = "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==";
   };
   "@rollup/plugin-inject@5.0.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz";
-    hash =
-      "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==";
+    url = "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz";
+    hash = "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==";
   };
   "@rollup/pluginutils@5.3.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz";
-    hash =
-      "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==";
+    url = "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz";
+    hash = "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==";
   };
   "@rollup/rollup-android-arm-eabi@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz";
-    hash =
-      "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz";
+    hash = "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==";
   };
   "@rollup/rollup-android-arm64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz";
-    hash =
-      "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==";
+    url = "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz";
+    hash = "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==";
   };
   "@rollup/rollup-darwin-arm64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz";
-    hash =
-      "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz";
+    hash = "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==";
   };
   "@rollup/rollup-darwin-x64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz";
-    hash =
-      "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==";
+    url = "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz";
+    hash = "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==";
   };
   "@rollup/rollup-freebsd-arm64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz";
-    hash =
-      "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz";
+    hash = "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==";
   };
   "@rollup/rollup-freebsd-x64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz";
-    hash =
-      "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz";
+    hash = "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==";
   };
   "@rollup/rollup-linux-arm-gnueabihf@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz";
-    hash =
-      "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz";
+    hash = "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==";
   };
   "@rollup/rollup-linux-arm-musleabihf@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz";
-    hash =
-      "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz";
+    hash = "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==";
   };
   "@rollup/rollup-linux-arm64-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz";
-    hash =
-      "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz";
+    hash = "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==";
   };
   "@rollup/rollup-linux-arm64-musl@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz";
-    hash =
-      "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz";
+    hash = "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==";
   };
   "@rollup/rollup-linux-loong64-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz";
-    hash =
-      "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz";
+    hash = "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==";
   };
   "@rollup/rollup-linux-loong64-musl@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz";
-    hash =
-      "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz";
+    hash = "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==";
   };
   "@rollup/rollup-linux-ppc64-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz";
-    hash =
-      "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz";
+    hash = "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==";
   };
   "@rollup/rollup-linux-ppc64-musl@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz";
-    hash =
-      "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz";
+    hash = "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==";
   };
   "@rollup/rollup-linux-riscv64-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz";
-    hash =
-      "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz";
+    hash = "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==";
   };
   "@rollup/rollup-linux-riscv64-musl@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz";
-    hash =
-      "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz";
+    hash = "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==";
   };
   "@rollup/rollup-linux-s390x-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz";
-    hash =
-      "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz";
+    hash = "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==";
   };
   "@rollup/rollup-linux-x64-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz";
-    hash =
-      "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz";
+    hash = "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==";
   };
   "@rollup/rollup-linux-x64-musl@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz";
-    hash =
-      "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==";
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz";
+    hash = "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==";
   };
   "@rollup/rollup-openbsd-x64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz";
-    hash =
-      "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==";
+    url = "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz";
+    hash = "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==";
   };
   "@rollup/rollup-openharmony-arm64@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz";
-    hash =
-      "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz";
+    hash = "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==";
   };
   "@rollup/rollup-win32-arm64-msvc@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz";
-    hash =
-      "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz";
+    hash = "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==";
   };
   "@rollup/rollup-win32-ia32-msvc@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz";
-    hash =
-      "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz";
+    hash = "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==";
   };
   "@rollup/rollup-win32-x64-gnu@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz";
-    hash =
-      "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz";
+    hash = "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==";
   };
   "@rollup/rollup-win32-x64-msvc@4.59.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz";
-    hash =
-      "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==";
+    url = "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz";
+    hash = "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==";
   };
   "@solid-primitives/event-listener@2.4.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.5.tgz";
-    hash =
-      "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==";
+    url = "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.5.tgz";
+    hash = "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==";
   };
   "@solid-primitives/keyed@1.5.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/keyed/-/keyed-1.5.3.tgz";
-    hash =
-      "sha512-zNadtyYBhJSOjXtogkGHmRxjGdz9KHc8sGGVAGlUABkE8BED2tbIZoxkwSqzOwde8OcUEH0bb5DLZUWIMvyBSA==";
+    url = "https://registry.npmjs.org/@solid-primitives/keyed/-/keyed-1.5.3.tgz";
+    hash = "sha512-zNadtyYBhJSOjXtogkGHmRxjGdz9KHc8sGGVAGlUABkE8BED2tbIZoxkwSqzOwde8OcUEH0bb5DLZUWIMvyBSA==";
   };
   "@solid-primitives/map@0.4.13" = fetchurl {
     url = "https://registry.npmjs.org/@solid-primitives/map/-/map-0.4.13.tgz";
-    hash =
-      "sha512-B1zyFbsiTQvqPr+cuPCXO72sRuczG9Swncqk5P74NCGw1VE8qa/Ry9GlfI1e/VdeQYHjan+XkbE3rO2GW/qKew==";
+    hash = "sha512-B1zyFbsiTQvqPr+cuPCXO72sRuczG9Swncqk5P74NCGw1VE8qa/Ry9GlfI1e/VdeQYHjan+XkbE3rO2GW/qKew==";
   };
   "@solid-primitives/media@2.3.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/media/-/media-2.3.5.tgz";
-    hash =
-      "sha512-LX9fB5WDaK87FMDtUB1qokBOfT2et9Uobv/zZaKLH9caFSz4+P70MBKEIBHcZQy+9MV5M2XvGYLTbLskjkzMjA==";
+    url = "https://registry.npmjs.org/@solid-primitives/media/-/media-2.3.5.tgz";
+    hash = "sha512-LX9fB5WDaK87FMDtUB1qokBOfT2et9Uobv/zZaKLH9caFSz4+P70MBKEIBHcZQy+9MV5M2XvGYLTbLskjkzMjA==";
   };
   "@solid-primitives/props@3.2.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/props/-/props-3.2.3.tgz";
-    hash =
-      "sha512-XzG6en9gSFwmvbKcATm2BxL63HegZ+BAG5fmHi8jyBppQHcaths7ffz+6vYvwYy3nlgLa20ufJLj7tst+PcHFA==";
+    url = "https://registry.npmjs.org/@solid-primitives/props/-/props-3.2.3.tgz";
+    hash = "sha512-XzG6en9gSFwmvbKcATm2BxL63HegZ+BAG5fmHi8jyBppQHcaths7ffz+6vYvwYy3nlgLa20ufJLj7tst+PcHFA==";
   };
   "@solid-primitives/refs@1.1.3" = fetchurl {
     url = "https://registry.npmjs.org/@solid-primitives/refs/-/refs-1.1.3.tgz";
-    hash =
-      "sha512-aam02fjNKpBteewF/UliPSQCVJsIIGOLEWQOh+ll6R/QePzBOOBMcC4G+5jTaO75JuUS1d/14Q1YXT3X0Ow6iA==";
+    hash = "sha512-aam02fjNKpBteewF/UliPSQCVJsIIGOLEWQOh+ll6R/QePzBOOBMcC4G+5jTaO75JuUS1d/14Q1YXT3X0Ow6iA==";
   };
   "@solid-primitives/resize-observer@2.1.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/resize-observer/-/resize-observer-2.1.5.tgz";
-    hash =
-      "sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==";
+    url = "https://registry.npmjs.org/@solid-primitives/resize-observer/-/resize-observer-2.1.5.tgz";
+    hash = "sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==";
   };
   "@solid-primitives/rootless@1.5.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/rootless/-/rootless-1.5.3.tgz";
-    hash =
-      "sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==";
+    url = "https://registry.npmjs.org/@solid-primitives/rootless/-/rootless-1.5.3.tgz";
+    hash = "sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==";
   };
   "@solid-primitives/static-store@0.1.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/static-store/-/static-store-0.1.3.tgz";
-    hash =
-      "sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==";
+    url = "https://registry.npmjs.org/@solid-primitives/static-store/-/static-store-0.1.3.tgz";
+    hash = "sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==";
   };
   "@solid-primitives/trigger@1.2.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/trigger/-/trigger-1.2.3.tgz";
-    hash =
-      "sha512-Za2JebEiDyfamjmDwRaESYqBBYOlgYGzB8kHYH0QrkXyLf2qNADlKdGN+z3vWSLCTDcKxChS43Kssjuc0OZhng==";
+    url = "https://registry.npmjs.org/@solid-primitives/trigger/-/trigger-1.2.3.tgz";
+    hash = "sha512-Za2JebEiDyfamjmDwRaESYqBBYOlgYGzB8kHYH0QrkXyLf2qNADlKdGN+z3vWSLCTDcKxChS43Kssjuc0OZhng==";
   };
   "@solid-primitives/utils@6.4.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.4.0.tgz";
-    hash =
-      "sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==";
+    url = "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.4.0.tgz";
+    hash = "sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==";
   };
   "@solidjs/router@0.15.4" = fetchurl {
     url = "https://registry.npmjs.org/@solidjs/router/-/router-0.15.4.tgz";
-    hash =
-      "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ==";
+    hash = "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ==";
   };
   "@solidjs/testing-library@0.8.10" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@solidjs/testing-library/-/testing-library-0.8.10.tgz";
-    hash =
-      "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==";
+    url = "https://registry.npmjs.org/@solidjs/testing-library/-/testing-library-0.8.10.tgz";
+    hash = "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==";
   };
   "@standard-schema/spec@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz";
-    hash =
-      "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==";
+    hash = "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==";
   };
   "@swc/helpers@0.5.19" = fetchurl {
     url = "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz";
-    hash =
-      "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==";
+    hash = "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==";
   };
   "@tailwindcss/node@4.2.1" = fetchurl {
     url = "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz";
-    hash =
-      "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==";
+    hash = "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==";
   };
   "@tailwindcss/oxide-android-arm64@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz";
-    hash =
-      "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz";
+    hash = "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==";
   };
   "@tailwindcss/oxide-darwin-arm64@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz";
-    hash =
-      "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz";
+    hash = "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==";
   };
   "@tailwindcss/oxide-darwin-x64@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz";
-    hash =
-      "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz";
+    hash = "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==";
   };
   "@tailwindcss/oxide-freebsd-x64@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz";
-    hash =
-      "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz";
+    hash = "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==";
   };
   "@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz";
-    hash =
-      "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz";
+    hash = "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==";
   };
   "@tailwindcss/oxide-linux-arm64-gnu@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz";
-    hash =
-      "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz";
+    hash = "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==";
   };
   "@tailwindcss/oxide-linux-arm64-musl@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz";
-    hash =
-      "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz";
+    hash = "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==";
   };
   "@tailwindcss/oxide-linux-x64-gnu@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz";
-    hash =
-      "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz";
+    hash = "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==";
   };
   "@tailwindcss/oxide-linux-x64-musl@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz";
-    hash =
-      "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz";
+    hash = "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==";
   };
   "@tailwindcss/oxide-wasm32-wasi@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz";
-    hash =
-      "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz";
+    hash = "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==";
   };
   "@tailwindcss/oxide-win32-arm64-msvc@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz";
-    hash =
-      "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz";
+    hash = "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==";
   };
   "@tailwindcss/oxide-win32-x64-msvc@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz";
-    hash =
-      "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==";
+    url = "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz";
+    hash = "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==";
   };
   "@tailwindcss/oxide@4.2.1" = fetchurl {
     url = "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz";
-    hash =
-      "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==";
+    hash = "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==";
   };
   "@tailwindcss/vite@4.2.1" = fetchurl {
     url = "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.1.tgz";
-    hash =
-      "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==";
+    hash = "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==";
   };
   "@tanstack/query-core@5.90.20" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz";
-    hash =
-      "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==";
+    url = "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz";
+    hash = "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==";
   };
   "@tanstack/solid-query@5.90.23" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tanstack/solid-query/-/solid-query-5.90.23.tgz";
-    hash =
-      "sha512-pbZc4+Kgm7ktzIuu01R3KOWfazQKgNp4AZvW0RSvv+sNMpYoileUDAkXEcjDJe6RJmb3fVvTR4LlcSL5pxDElQ==";
+    url = "https://registry.npmjs.org/@tanstack/solid-query/-/solid-query-5.90.23.tgz";
+    hash = "sha512-pbZc4+Kgm7ktzIuu01R3KOWfazQKgNp4AZvW0RSvv+sNMpYoileUDAkXEcjDJe6RJmb3fVvTR4LlcSL5pxDElQ==";
   };
   "@tanstack/solid-table@8.21.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tanstack/solid-table/-/solid-table-8.21.3.tgz";
-    hash =
-      "sha512-PmhfSLBxVKiFs01LtYOYrCRhCyTUjxmb4KlxRQiqcALtip8+DOJeeezQM4RSX/GUS0SMVHyH/dNboCpcO++k2A==";
+    url = "https://registry.npmjs.org/@tanstack/solid-table/-/solid-table-8.21.3.tgz";
+    hash = "sha512-PmhfSLBxVKiFs01LtYOYrCRhCyTUjxmb4KlxRQiqcALtip8+DOJeeezQM4RSX/GUS0SMVHyH/dNboCpcO++k2A==";
   };
   "@tanstack/solid-virtual@3.13.21" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tanstack/solid-virtual/-/solid-virtual-3.13.21.tgz";
-    hash =
-      "sha512-SOwgCLVFHzousW9TnbkRMlUxdCHWP8xmp+v9ay2S6aaNT4MgEp6w3/EAFPQuXGVoRgyh8i4M+KZKpmliyTsNfw==";
+    url = "https://registry.npmjs.org/@tanstack/solid-virtual/-/solid-virtual-3.13.21.tgz";
+    hash = "sha512-SOwgCLVFHzousW9TnbkRMlUxdCHWP8xmp+v9ay2S6aaNT4MgEp6w3/EAFPQuXGVoRgyh8i4M+KZKpmliyTsNfw==";
   };
   "@tanstack/table-core@8.21.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz";
-    hash =
-      "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==";
+    url = "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz";
+    hash = "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==";
   };
   "@tanstack/virtual-core@3.13.21" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz";
-    hash =
-      "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==";
+    url = "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz";
+    hash = "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==";
   };
   "@testing-library/dom@10.4.1" = fetchurl {
     url = "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz";
-    hash =
-      "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==";
+    hash = "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==";
   };
   "@testing-library/jest-dom@6.9.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz";
-    hash =
-      "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==";
+    url = "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz";
+    hash = "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==";
   };
   "@testing-library/user-event@14.6.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz";
-    hash =
-      "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==";
+    url = "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz";
+    hash = "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==";
   };
   "@tybys/wasm-util@0.10.1" = fetchurl {
     url = "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz";
-    hash =
-      "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==";
+    hash = "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==";
   };
   "@types/aria-query@5.0.4" = fetchurl {
     url = "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz";
-    hash =
-      "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==";
+    hash = "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==";
   };
   "@types/babel__core@7.20.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz";
-    hash =
-      "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==";
+    url = "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz";
+    hash = "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==";
   };
   "@types/babel__generator@7.27.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz";
-    hash =
-      "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==";
+    url = "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz";
+    hash = "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==";
   };
   "@types/babel__template@7.4.4" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz";
-    hash =
-      "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==";
+    url = "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz";
+    hash = "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==";
   };
   "@types/babel__traverse@7.28.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz";
-    hash =
-      "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==";
+    url = "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz";
+    hash = "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==";
   };
   "@types/chai@5.2.3" = fetchurl {
     url = "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz";
-    hash =
-      "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==";
+    hash = "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==";
   };
   "@types/deep-eql@4.0.2" = fetchurl {
     url = "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz";
-    hash =
-      "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==";
+    hash = "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==";
   };
   "@types/estree@1.0.8" = fetchurl {
     url = "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz";
-    hash =
-      "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==";
+    hash = "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==";
   };
   "@types/json-schema@7.0.15" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz";
-    hash =
-      "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==";
+    url = "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz";
+    hash = "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==";
   };
   "@types/node@24.12.0" = fetchurl {
     url = "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz";
-    hash =
-      "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==";
+    hash = "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==";
   };
   "@types/whatwg-mimetype@3.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz";
-    hash =
-      "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==";
+    url = "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz";
+    hash = "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==";
   };
   "@types/ws@8.18.1" = fetchurl {
     url = "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz";
-    hash =
-      "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==";
+    hash = "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==";
   };
   "@typescript-eslint/eslint-plugin@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz";
-    hash =
-      "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==";
+    url = "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz";
+    hash = "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==";
   };
   "@typescript-eslint/parser@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz";
-    hash =
-      "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==";
+    url = "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz";
+    hash = "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==";
   };
   "@typescript-eslint/project-service@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz";
-    hash =
-      "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==";
+    url = "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz";
+    hash = "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==";
   };
   "@typescript-eslint/scope-manager@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz";
-    hash =
-      "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==";
+    url = "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz";
+    hash = "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==";
   };
   "@typescript-eslint/tsconfig-utils@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz";
-    hash =
-      "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==";
+    url = "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz";
+    hash = "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==";
   };
   "@typescript-eslint/type-utils@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz";
-    hash =
-      "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==";
+    url = "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz";
+    hash = "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==";
   };
   "@typescript-eslint/types@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz";
-    hash =
-      "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==";
+    url = "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz";
+    hash = "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==";
   };
   "@typescript-eslint/typescript-estree@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz";
-    hash =
-      "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==";
+    url = "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz";
+    hash = "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==";
   };
   "@typescript-eslint/utils@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz";
-    hash =
-      "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==";
+    url = "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz";
+    hash = "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==";
   };
   "@typescript-eslint/visitor-keys@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz";
-    hash =
-      "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==";
+    url = "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz";
+    hash = "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==";
   };
   "@vitest/coverage-v8@4.0.18" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz";
-    hash =
-      "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==";
+    url = "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz";
+    hash = "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==";
   };
   "@vitest/expect@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz";
-    hash =
-      "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==";
+    hash = "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==";
   };
   "@vitest/mocker@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz";
-    hash =
-      "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==";
+    hash = "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==";
   };
   "@vitest/pretty-format@4.0.18" = fetchurl {
-    url =
-      "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz";
-    hash =
-      "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==";
+    url = "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz";
+    hash = "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==";
   };
   "@vitest/runner@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz";
-    hash =
-      "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==";
+    hash = "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==";
   };
   "@vitest/snapshot@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz";
-    hash =
-      "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==";
+    hash = "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==";
   };
   "@vitest/spy@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz";
-    hash =
-      "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==";
+    hash = "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==";
   };
   "@vitest/ui@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz";
-    hash =
-      "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==";
+    hash = "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==";
   };
   "@vitest/utils@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz";
-    hash =
-      "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==";
+    hash = "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==";
   };
   "acorn-jsx@5.3.2" = fetchurl {
     url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz";
-    hash =
-      "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==";
+    hash = "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==";
   };
   "acorn@8.16.0" = fetchurl {
     url = "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz";
-    hash =
-      "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==";
+    hash = "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==";
   };
   "ajv@6.14.0" = fetchurl {
     url = "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz";
-    hash =
-      "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==";
+    hash = "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==";
   };
   "ansi-regex@5.0.1" = fetchurl {
     url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz";
-    hash =
-      "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==";
+    hash = "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==";
   };
   "ansi-styles@4.3.0" = fetchurl {
     url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz";
-    hash =
-      "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==";
+    hash = "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==";
   };
   "ansi-styles@5.2.0" = fetchurl {
     url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz";
-    hash =
-      "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==";
+    hash = "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==";
   };
   "argparse@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz";
-    hash =
-      "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==";
+    hash = "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==";
   };
   "aria-query@5.3.0" = fetchurl {
     url = "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz";
-    hash =
-      "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==";
+    hash = "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==";
   };
   "aria-query@5.3.2" = fetchurl {
     url = "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz";
-    hash =
-      "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==";
+    hash = "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==";
   };
   "asn1.js@4.10.1" = fetchurl {
     url = "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz";
-    hash =
-      "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==";
+    hash = "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==";
   };
   "assert@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz";
-    hash =
-      "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==";
+    hash = "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==";
   };
   "assertion-error@2.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz";
-    hash =
-      "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==";
+    url = "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz";
+    hash = "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==";
   };
   "ast-v8-to-istanbul@0.3.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz";
-    hash =
-      "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==";
+    url = "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz";
+    hash = "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==";
   };
   "available-typed-arrays@1.0.7" = fetchurl {
-    url =
-      "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz";
-    hash =
-      "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==";
+    url = "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz";
+    hash = "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==";
   };
   "babel-plugin-jsx-dom-expressions@0.40.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.5.tgz";
-    hash =
-      "sha512-8TFKemVLDYezqqv4mWz+PhRrkryTzivTGu0twyLrOkVZ0P63COx2Y04eVsUjFlwSOXui1z3P3Pn209dokWnirg==";
+    url = "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.5.tgz";
+    hash = "sha512-8TFKemVLDYezqqv4mWz+PhRrkryTzivTGu0twyLrOkVZ0P63COx2Y04eVsUjFlwSOXui1z3P3Pn209dokWnirg==";
   };
   "babel-preset-solid@1.9.10" = fetchurl {
-    url =
-      "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz";
-    hash =
-      "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==";
+    url = "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz";
+    hash = "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==";
   };
   "balanced-match@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz";
-    hash =
-      "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==";
+    url = "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz";
+    hash = "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==";
   };
   "balanced-match@4.0.4" = fetchurl {
-    url =
-      "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz";
-    hash =
-      "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==";
+    url = "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz";
+    hash = "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==";
   };
   "base64-js@1.5.1" = fetchurl {
     url = "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz";
-    hash =
-      "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
+    hash = "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
   };
   "baseline-browser-mapping@2.10.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz";
-    hash =
-      "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==";
+    url = "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz";
+    hash = "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==";
   };
   "bn.js@4.12.3" = fetchurl {
     url = "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz";
-    hash =
-      "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==";
+    hash = "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==";
   };
   "bn.js@5.2.3" = fetchurl {
     url = "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz";
-    hash =
-      "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==";
+    hash = "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==";
   };
   "brace-expansion@1.1.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz";
-    hash =
-      "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==";
+    url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz";
+    hash = "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==";
   };
   "brace-expansion@5.0.4" = fetchurl {
-    url =
-      "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz";
-    hash =
-      "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==";
+    url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz";
+    hash = "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==";
   };
   "brorand@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz";
-    hash =
-      "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==";
+    hash = "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==";
   };
   "browser-resolve@2.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz";
-    hash =
-      "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==";
+    url = "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz";
+    hash = "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==";
   };
   "browserify-aes@1.2.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz";
-    hash =
-      "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==";
+    url = "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz";
+    hash = "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==";
   };
   "browserify-cipher@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz";
-    hash =
-      "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==";
+    url = "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz";
+    hash = "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==";
   };
   "browserify-des@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz";
-    hash =
-      "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==";
+    url = "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz";
+    hash = "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==";
   };
   "browserify-rsa@4.1.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz";
-    hash =
-      "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==";
+    url = "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz";
+    hash = "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==";
   };
   "browserify-sign@4.2.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz";
-    hash =
-      "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==";
+    url = "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz";
+    hash = "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==";
   };
   "browserify-zlib@0.2.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz";
-    hash =
-      "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==";
+    url = "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz";
+    hash = "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==";
   };
   "browserslist@4.28.1" = fetchurl {
     url = "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz";
-    hash =
-      "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==";
+    hash = "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==";
   };
   "buffer-xor@1.0.3" = fetchurl {
     url = "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz";
-    hash =
-      "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==";
+    hash = "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==";
   };
   "buffer@5.7.1" = fetchurl {
     url = "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz";
-    hash =
-      "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==";
+    hash = "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==";
   };
   "builtin-status-codes@3.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz";
-    hash =
-      "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==";
+    url = "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz";
+    hash = "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==";
   };
   "call-bind-apply-helpers@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz";
-    hash =
-      "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==";
+    url = "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz";
+    hash = "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==";
   };
   "call-bind@1.0.8" = fetchurl {
     url = "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz";
-    hash =
-      "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==";
+    hash = "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==";
   };
   "call-bound@1.0.4" = fetchurl {
     url = "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz";
-    hash =
-      "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==";
+    hash = "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==";
   };
   "callsites@3.1.0" = fetchurl {
     url = "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz";
-    hash =
-      "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==";
+    hash = "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==";
   };
   "caniuse-lite@1.0.30001777" = fetchurl {
-    url =
-      "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz";
-    hash =
-      "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==";
+    url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz";
+    hash = "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==";
   };
   "ccxt@4.5.42" = fetchurl {
     url = "https://registry.npmjs.org/ccxt/-/ccxt-4.5.42.tgz";
-    hash =
-      "sha512-7TKtOOnAheWzNtZHSBjuGKIbt5CRDJAyybyrYnj6moZsK9TXBmxPJbQIBAWKCmcOCkddIZRf1K6gKKFMQO9eyA==";
+    hash = "sha512-7TKtOOnAheWzNtZHSBjuGKIbt5CRDJAyybyrYnj6moZsK9TXBmxPJbQIBAWKCmcOCkddIZRf1K6gKKFMQO9eyA==";
   };
   "chai@6.2.2" = fetchurl {
     url = "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz";
-    hash =
-      "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==";
+    hash = "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==";
   };
   "chalk@4.1.2" = fetchurl {
     url = "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz";
-    hash =
-      "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==";
+    hash = "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==";
   };
   "cipher-base@1.0.7" = fetchurl {
     url = "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz";
-    hash =
-      "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==";
+    hash = "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==";
   };
   "class-variance-authority@0.7.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz";
-    hash =
-      "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==";
+    url = "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz";
+    hash = "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==";
   };
   "clsx@2.1.1" = fetchurl {
     url = "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz";
-    hash =
-      "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==";
+    hash = "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==";
   };
   "color-convert@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz";
-    hash =
-      "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==";
+    hash = "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==";
   };
   "color-name@1.1.4" = fetchurl {
     url = "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz";
-    hash =
-      "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
+    hash = "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
   };
   "concat-map@0.0.1" = fetchurl {
     url = "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz";
-    hash =
-      "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==";
+    hash = "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==";
   };
   "console-browserify@1.2.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz";
-    hash =
-      "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==";
+    url = "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz";
+    hash = "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==";
   };
   "constants-browserify@1.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz";
-    hash =
-      "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==";
+    url = "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz";
+    hash = "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==";
   };
   "convert-source-map@2.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz";
-    hash =
-      "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==";
+    url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz";
+    hash = "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==";
   };
   "core-util-is@1.0.3" = fetchurl {
     url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz";
-    hash =
-      "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==";
+    hash = "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==";
   };
   "create-ecdh@4.0.4" = fetchurl {
     url = "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz";
-    hash =
-      "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==";
+    hash = "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==";
   };
   "create-hash@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz";
-    hash =
-      "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==";
+    hash = "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==";
   };
   "create-hmac@1.1.7" = fetchurl {
     url = "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz";
-    hash =
-      "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==";
+    hash = "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==";
   };
   "create-require@1.1.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz";
-    hash =
-      "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==";
+    url = "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz";
+    hash = "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==";
   };
   "cross-spawn@7.0.6" = fetchurl {
     url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz";
-    hash =
-      "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==";
+    hash = "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==";
   };
   "crypto-browserify@3.12.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz";
-    hash =
-      "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==";
+    url = "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz";
+    hash = "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==";
   };
   "css.escape@1.5.1" = fetchurl {
     url = "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz";
-    hash =
-      "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==";
+    hash = "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==";
   };
   "csstype@3.2.3" = fetchurl {
     url = "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz";
-    hash =
-      "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==";
+    hash = "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==";
   };
   "date-fns@4.1.0" = fetchurl {
     url = "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz";
-    hash =
-      "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==";
+    hash = "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==";
   };
   "debug@4.4.3" = fetchurl {
     url = "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz";
-    hash =
-      "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==";
+    hash = "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==";
   };
   "decimal.js@10.6.0" = fetchurl {
     url = "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz";
-    hash =
-      "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==";
+    hash = "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==";
   };
   "deep-is@0.1.4" = fetchurl {
     url = "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz";
-    hash =
-      "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==";
+    hash = "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==";
   };
   "define-data-property@1.1.4" = fetchurl {
-    url =
-      "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz";
-    hash =
-      "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==";
+    url = "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz";
+    hash = "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==";
   };
   "define-properties@1.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz";
-    hash =
-      "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==";
+    url = "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz";
+    hash = "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==";
   };
   "dequal@2.0.3" = fetchurl {
     url = "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz";
-    hash =
-      "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==";
+    hash = "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==";
   };
   "des.js@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz";
-    hash =
-      "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==";
+    hash = "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==";
   };
   "detect-libc@2.1.2" = fetchurl {
     url = "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz";
-    hash =
-      "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==";
+    hash = "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==";
   };
   "diffie-hellman@5.0.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz";
-    hash =
-      "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==";
+    url = "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz";
+    hash = "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==";
   };
   "dom-accessibility-api@0.5.16" = fetchurl {
-    url =
-      "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz";
-    hash =
-      "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==";
+    url = "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz";
+    hash = "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==";
   };
   "dom-accessibility-api@0.6.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz";
-    hash =
-      "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==";
+    url = "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz";
+    hash = "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==";
   };
   "domain-browser@4.22.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz";
-    hash =
-      "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==";
+    url = "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz";
+    hash = "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==";
   };
   "dunder-proto@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz";
-    hash =
-      "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==";
+    hash = "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==";
   };
   "electron-to-chromium@1.5.307" = fetchurl {
-    url =
-      "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz";
-    hash =
-      "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==";
+    url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz";
+    hash = "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==";
   };
   "elliptic@6.6.1" = fetchurl {
     url = "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz";
-    hash =
-      "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==";
+    hash = "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==";
   };
   "enhanced-resolve@5.20.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz";
-    hash =
-      "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==";
+    url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz";
+    hash = "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==";
   };
   "entities@6.0.1" = fetchurl {
     url = "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz";
-    hash =
-      "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==";
+    hash = "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==";
   };
   "entities@7.0.1" = fetchurl {
     url = "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz";
-    hash =
-      "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==";
+    hash = "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==";
   };
   "es-define-property@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz";
-    hash =
-      "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==";
+    url = "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz";
+    hash = "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==";
   };
   "es-errors@1.3.0" = fetchurl {
     url = "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz";
-    hash =
-      "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==";
+    hash = "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==";
   };
   "es-module-lexer@1.7.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz";
-    hash =
-      "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==";
+    url = "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz";
+    hash = "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==";
   };
   "es-object-atoms@1.1.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz";
-    hash =
-      "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==";
+    url = "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz";
+    hash = "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==";
   };
   "esbuild@0.25.12" = fetchurl {
     url = "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz";
-    hash =
-      "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==";
+    hash = "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==";
   };
   "escalade@3.2.0" = fetchurl {
     url = "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz";
-    hash =
-      "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==";
+    hash = "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==";
   };
   "escape-string-regexp@4.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz";
-    hash =
-      "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==";
+    url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz";
+    hash = "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==";
   };
   "eslint-plugin-solid@0.14.5" = fetchurl {
-    url =
-      "https://registry.npmjs.org/eslint-plugin-solid/-/eslint-plugin-solid-0.14.5.tgz";
-    hash =
-      "sha512-nfuYK09ah5aJG/oEN6P1qziy1zLgW4PDWe75VNPi4CEFYk1x2AEqwFeQfEPR7gNn0F2jOeqKhx2E+5oNCOBYWQ==";
+    url = "https://registry.npmjs.org/eslint-plugin-solid/-/eslint-plugin-solid-0.14.5.tgz";
+    hash = "sha512-nfuYK09ah5aJG/oEN6P1qziy1zLgW4PDWe75VNPi4CEFYk1x2AEqwFeQfEPR7gNn0F2jOeqKhx2E+5oNCOBYWQ==";
   };
   "eslint-scope@8.4.0" = fetchurl {
     url = "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz";
-    hash =
-      "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==";
+    hash = "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==";
   };
   "eslint-visitor-keys@3.4.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz";
-    hash =
-      "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==";
+    url = "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz";
+    hash = "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==";
   };
   "eslint-visitor-keys@4.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz";
-    hash =
-      "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==";
+    url = "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz";
+    hash = "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==";
   };
   "eslint-visitor-keys@5.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz";
-    hash =
-      "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==";
+    url = "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz";
+    hash = "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==";
   };
   "eslint@9.39.4" = fetchurl {
     url = "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz";
-    hash =
-      "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==";
+    hash = "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==";
   };
   "espree@10.4.0" = fetchurl {
     url = "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz";
-    hash =
-      "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==";
+    hash = "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==";
   };
   "esquery@1.7.0" = fetchurl {
     url = "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz";
-    hash =
-      "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==";
+    hash = "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==";
   };
   "esrecurse@4.3.0" = fetchurl {
     url = "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz";
-    hash =
-      "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==";
+    hash = "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==";
   };
   "estraverse@5.3.0" = fetchurl {
     url = "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz";
-    hash =
-      "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==";
+    hash = "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==";
   };
   "estree-walker@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz";
-    hash =
-      "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==";
+    hash = "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==";
   };
   "estree-walker@3.0.3" = fetchurl {
     url = "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz";
-    hash =
-      "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==";
+    hash = "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==";
   };
   "esutils@2.0.3" = fetchurl {
     url = "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz";
-    hash =
-      "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==";
+    hash = "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==";
   };
   "events@3.3.0" = fetchurl {
     url = "https://registry.npmjs.org/events/-/events-3.3.0.tgz";
-    hash =
-      "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==";
+    hash = "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==";
   };
   "evp_bytestokey@1.0.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz";
-    hash =
-      "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==";
+    url = "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz";
+    hash = "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==";
   };
   "expect-type@1.3.0" = fetchurl {
     url = "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz";
-    hash =
-      "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==";
+    hash = "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==";
   };
   "fancy-canvas@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz";
-    hash =
-      "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==";
+    hash = "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==";
   };
   "fast-deep-equal@3.1.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
-    hash =
-      "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==";
+    url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
+    hash = "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==";
   };
   "fast-json-stable-stringify@2.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
-    hash =
-      "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==";
+    url = "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
+    hash = "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==";
   };
   "fast-levenshtein@2.0.6" = fetchurl {
-    url =
-      "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz";
-    hash =
-      "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==";
+    url = "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz";
+    hash = "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==";
   };
   "fdir@6.5.0" = fetchurl {
     url = "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz";
-    hash =
-      "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==";
+    hash = "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==";
   };
   "fflate@0.8.2" = fetchurl {
     url = "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz";
-    hash =
-      "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==";
+    hash = "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==";
   };
   "file-entry-cache@8.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz";
-    hash =
-      "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==";
+    url = "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz";
+    hash = "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==";
   };
   "find-up@5.0.0" = fetchurl {
     url = "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz";
-    hash =
-      "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==";
+    hash = "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==";
   };
   "flat-cache@4.0.1" = fetchurl {
     url = "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz";
-    hash =
-      "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==";
+    hash = "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==";
   };
   "flatted@3.3.4" = fetchurl {
     url = "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz";
-    hash =
-      "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==";
+    hash = "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==";
   };
   "for-each@0.3.5" = fetchurl {
     url = "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz";
-    hash =
-      "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==";
+    hash = "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==";
   };
   "fsevents@2.3.3" = fetchurl {
     url = "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz";
-    hash =
-      "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==";
+    hash = "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==";
   };
   "function-bind@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz";
-    hash =
-      "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==";
+    hash = "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==";
   };
   "generator-function@2.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz";
-    hash =
-      "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==";
+    url = "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz";
+    hash = "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==";
   };
   "gensync@1.0.0-beta.2" = fetchurl {
     url = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
-    hash =
-      "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
+    hash = "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
   };
   "get-intrinsic@1.3.0" = fetchurl {
     url = "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz";
-    hash =
-      "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==";
+    hash = "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==";
   };
   "get-proto@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz";
-    hash =
-      "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==";
+    hash = "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==";
   };
   "glob-parent@6.0.2" = fetchurl {
     url = "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz";
-    hash =
-      "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==";
+    hash = "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==";
   };
   "globals@14.0.0" = fetchurl {
     url = "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz";
-    hash =
-      "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==";
+    hash = "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==";
   };
   "globals@16.5.0" = fetchurl {
     url = "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz";
-    hash =
-      "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==";
+    hash = "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==";
   };
   "gopd@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz";
-    hash =
-      "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==";
+    hash = "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==";
   };
   "graceful-fs@4.2.11" = fetchurl {
     url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz";
-    hash =
-      "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==";
+    hash = "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==";
   };
   "happy-dom@20.8.3" = fetchurl {
     url = "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.3.tgz";
-    hash =
-      "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ==";
+    hash = "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ==";
   };
   "has-flag@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz";
-    hash =
-      "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==";
+    hash = "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==";
   };
   "has-property-descriptors@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz";
-    hash =
-      "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==";
+    url = "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz";
+    hash = "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==";
   };
   "has-symbols@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz";
-    hash =
-      "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==";
+    hash = "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==";
   };
   "has-tostringtag@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz";
-    hash =
-      "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==";
+    url = "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz";
+    hash = "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==";
   };
   "hash-base@3.0.5" = fetchurl {
     url = "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz";
-    hash =
-      "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==";
+    hash = "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==";
   };
   "hash-base@3.1.2" = fetchurl {
     url = "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz";
-    hash =
-      "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==";
+    hash = "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==";
   };
   "hash.js@1.1.7" = fetchurl {
     url = "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz";
-    hash =
-      "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==";
+    hash = "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==";
   };
   "hasown@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz";
-    hash =
-      "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==";
+    hash = "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==";
   };
   "hmac-drbg@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz";
-    hash =
-      "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==";
+    hash = "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==";
   };
   "html-entities@2.3.3" = fetchurl {
     url = "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz";
-    hash =
-      "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==";
+    hash = "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==";
   };
   "html-escaper@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz";
-    hash =
-      "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==";
+    hash = "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==";
   };
   "html-tags@3.3.1" = fetchurl {
     url = "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz";
-    hash =
-      "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==";
+    hash = "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==";
   };
   "https-browserify@1.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz";
-    hash =
-      "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==";
+    url = "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz";
+    hash = "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==";
   };
   "ieee754@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz";
-    hash =
-      "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==";
+    hash = "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==";
   };
   "ignore@5.3.2" = fetchurl {
     url = "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz";
-    hash =
-      "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==";
+    hash = "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==";
   };
   "ignore@7.0.5" = fetchurl {
     url = "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz";
-    hash =
-      "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==";
+    hash = "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==";
   };
   "import-fresh@3.3.1" = fetchurl {
     url = "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz";
-    hash =
-      "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==";
+    hash = "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==";
   };
   "imurmurhash@0.1.4" = fetchurl {
     url = "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz";
-    hash =
-      "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==";
+    hash = "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==";
   };
   "indent-string@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz";
-    hash =
-      "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==";
+    hash = "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==";
   };
   "inherits@2.0.4" = fetchurl {
     url = "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz";
-    hash =
-      "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==";
+    hash = "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==";
   };
   "inline-style-parser@0.2.7" = fetchurl {
-    url =
-      "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz";
-    hash =
-      "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==";
+    url = "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz";
+    hash = "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==";
   };
   "is-arguments@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz";
-    hash =
-      "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==";
+    hash = "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==";
   };
   "is-callable@1.2.7" = fetchurl {
     url = "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz";
-    hash =
-      "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==";
+    hash = "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==";
   };
   "is-core-module@2.16.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz";
-    hash =
-      "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==";
+    url = "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz";
+    hash = "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==";
   };
   "is-extglob@2.1.1" = fetchurl {
     url = "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz";
-    hash =
-      "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
+    hash = "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
   };
   "is-generator-function@1.1.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz";
-    hash =
-      "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==";
+    url = "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz";
+    hash = "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==";
   };
   "is-glob@4.0.3" = fetchurl {
     url = "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz";
-    hash =
-      "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
+    hash = "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
   };
   "is-html@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/is-html/-/is-html-2.0.0.tgz";
-    hash =
-      "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==";
+    hash = "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==";
   };
   "is-nan@1.3.2" = fetchurl {
     url = "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz";
-    hash =
-      "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==";
+    hash = "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==";
   };
   "is-regex@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz";
-    hash =
-      "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==";
+    hash = "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==";
   };
   "is-typed-array@1.1.15" = fetchurl {
-    url =
-      "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz";
-    hash =
-      "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==";
+    url = "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz";
+    hash = "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==";
   };
   "is-what@4.1.16" = fetchurl {
     url = "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz";
-    hash =
-      "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==";
+    hash = "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==";
   };
   "isarray@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
-    hash =
-      "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==";
+    hash = "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==";
   };
   "isarray@2.0.5" = fetchurl {
     url = "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz";
-    hash =
-      "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==";
+    hash = "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==";
   };
   "isexe@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz";
-    hash =
-      "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==";
+    hash = "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==";
   };
   "isomorphic-timers-promises@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz";
-    hash =
-      "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==";
+    url = "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz";
+    hash = "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==";
   };
   "istanbul-lib-coverage@3.2.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz";
-    hash =
-      "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==";
+    url = "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz";
+    hash = "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==";
   };
   "istanbul-lib-report@3.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz";
-    hash =
-      "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==";
+    url = "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz";
+    hash = "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==";
   };
   "istanbul-reports@3.2.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz";
-    hash =
-      "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==";
+    url = "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz";
+    hash = "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==";
   };
   "jiti@2.6.1" = fetchurl {
     url = "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz";
-    hash =
-      "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==";
+    hash = "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==";
   };
   "js-tokens@10.0.0" = fetchurl {
     url = "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz";
-    hash =
-      "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==";
+    hash = "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==";
   };
   "js-tokens@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz";
-    hash =
-      "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
+    hash = "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
   };
   "js-yaml@4.1.1" = fetchurl {
     url = "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz";
-    hash =
-      "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==";
+    hash = "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==";
   };
   "jsesc@3.1.0" = fetchurl {
     url = "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz";
-    hash =
-      "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==";
+    hash = "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==";
   };
   "json-buffer@3.0.1" = fetchurl {
     url = "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz";
-    hash =
-      "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==";
+    hash = "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==";
   };
   "json-schema-traverse@0.4.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
-    hash =
-      "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
+    url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
+    hash = "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
   };
   "json-stable-stringify-without-jsonify@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz";
-    hash =
-      "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==";
+    url = "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz";
+    hash = "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==";
   };
   "json5@2.2.3" = fetchurl {
     url = "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz";
-    hash =
-      "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
+    hash = "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
   };
   "kebab-case@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.2.tgz";
-    hash =
-      "sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q==";
+    hash = "sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q==";
   };
   "keyv@4.5.4" = fetchurl {
     url = "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz";
-    hash =
-      "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==";
+    hash = "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==";
   };
   "known-css-properties@0.30.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz";
-    hash =
-      "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==";
+    url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz";
+    hash = "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==";
   };
   "levn@0.4.1" = fetchurl {
     url = "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz";
-    hash =
-      "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==";
+    hash = "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==";
   };
   "lightningcss-android-arm64@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz";
-    hash =
-      "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==";
+    url = "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz";
+    hash = "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==";
   };
   "lightningcss-darwin-arm64@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz";
-    hash =
-      "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==";
+    url = "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz";
+    hash = "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==";
   };
   "lightningcss-darwin-x64@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz";
-    hash =
-      "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==";
+    url = "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz";
+    hash = "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==";
   };
   "lightningcss-freebsd-x64@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz";
-    hash =
-      "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==";
+    url = "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz";
+    hash = "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==";
   };
   "lightningcss-linux-arm-gnueabihf@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz";
-    hash =
-      "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==";
+    url = "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz";
+    hash = "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==";
   };
   "lightningcss-linux-arm64-gnu@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz";
-    hash =
-      "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==";
+    url = "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz";
+    hash = "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==";
   };
   "lightningcss-linux-arm64-musl@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz";
-    hash =
-      "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==";
+    url = "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz";
+    hash = "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==";
   };
   "lightningcss-linux-x64-gnu@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz";
-    hash =
-      "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==";
+    url = "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz";
+    hash = "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==";
   };
   "lightningcss-linux-x64-musl@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz";
-    hash =
-      "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==";
+    url = "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz";
+    hash = "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==";
   };
   "lightningcss-win32-arm64-msvc@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz";
-    hash =
-      "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==";
+    url = "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz";
+    hash = "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==";
   };
   "lightningcss-win32-x64-msvc@1.31.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz";
-    hash =
-      "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==";
+    url = "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz";
+    hash = "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==";
   };
   "lightningcss@1.31.1" = fetchurl {
     url = "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz";
-    hash =
-      "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==";
+    hash = "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==";
   };
   "lightweight-charts@5.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz";
-    hash =
-      "sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==";
+    url = "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz";
+    hash = "sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==";
   };
   "locate-path@6.0.0" = fetchurl {
     url = "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz";
-    hash =
-      "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==";
+    hash = "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==";
   };
   "lodash.merge@4.6.2" = fetchurl {
     url = "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz";
-    hash =
-      "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==";
+    hash = "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==";
   };
   "long@5.3.2" = fetchurl {
     url = "https://registry.npmjs.org/long/-/long-5.3.2.tgz";
-    hash =
-      "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==";
+    hash = "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==";
   };
   "lru-cache@5.1.1" = fetchurl {
     url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
-    hash =
-      "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
+    hash = "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
   };
   "lucide-solid@0.577.0" = fetchurl {
     url = "https://registry.npmjs.org/lucide-solid/-/lucide-solid-0.577.0.tgz";
-    hash =
-      "sha512-r/rsauBlyNjFlUhXCkD544tOH1GgcFFupw9oP2zZT4BiFkHoO3MTr12QfKBrS5zCRIhktc/qY2tRr925hFlNuQ==";
+    hash = "sha512-r/rsauBlyNjFlUhXCkD544tOH1GgcFFupw9oP2zZT4BiFkHoO3MTr12QfKBrS5zCRIhktc/qY2tRr925hFlNuQ==";
   };
   "lz-string@1.5.0" = fetchurl {
     url = "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz";
-    hash =
-      "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==";
+    hash = "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==";
   };
   "magic-string@0.30.21" = fetchurl {
     url = "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz";
-    hash =
-      "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==";
+    hash = "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==";
   };
   "magicast@0.5.2" = fetchurl {
     url = "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz";
-    hash =
-      "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==";
+    hash = "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==";
   };
   "make-dir@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz";
-    hash =
-      "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==";
+    hash = "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==";
   };
   "math-intrinsics@1.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz";
-    hash =
-      "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==";
+    url = "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz";
+    hash = "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==";
   };
   "md5.js@1.3.5" = fetchurl {
     url = "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz";
-    hash =
-      "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==";
+    hash = "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==";
   };
   "merge-anything@5.1.7" = fetchurl {
-    url =
-      "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz";
-    hash =
-      "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==";
+    url = "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz";
+    hash = "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==";
   };
   "miller-rabin@4.0.1" = fetchurl {
     url = "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz";
-    hash =
-      "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==";
+    hash = "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==";
   };
   "min-indent@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz";
-    hash =
-      "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==";
+    hash = "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==";
   };
   "minimalistic-assert@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz";
-    hash =
-      "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==";
+    url = "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz";
+    hash = "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==";
   };
   "minimalistic-crypto-utils@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz";
-    hash =
-      "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==";
+    url = "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz";
+    hash = "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==";
   };
   "minimatch@10.2.4" = fetchurl {
     url = "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz";
-    hash =
-      "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==";
+    hash = "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==";
   };
   "minimatch@3.1.5" = fetchurl {
     url = "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz";
-    hash =
-      "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==";
+    hash = "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==";
   };
   "mrmime@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz";
-    hash =
-      "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==";
+    hash = "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==";
   };
   "ms@2.1.3" = fetchurl {
     url = "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz";
-    hash =
-      "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
+    hash = "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
   };
   "nanoid@3.3.11" = fetchurl {
     url = "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz";
-    hash =
-      "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==";
+    hash = "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==";
   };
   "natural-compare@1.4.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz";
-    hash =
-      "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==";
+    url = "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz";
+    hash = "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==";
   };
   "node-releases@2.0.36" = fetchurl {
     url = "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz";
-    hash =
-      "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==";
+    hash = "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==";
   };
   "node-stdlib-browser@1.3.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz";
-    hash =
-      "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==";
+    url = "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz";
+    hash = "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==";
   };
   "object-inspect@1.13.4" = fetchurl {
-    url =
-      "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz";
-    hash =
-      "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==";
+    url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz";
+    hash = "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==";
   };
   "object-is@1.1.6" = fetchurl {
     url = "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz";
-    hash =
-      "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==";
+    hash = "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==";
   };
   "object-keys@1.1.1" = fetchurl {
     url = "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz";
-    hash =
-      "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==";
+    hash = "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==";
   };
   "object.assign@4.1.7" = fetchurl {
     url = "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz";
-    hash =
-      "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==";
+    hash = "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==";
   };
   "obug@2.1.1" = fetchurl {
     url = "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz";
-    hash =
-      "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==";
+    hash = "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==";
   };
   "optionator@0.9.4" = fetchurl {
     url = "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz";
-    hash =
-      "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==";
+    hash = "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==";
   };
   "os-browserify@0.3.0" = fetchurl {
     url = "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz";
-    hash =
-      "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==";
+    hash = "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==";
   };
   "p-limit@3.1.0" = fetchurl {
     url = "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz";
-    hash =
-      "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==";
+    hash = "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==";
   };
   "p-locate@5.0.0" = fetchurl {
     url = "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz";
-    hash =
-      "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==";
+    hash = "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==";
   };
   "pako@1.0.11" = fetchurl {
     url = "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz";
-    hash =
-      "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==";
+    hash = "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==";
   };
   "parent-module@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz";
-    hash =
-      "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==";
+    hash = "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==";
   };
   "parse-asn1@5.1.9" = fetchurl {
     url = "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz";
-    hash =
-      "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==";
+    hash = "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==";
   };
   "parse5@7.3.0" = fetchurl {
     url = "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz";
-    hash =
-      "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==";
+    hash = "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==";
   };
   "path-browserify@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz";
-    hash =
-      "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==";
+    url = "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz";
+    hash = "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==";
   };
   "path-exists@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz";
-    hash =
-      "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==";
+    hash = "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==";
   };
   "path-key@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz";
-    hash =
-      "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==";
+    hash = "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==";
   };
   "path-parse@1.0.7" = fetchurl {
     url = "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz";
-    hash =
-      "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==";
+    hash = "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==";
   };
   "pathe@2.0.3" = fetchurl {
     url = "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz";
-    hash =
-      "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==";
+    hash = "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==";
   };
   "pbkdf2@3.1.5" = fetchurl {
     url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz";
-    hash =
-      "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==";
+    hash = "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==";
   };
   "picocolors@1.1.1" = fetchurl {
     url = "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz";
-    hash =
-      "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==";
+    hash = "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==";
   };
   "picomatch@4.0.3" = fetchurl {
     url = "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz";
-    hash =
-      "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==";
+    hash = "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==";
   };
   "pkg-dir@5.0.0" = fetchurl {
     url = "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz";
-    hash =
-      "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==";
+    hash = "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==";
   };
   "possible-typed-array-names@1.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz";
-    hash =
-      "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==";
+    url = "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz";
+    hash = "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==";
   };
   "postcss@8.5.8" = fetchurl {
     url = "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz";
-    hash =
-      "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==";
+    hash = "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==";
   };
   "prelude-ls@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz";
-    hash =
-      "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==";
+    hash = "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==";
   };
   "pretty-format@27.5.1" = fetchurl {
     url = "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz";
-    hash =
-      "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==";
+    hash = "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==";
   };
   "process-nextick-args@2.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
-    hash =
-      "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==";
+    url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
+    hash = "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==";
   };
   "process@0.11.10" = fetchurl {
     url = "https://registry.npmjs.org/process/-/process-0.11.10.tgz";
-    hash =
-      "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==";
+    hash = "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==";
   };
   "protobufjs@8.0.0" = fetchurl {
     url = "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz";
-    hash =
-      "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==";
+    hash = "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==";
   };
   "public-encrypt@4.0.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz";
-    hash =
-      "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==";
+    url = "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz";
+    hash = "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==";
   };
   "punycode@1.4.1" = fetchurl {
     url = "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz";
-    hash =
-      "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==";
+    hash = "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==";
   };
   "punycode@2.3.1" = fetchurl {
     url = "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz";
-    hash =
-      "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==";
+    hash = "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==";
   };
   "qs@6.15.0" = fetchurl {
     url = "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz";
-    hash =
-      "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==";
+    hash = "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==";
   };
   "querystring-es3@0.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz";
-    hash =
-      "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==";
+    url = "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz";
+    hash = "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==";
   };
   "randombytes@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz";
-    hash =
-      "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==";
+    hash = "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==";
   };
   "randomfill@1.0.4" = fetchurl {
     url = "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz";
-    hash =
-      "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==";
+    hash = "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==";
   };
   "react-is@17.0.2" = fetchurl {
     url = "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz";
-    hash =
-      "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==";
+    hash = "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==";
   };
   "readable-stream@2.3.8" = fetchurl {
-    url =
-      "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz";
-    hash =
-      "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==";
+    url = "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz";
+    hash = "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==";
   };
   "readable-stream@3.6.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz";
-    hash =
-      "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==";
+    url = "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz";
+    hash = "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==";
   };
   "redent@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz";
-    hash =
-      "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==";
+    hash = "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==";
   };
   "resolve-from@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz";
-    hash =
-      "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==";
+    hash = "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==";
   };
   "resolve@1.22.11" = fetchurl {
     url = "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz";
-    hash =
-      "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==";
+    hash = "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==";
   };
   "ripemd160@2.0.3" = fetchurl {
     url = "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz";
-    hash =
-      "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==";
+    hash = "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==";
   };
   "rollup@4.59.0" = fetchurl {
     url = "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz";
-    hash =
-      "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==";
+    hash = "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==";
   };
   "safe-buffer@5.1.2" = fetchurl {
     url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz";
-    hash =
-      "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==";
+    hash = "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==";
   };
   "safe-buffer@5.2.1" = fetchurl {
     url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz";
-    hash =
-      "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==";
+    hash = "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==";
   };
   "safe-regex-test@1.1.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz";
-    hash =
-      "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==";
+    url = "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz";
+    hash = "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==";
   };
   "semver@6.3.1" = fetchurl {
     url = "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz";
-    hash =
-      "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
+    hash = "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
   };
   "semver@7.7.4" = fetchurl {
     url = "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz";
-    hash =
-      "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==";
+    hash = "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==";
   };
   "seroval-plugins@1.5.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz";
-    hash =
-      "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==";
+    url = "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz";
+    hash = "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==";
   };
   "seroval@1.5.0" = fetchurl {
     url = "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz";
-    hash =
-      "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==";
+    hash = "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==";
   };
   "set-function-length@1.2.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz";
-    hash =
-      "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==";
+    url = "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz";
+    hash = "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==";
   };
   "setimmediate@1.0.5" = fetchurl {
     url = "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz";
-    hash =
-      "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==";
+    hash = "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==";
   };
   "sha.js@2.4.12" = fetchurl {
     url = "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz";
-    hash =
-      "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==";
+    hash = "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==";
   };
   "shebang-command@2.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz";
-    hash =
-      "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==";
+    url = "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz";
+    hash = "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==";
   };
   "shebang-regex@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz";
-    hash =
-      "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==";
+    hash = "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==";
   };
   "side-channel-list@1.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz";
-    hash =
-      "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==";
+    url = "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz";
+    hash = "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==";
   };
   "side-channel-map@1.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz";
-    hash =
-      "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==";
+    url = "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz";
+    hash = "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==";
   };
   "side-channel-weakmap@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz";
-    hash =
-      "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==";
+    url = "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz";
+    hash = "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==";
   };
   "side-channel@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz";
-    hash =
-      "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==";
+    hash = "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==";
   };
   "siginfo@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz";
-    hash =
-      "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==";
+    hash = "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==";
   };
   "sirv@3.0.2" = fetchurl {
     url = "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz";
-    hash =
-      "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==";
+    hash = "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==";
   };
   "solid-js@1.9.11" = fetchurl {
     url = "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz";
-    hash =
-      "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==";
+    hash = "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==";
   };
   "solid-presence@0.1.8" = fetchurl {
-    url =
-      "https://registry.npmjs.org/solid-presence/-/solid-presence-0.1.8.tgz";
-    hash =
-      "sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==";
+    url = "https://registry.npmjs.org/solid-presence/-/solid-presence-0.1.8.tgz";
+    hash = "sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==";
   };
   "solid-prevent-scroll@0.1.10" = fetchurl {
-    url =
-      "https://registry.npmjs.org/solid-prevent-scroll/-/solid-prevent-scroll-0.1.10.tgz";
-    hash =
-      "sha512-KplGPX2GHiWJLZ6AXYRql4M127PdYzfwvLJJXMkO+CMb8Np4VxqDAg5S8jLdwlEuBis/ia9DKw2M8dFx5u8Mhw==";
+    url = "https://registry.npmjs.org/solid-prevent-scroll/-/solid-prevent-scroll-0.1.10.tgz";
+    hash = "sha512-KplGPX2GHiWJLZ6AXYRql4M127PdYzfwvLJJXMkO+CMb8Np4VxqDAg5S8jLdwlEuBis/ia9DKw2M8dFx5u8Mhw==";
   };
   "solid-refresh@0.6.3" = fetchurl {
     url = "https://registry.npmjs.org/solid-refresh/-/solid-refresh-0.6.3.tgz";
-    hash =
-      "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==";
+    hash = "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==";
   };
   "solid-sonner@0.3.1" = fetchurl {
     url = "https://registry.npmjs.org/solid-sonner/-/solid-sonner-0.3.1.tgz";
-    hash =
-      "sha512-F/+zi9yKJTHh5hX1UGJfkDvyC+F34Vi3jgy44NJwOKCgic1QtAon0b1iT9OsDO77RTgR+PCil+3Y5B8T2Owy1Q==";
+    hash = "sha512-F/+zi9yKJTHh5hX1UGJfkDvyC+F34Vi3jgy44NJwOKCgic1QtAon0b1iT9OsDO77RTgR+PCil+3Y5B8T2Owy1Q==";
   };
   "source-map-js@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz";
-    hash =
-      "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==";
+    hash = "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==";
   };
   "stackback@0.0.2" = fetchurl {
     url = "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz";
-    hash =
-      "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==";
+    hash = "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==";
   };
   "std-env@3.10.0" = fetchurl {
     url = "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz";
-    hash =
-      "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==";
+    hash = "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==";
   };
   "stream-browserify@3.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz";
-    hash =
-      "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==";
+    url = "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz";
+    hash = "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==";
   };
   "stream-http@3.2.0" = fetchurl {
     url = "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz";
-    hash =
-      "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==";
+    hash = "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==";
   };
   "string_decoder@1.1.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz";
-    hash =
-      "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==";
+    url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz";
+    hash = "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==";
   };
   "string_decoder@1.3.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz";
-    hash =
-      "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==";
+    url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz";
+    hash = "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==";
   };
   "strip-indent@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz";
-    hash =
-      "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==";
+    hash = "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==";
   };
   "strip-json-comments@3.1.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz";
-    hash =
-      "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==";
+    url = "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz";
+    hash = "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==";
   };
   "style-to-object@1.0.14" = fetchurl {
-    url =
-      "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz";
-    hash =
-      "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==";
+    url = "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz";
+    hash = "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==";
   };
   "supports-color@7.2.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz";
-    hash =
-      "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==";
+    url = "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz";
+    hash = "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==";
   };
   "supports-preserve-symlinks-flag@1.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
-    hash =
-      "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==";
+    url = "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
+    hash = "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==";
   };
   "tailwind-merge@3.5.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz";
-    hash =
-      "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==";
+    url = "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz";
+    hash = "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==";
   };
   "tailwindcss-animate@1.0.7" = fetchurl {
-    url =
-      "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz";
-    hash =
-      "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==";
+    url = "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz";
+    hash = "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==";
   };
   "tailwindcss@4.2.1" = fetchurl {
     url = "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz";
-    hash =
-      "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==";
+    hash = "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==";
   };
   "tapable@2.3.0" = fetchurl {
     url = "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz";
-    hash =
-      "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==";
+    hash = "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==";
   };
   "timers-browserify@2.0.12" = fetchurl {
-    url =
-      "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz";
-    hash =
-      "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==";
+    url = "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz";
+    hash = "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==";
   };
   "tinybench@2.9.0" = fetchurl {
     url = "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz";
-    hash =
-      "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==";
+    hash = "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==";
   };
   "tinyexec@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz";
-    hash =
-      "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==";
+    hash = "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==";
   };
   "tinyglobby@0.2.15" = fetchurl {
     url = "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz";
-    hash =
-      "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==";
+    hash = "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==";
   };
   "tinyrainbow@3.0.3" = fetchurl {
     url = "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz";
-    hash =
-      "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==";
+    hash = "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==";
   };
   "to-buffer@1.2.2" = fetchurl {
     url = "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz";
-    hash =
-      "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==";
+    hash = "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==";
   };
   "totalist@3.0.1" = fetchurl {
     url = "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz";
-    hash =
-      "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==";
+    hash = "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==";
   };
   "ts-api-utils@2.4.0" = fetchurl {
     url = "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz";
-    hash =
-      "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==";
+    hash = "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==";
   };
   "tslib@2.8.1" = fetchurl {
     url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
-    hash =
-      "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
+    hash = "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
   };
   "tty-browserify@0.0.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz";
-    hash =
-      "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==";
+    url = "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz";
+    hash = "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==";
   };
   "tw-animate-css@1.4.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz";
-    hash =
-      "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==";
+    url = "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz";
+    hash = "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==";
   };
   "type-check@0.4.0" = fetchurl {
     url = "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz";
-    hash =
-      "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==";
+    hash = "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==";
   };
   "typed-array-buffer@1.0.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz";
-    hash =
-      "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==";
+    url = "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz";
+    hash = "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==";
   };
   "typescript-eslint@8.56.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz";
-    hash =
-      "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==";
+    url = "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz";
+    hash = "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==";
   };
   "typescript@5.8.3" = fetchurl {
     url = "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz";
-    hash =
-      "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==";
+    hash = "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==";
   };
   "undici-types@7.16.0" = fetchurl {
     url = "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz";
-    hash =
-      "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==";
+    hash = "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==";
   };
   "update-browserslist-db@1.2.3" = fetchurl {
-    url =
-      "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz";
-    hash =
-      "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==";
+    url = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz";
+    hash = "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==";
   };
   "uri-js@4.4.1" = fetchurl {
     url = "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz";
-    hash =
-      "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==";
+    hash = "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==";
   };
   "url@0.11.4" = fetchurl {
     url = "https://registry.npmjs.org/url/-/url-0.11.4.tgz";
-    hash =
-      "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==";
+    hash = "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==";
   };
   "util-deprecate@1.0.2" = fetchurl {
-    url =
-      "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
-    hash =
-      "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==";
+    url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
+    hash = "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==";
   };
   "util@0.12.5" = fetchurl {
     url = "https://registry.npmjs.org/util/-/util-0.12.5.tgz";
-    hash =
-      "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==";
+    hash = "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==";
   };
   "vite-plugin-node-stdlib-browser@0.2.1" = fetchurl {
-    url =
-      "https://registry.npmjs.org/vite-plugin-node-stdlib-browser/-/vite-plugin-node-stdlib-browser-0.2.1.tgz";
-    hash =
-      "sha512-6u2i613Dkqj5KaTNIrnZvE6y3/awWAp0S5TjucTvGxdhetftB1Mgvblc+nwYzlw6sntPlac8UOC7ttXNh+LZKA==";
+    url = "https://registry.npmjs.org/vite-plugin-node-stdlib-browser/-/vite-plugin-node-stdlib-browser-0.2.1.tgz";
+    hash = "sha512-6u2i613Dkqj5KaTNIrnZvE6y3/awWAp0S5TjucTvGxdhetftB1Mgvblc+nwYzlw6sntPlac8UOC7ttXNh+LZKA==";
   };
   "vite-plugin-solid@2.11.10" = fetchurl {
-    url =
-      "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.10.tgz";
-    hash =
-      "sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw==";
+    url = "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.10.tgz";
+    hash = "sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw==";
   };
   "vite@6.4.1" = fetchurl {
     url = "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz";
-    hash =
-      "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==";
+    hash = "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==";
   };
   "vitefu@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/vitefu/-/vitefu-1.1.2.tgz";
-    hash =
-      "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==";
+    hash = "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==";
   };
   "vitest@4.0.18" = fetchurl {
     url = "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz";
-    hash =
-      "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==";
+    hash = "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==";
   };
   "vm-browserify@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz";
-    hash =
-      "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==";
+    hash = "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==";
   };
   "whatwg-mimetype@3.0.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz";
-    hash =
-      "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==";
+    url = "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz";
+    hash = "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==";
   };
   "which-typed-array@1.1.20" = fetchurl {
-    url =
-      "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz";
-    hash =
-      "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==";
+    url = "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz";
+    hash = "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==";
   };
   "which@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/which/-/which-2.0.2.tgz";
-    hash =
-      "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
+    hash = "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
   };
   "why-is-node-running@2.3.0" = fetchurl {
-    url =
-      "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz";
-    hash =
-      "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==";
+    url = "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz";
+    hash = "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==";
   };
   "word-wrap@1.2.5" = fetchurl {
     url = "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz";
-    hash =
-      "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==";
+    hash = "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==";
   };
   "ws@8.19.0" = fetchurl {
     url = "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz";
-    hash =
-      "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==";
+    hash = "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==";
   };
   "xtend@4.0.2" = fetchurl {
     url = "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz";
-    hash =
-      "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==";
+    hash = "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==";
   };
   "yallist@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
-    hash =
-      "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
+    hash = "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
   };
   "yocto-queue@0.1.0" = fetchurl {
     url = "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz";
-    hash =
-      "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==";
+    hash = "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==";
   };
 }

--- a/frontend/default.nix
+++ b/frontend/default.nix
@@ -6,7 +6,10 @@ let
   commonArgs = {
     version = "0.1.0";
     src = ./.;
-    nativeBuildInputs = [ bun2nix.hook pkgs.bun ];
+    nativeBuildInputs = [
+      bun2nix.hook
+      pkgs.bun
+    ];
     inherit bunDeps;
     dontUseBunBuild = true;
     dontUseBunCheck = true;
@@ -14,45 +17,55 @@ let
     dontRunLifecycleScripts = true;
   };
 
-in {
-  package = pkgs.stdenv.mkDerivation (commonArgs // {
-    pname = "moneymentum-frontend";
+in
+{
+  package = pkgs.stdenv.mkDerivation (
+    commonArgs
+    // {
+      pname = "moneymentum-frontend";
 
-    buildPhase = ''
-      bun run build
-    '';
+      buildPhase = ''
+        bun run build
+      '';
 
-    installPhase = ''
-      cp -r dist $out
-    '';
+      installPhase = ''
+        cp -r dist $out
+      '';
 
-    meta = {
-      description = "moneymentum frontend";
-      homepage = "https://github.com/dataclique/moneymentum";
-    };
-  });
+      meta = {
+        description = "moneymentum frontend";
+        homepage = "https://github.com/dataclique/moneymentum";
+      };
+    }
+  );
 
-  lint = pkgs.stdenv.mkDerivation (commonArgs // {
-    pname = "moneymentum-frontend-lint";
+  lint = pkgs.stdenv.mkDerivation (
+    commonArgs
+    // {
+      pname = "moneymentum-frontend-lint";
 
-    buildPhase = ''
-      bun run lint
-    '';
+      buildPhase = ''
+        bun run lint
+      '';
 
-    installPhase = ''
-      touch $out
-    '';
-  });
+      installPhase = ''
+        touch $out
+      '';
+    }
+  );
 
-  test = pkgs.stdenv.mkDerivation (commonArgs // {
-    pname = "moneymentum-frontend-test";
+  test = pkgs.stdenv.mkDerivation (
+    commonArgs
+    // {
+      pname = "moneymentum-frontend-test";
 
-    buildPhase = ''
-      bun run test --run
-    '';
+      buildPhase = ''
+        bun run test --run
+      '';
 
-    installPhase = ''
-      touch $out
-    '';
-  });
+      installPhase = ''
+        touch $out
+      '';
+    }
+  );
 }

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -4,8 +4,7 @@ import { cn } from "@/lib/cn"
 import { badgeVariants, type BadgeVariants } from "@/lib/badge-variants"
 
 interface BadgeProps
-  extends JSX.HTMLAttributes<HTMLDivElement>,
-    BadgeVariants {}
+  extends JSX.HTMLAttributes<HTMLDivElement>, BadgeVariants {}
 
 const Badge = (props: BadgeProps) => {
   const [local, rest] = splitProps(props, ["class", "variant"])

--- a/frontend/src/components/wallet-header.test.tsx
+++ b/frontend/src/components/wallet-header.test.tsx
@@ -31,13 +31,10 @@ vi.mock("@/services/hyperliquid-client", () => ({
   HyperliquidClient: class MockHyperliquidClient {
     getBalance = vi.fn()
     getCurrentPositions = vi.fn()
-    listPerpTickers = vi.fn()
-    getLeverageLimits = vi.fn()
     rebalancePositions = vi.fn()
     getNetworkMode = vi.fn()
     getWalletAddress = vi.fn()
   },
-  preloadMarkets: vi.fn().mockResolvedValue(undefined),
 }))
 
 const createWrapper = () => {

--- a/frontend/src/contexts/WalletProvider.tsx
+++ b/frontend/src/contexts/WalletProvider.tsx
@@ -1,6 +1,5 @@
 import {
   createSignal,
-  createEffect,
   createMemo,
   onMount,
   onCleanup,
@@ -15,10 +14,7 @@ import {
   type NetworkMode,
   type WalletCredentials,
 } from "./wallet-context"
-import {
-  HyperliquidClient,
-  preloadMarkets,
-} from "@/services/hyperliquid-client"
+import { HyperliquidClient } from "@/services/hyperliquid-client"
 
 export const WalletProvider = (props: ParentProps) => {
   const [credentials, setCredentials] = createSignal<WalletCredentials | null>(
@@ -27,11 +23,6 @@ export const WalletProvider = (props: ParentProps) => {
   const [networkMode, setNetworkModeState] = createSignal<NetworkMode>(
     getStoredNetworkMode(),
   )
-
-  // createEffect: eagerly preload market metadata whenever networkMode changes
-  createEffect(() => {
-    void preloadMarkets(networkMode())
-  })
 
   const isConnected = createMemo(() => credentials() !== null)
 

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -282,6 +282,10 @@ describe("useTrading hooks", () => {
       ])
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/hyperliquid/markets?network=testnet",
+        expect.objectContaining({
+          cache: "no-store",
+          signal: expect.any(AbortSignal),
+        }),
       )
     })
   })

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -22,11 +22,18 @@ const mockMethods = {
   getAccountSummary: vi.fn(),
   getFundingRates: vi.fn(),
   getCurrentPositions: vi.fn(),
-  listPerpTickers: vi.fn(),
-  getLeverageLimits: vi.fn(),
   rebalancePositions: vi.fn(),
   getNetworkMode: vi.fn(),
   getWalletAddress: vi.fn(),
+}
+
+const mockMarketsResponse = {
+  tickers: ["BTC/USDC:USDC", "ETH/USDC:USDC", "SOL/USDC:USDC"],
+  leverageLimits: [
+    { symbol: "BTC/USDC:USDC", maxLeverage: 50 },
+    { symbol: "ETH/USDC:USDC", maxLeverage: 25 },
+  ],
+  refreshedAt: "2024-01-01T00:00:00Z",
 }
 
 // Mock the HyperliquidClient as a class
@@ -36,13 +43,10 @@ vi.mock("@/services/hyperliquid-client", () => ({
     getAccountSummary = mockMethods.getAccountSummary
     getFundingRates = mockMethods.getFundingRates
     getCurrentPositions = mockMethods.getCurrentPositions
-    listPerpTickers = mockMethods.listPerpTickers
-    getLeverageLimits = mockMethods.getLeverageLimits
     rebalancePositions = mockMethods.rebalancePositions
     getNetworkMode = mockMethods.getNetworkMode
     getWalletAddress = mockMethods.getWalletAddress
   },
-  preloadMarkets: vi.fn().mockResolvedValue(undefined),
 }))
 
 const createWrapper = () => {
@@ -116,9 +120,17 @@ describe("useTrading hooks", () => {
     vi.clearAllMocks()
     ensureLocalStorage()
     localStorage.clear()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockMarketsResponse,
+      }),
+    )
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     ensureLocalStorage()
     localStorage.clear()
   })
@@ -240,19 +252,9 @@ describe("useTrading hooks", () => {
   })
 
   describe("useHyperliquidTickers", () => {
-    it("fetches tickers when connected", async () => {
-      mockMethods.listPerpTickers.mockResolvedValue([
-        "BTC/USDC:USDC",
-        "ETH/USDC:USDC",
-        "SOL/USDC:USDC",
-      ])
-
+    it("fetches tickers from backend markets endpoint", async () => {
       const { result } = renderHook(() => useHyperliquidTickers(), {
-        wrapper: createConnectedWrapper({
-          accountAddress: "0xTestAccountAddress",
-          apiWalletAddress: "0xTestApiWallet",
-          privateKey: "0xTestSecret",
-        }),
+        wrapper: createWrapper(),
       })
 
       await waitFor(() => {
@@ -264,22 +266,14 @@ describe("useTrading hooks", () => {
         "ETH/USDC:USDC",
         "SOL/USDC:USDC",
       ])
+      expect(global.fetch).toHaveBeenCalledWith("/api/hyperliquid/markets")
     })
   })
 
   describe("useHyperliquidLeverageLimits", () => {
-    it("fetches leverage limits when connected", async () => {
-      mockMethods.getLeverageLimits.mockResolvedValue([
-        { symbol: "BTC/USDC:USDC", maxLeverage: 50 },
-        { symbol: "ETH/USDC:USDC", maxLeverage: 25 },
-      ])
-
+    it("fetches leverage limits from backend markets endpoint", async () => {
       const { result } = renderHook(() => useHyperliquidLeverageLimits(), {
-        wrapper: createConnectedWrapper({
-          accountAddress: "0xTestAccountAddress",
-          apiWalletAddress: "0xTestApiWallet",
-          privateKey: "0xTestSecret",
-        }),
+        wrapper: createWrapper(),
       })
 
       await waitFor(() => {

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -12,7 +12,9 @@ import {
   useRebalanceHyperliquidPositions,
   useWalletSettings,
   useSwitchNetwork,
+  marketsRemainingStaleTimeMs,
 } from "./useTrading"
+import { MARKETS_MAX_AGE_MS } from "@/services/hyperliquid-client"
 import { WalletProvider } from "@/contexts/WalletProvider"
 import { useWallet } from "@/hooks/useWallet"
 
@@ -30,24 +32,30 @@ const mockMethods = {
 const mockMarketsResponse = {
   tickers: ["BTC/USDC:USDC", "ETH/USDC:USDC", "SOL/USDC:USDC"],
   leverageLimits: [
-    { symbol: "BTC/USDC:USDC", maxLeverage: 50 },
-    { symbol: "ETH/USDC:USDC", maxLeverage: 25 },
+    { symbol: "BTC/USDC:USDC", maxLeverage: 50, assetIndex: 0 },
+    { symbol: "ETH/USDC:USDC", maxLeverage: 25, assetIndex: 1 },
   ],
-  refreshedAt: "2024-01-01T00:00:00Z",
+  refreshedAt: new Date().toISOString(),
+  marketsMaxAgeMs: MARKETS_MAX_AGE_MS,
 }
 
-// Mock the HyperliquidClient as a class
-vi.mock("@/services/hyperliquid-client", () => ({
-  HyperliquidClient: class MockHyperliquidClient {
-    getBalance = mockMethods.getBalance
-    getAccountSummary = mockMethods.getAccountSummary
-    getFundingRates = mockMethods.getFundingRates
-    getCurrentPositions = mockMethods.getCurrentPositions
-    rebalancePositions = mockMethods.rebalancePositions
-    getNetworkMode = mockMethods.getNetworkMode
-    getWalletAddress = mockMethods.getWalletAddress
-  },
-}))
+// Mock the HyperliquidClient as a class; keep real fetchHyperliquidMarkets.
+vi.mock("@/services/hyperliquid-client", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("@/services/hyperliquid-client")>()
+  return {
+    ...actual,
+    HyperliquidClient: class MockHyperliquidClient {
+      getBalance = mockMethods.getBalance
+      getAccountSummary = mockMethods.getAccountSummary
+      getFundingRates = mockMethods.getFundingRates
+      getCurrentPositions = mockMethods.getCurrentPositions
+      rebalancePositions = mockMethods.rebalancePositions
+      getNetworkMode = mockMethods.getNetworkMode
+      getWalletAddress = mockMethods.getWalletAddress
+    },
+  }
+})
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -122,9 +130,16 @@ describe("useTrading hooks", () => {
     localStorage.clear()
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => mockMarketsResponse,
+      vi.fn().mockImplementation(async input => {
+        const url = String(input)
+        if (!url.includes("network=testnet")) {
+          throw new Error(`expected testnet markets fetch, got ${url}`)
+        }
+        return {
+          ok: true,
+          headers: new Headers({ "cache-control": "public, max-age=86400" }),
+          json: async () => mockMarketsResponse,
+        }
       }),
     )
   })
@@ -251,6 +266,33 @@ describe("useTrading hooks", () => {
     })
   })
 
+  describe("marketsRemainingStaleTimeMs", () => {
+    it("returns remaining time until markets max age expires", () => {
+      const refreshedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+
+      const remaining = marketsRemainingStaleTimeMs(
+        { tickers: [], leverageLimits: [], refreshedAt },
+        MARKETS_MAX_AGE_MS,
+      )
+
+      expect(remaining).toBeGreaterThan(MARKETS_MAX_AGE_MS - 2 * 60 * 60 * 1000)
+      expect(remaining).toBeLessThanOrEqual(MARKETS_MAX_AGE_MS - 60 * 60 * 1000)
+    })
+
+    it("returns zero when markets data is already past max age", () => {
+      const refreshedAt = new Date(
+        Date.now() - MARKETS_MAX_AGE_MS - 1000,
+      ).toISOString()
+
+      expect(
+        marketsRemainingStaleTimeMs(
+          { tickers: [], leverageLimits: [], refreshedAt },
+          MARKETS_MAX_AGE_MS,
+        ),
+      ).toBe(0)
+    })
+  })
+
   describe("useHyperliquidTickers", () => {
     it("fetches tickers from backend markets endpoint", async () => {
       const { result } = renderHook(() => useHyperliquidTickers(), {
@@ -266,7 +308,9 @@ describe("useTrading hooks", () => {
         "ETH/USDC:USDC",
         "SOL/USDC:USDC",
       ])
-      expect(global.fetch).toHaveBeenCalledWith("/api/hyperliquid/markets")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/hyperliquid/markets?network=testnet",
+      )
     })
   })
 
@@ -281,8 +325,8 @@ describe("useTrading hooks", () => {
       })
 
       expect(result.data).toEqual([
-        { symbol: "BTC/USDC:USDC", maxLeverage: 50 },
-        { symbol: "ETH/USDC:USDC", maxLeverage: 25 },
+        { symbol: "BTC/USDC:USDC", maxLeverage: 50, assetIndex: 0 },
+        { symbol: "ETH/USDC:USDC", maxLeverage: 25, assetIndex: 1 },
       ])
     })
   })

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -12,7 +12,6 @@ import {
   useRebalanceHyperliquidPositions,
   useWalletSettings,
   useSwitchNetwork,
-  marketsRemainingStaleTimeMs,
 } from "./useTrading"
 import { MARKETS_MAX_AGE_MS } from "@/services/hyperliquid-client"
 import { WalletProvider } from "@/contexts/WalletProvider"
@@ -263,33 +262,6 @@ describe("useTrading hooks", () => {
       expect(result.data?.totalNotional).toBe(1000)
       expect(result.data?.positions[0].percentage).toBe(50)
       expect(result.data?.positions[1].percentage).toBe(50)
-    })
-  })
-
-  describe("marketsRemainingStaleTimeMs", () => {
-    it("returns remaining time until markets max age expires", () => {
-      const refreshedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
-
-      const remaining = marketsRemainingStaleTimeMs(
-        { tickers: [], leverageLimits: [], refreshedAt },
-        MARKETS_MAX_AGE_MS,
-      )
-
-      expect(remaining).toBeGreaterThan(MARKETS_MAX_AGE_MS - 2 * 60 * 60 * 1000)
-      expect(remaining).toBeLessThanOrEqual(MARKETS_MAX_AGE_MS - 60 * 60 * 1000)
-    })
-
-    it("returns zero when markets data is already past max age", () => {
-      const refreshedAt = new Date(
-        Date.now() - MARKETS_MAX_AGE_MS - 1000,
-      ).toISOString()
-
-      expect(
-        marketsRemainingStaleTimeMs(
-          { tickers: [], leverageLimits: [], refreshedAt },
-          MARKETS_MAX_AGE_MS,
-        ),
-      ).toBe(0)
     })
   })
 

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -1,15 +1,24 @@
 import { createMemo } from "solid-js"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/solid-query"
 import { useWallet } from "./useWallet"
-import type {
-  OrderResult,
-  CurrentPosition,
-  LeverageLimit,
-  OrderSide,
+import {
+  fetchHyperliquidMarkets,
+  MARKETS_MAX_AGE_MS,
+  type OrderResult,
+  type CurrentPosition,
+  type LeverageLimit,
+  type OrderSide,
+  type HyperliquidMarketsResponse,
 } from "@/services/hyperliquid-client"
 import type { RebalanceAction } from "@/pages/Portfolio/hooks/portfolioRebalancer"
 
-export type { OrderSide, OrderResult, CurrentPosition, LeverageLimit }
+export type {
+  OrderSide,
+  OrderResult,
+  CurrentPosition,
+  LeverageLimit,
+  HyperliquidMarketsResponse,
+}
 
 const QUERY_KEYS = {
   balance: ["hyperliquid", "balance"],
@@ -20,26 +29,18 @@ const QUERY_KEYS = {
 } as const
 
 const DATA_STALE_TIME_MS = 30_000
-const MARKETS_STALE_TIME_MS = 24 * 60 * 60 * 1000
 
-export interface HyperliquidMarketsResponse {
-  tickers: string[]
-  leverageLimits: LeverageLimit[]
-  refreshedAt: string | null
+export const marketsRemainingStaleTimeMs = (
+  markets: HyperliquidMarketsResponse | undefined,
+  maxAgeMs: number = MARKETS_MAX_AGE_MS,
+): number => {
+  if (!markets?.refreshedAt) return 0
+
+  const refreshedMs = Date.parse(markets.refreshedAt)
+  if (Number.isNaN(refreshedMs)) return 0
+
+  return Math.max(0, maxAgeMs - (Date.now() - refreshedMs))
 }
-
-const fetchHyperliquidMarkets =
-  async (): Promise<HyperliquidMarketsResponse> => {
-    const response = await fetch(
-      `${import.meta.env.BASE_URL}api/hyperliquid/markets`,
-    )
-    if (!response.ok) {
-      throw new Error(
-        `hyperliquid markets request failed: ${String(response.status)}`,
-      )
-    }
-    return response.json() as Promise<HyperliquidMarketsResponse>
-  }
 
 export const useHyperliquidClient = () => {
   const { client, credentials, networkMode, isConnected } = useWallet()
@@ -47,12 +48,14 @@ export const useHyperliquidClient = () => {
 }
 
 export const useHyperliquidMarkets = () => {
-  const { networkMode } = useWallet()
+  const { networkMode } = useHyperliquidClient()
+  const network = createMemo(() => networkMode())
 
   return useQuery(() => ({
-    queryKey: [...QUERY_KEYS.markets, networkMode()],
-    queryFn: fetchHyperliquidMarkets,
-    staleTime: MARKETS_STALE_TIME_MS,
+    queryKey: [...QUERY_KEYS.markets, network()],
+    queryFn: () => fetchHyperliquidMarkets(network()),
+    staleTime: 0,
+    gcTime: 0,
   }))
 }
 
@@ -147,10 +150,11 @@ export const useHyperliquidPositions = () => {
 
 export const useHyperliquidTickers = () => {
   const marketsQuery = useHyperliquidMarkets()
+  const tickers = createMemo(() => marketsQuery.data?.tickers)
 
   return {
     get data() {
-      return marketsQuery.data?.tickers
+      return tickers()
     },
     get isLoading() {
       return marketsQuery.isLoading
@@ -169,10 +173,11 @@ export const useHyperliquidTickers = () => {
 
 export const useHyperliquidLeverageLimits = () => {
   const marketsQuery = useHyperliquidMarkets()
+  const leverageLimits = createMemo(() => marketsQuery.data?.leverageLimits)
 
   return {
     get data() {
-      return marketsQuery.data?.leverageLimits
+      return leverageLimits()
     },
     get isLoading() {
       return marketsQuery.isLoading
@@ -218,7 +223,6 @@ export const useRebalanceHyperliquidPositions = () => {
       if (!c) throw new Error("Wallet not connected")
 
       const results = await c.rebalancePositions(params.actions)
-
       return { orders: results }
     },
     onSuccess: () => {
@@ -263,8 +267,8 @@ export const useSwitchNetwork = () => {
   return useMutation(() => ({
     mutationFn: async (network: "testnet" | "mainnet") => {
       await queryClient.cancelQueries({ queryKey: ["hyperliquid"] })
-      queryClient.removeQueries({ queryKey: ["hyperliquid"] })
       setNetworkMode(network)
+      await queryClient.invalidateQueries({ queryKey: ["hyperliquid"] })
       return network
     },
   }))

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/solid-query"
 import { useWallet } from "./useWallet"
 import {
   fetchHyperliquidMarkets,
+  MARKETS_MAX_AGE_MS,
   type OrderResult,
   type CurrentPosition,
   type LeverageLimit,
@@ -41,8 +42,8 @@ export const useHyperliquidMarkets = () => {
   return useQuery(() => ({
     queryKey: [...QUERY_KEYS.markets, network()],
     queryFn: () => fetchHyperliquidMarkets(network()),
-    staleTime: 0,
-    gcTime: 0,
+    staleTime: MARKETS_MAX_AGE_MS,
+    gcTime: MARKETS_MAX_AGE_MS,
   }))
 }
 

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -3,7 +3,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/solid-query"
 import { useWallet } from "./useWallet"
 import {
   fetchHyperliquidMarkets,
-  MARKETS_MAX_AGE_MS,
   type OrderResult,
   type CurrentPosition,
   type LeverageLimit,
@@ -29,18 +28,6 @@ const QUERY_KEYS = {
 } as const
 
 const DATA_STALE_TIME_MS = 30_000
-
-export const marketsRemainingStaleTimeMs = (
-  markets: HyperliquidMarketsResponse | undefined,
-  maxAgeMs: number = MARKETS_MAX_AGE_MS,
-): number => {
-  if (!markets?.refreshedAt) return 0
-
-  const refreshedMs = Date.parse(markets.refreshedAt)
-  if (Number.isNaN(refreshedMs)) return 0
-
-  return Math.max(0, maxAgeMs - (Date.now() - refreshedMs))
-}
 
 export const useHyperliquidClient = () => {
   const { client, credentials, networkMode, isConnected } = useWallet()

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -15,16 +15,45 @@ const QUERY_KEYS = {
   balance: ["hyperliquid", "balance"],
   accountSummary: ["hyperliquid", "account-summary"],
   positions: ["hyperliquid", "positions"],
-  tickers: ["hyperliquid", "tickers"],
-  leverageLimits: ["hyperliquid", "leverage-limits"],
+  markets: ["hyperliquid", "markets"],
   fundingRates: ["hyperliquid", "funding-rates"],
 } as const
 
 const DATA_STALE_TIME_MS = 30_000
+const MARKETS_STALE_TIME_MS = 24 * 60 * 60 * 1000
+
+export interface HyperliquidMarketsResponse {
+  tickers: string[]
+  leverageLimits: LeverageLimit[]
+  refreshedAt: string | null
+}
+
+const fetchHyperliquidMarkets =
+  async (): Promise<HyperliquidMarketsResponse> => {
+    const response = await fetch(
+      `${import.meta.env.BASE_URL}api/hyperliquid/markets`,
+    )
+    if (!response.ok) {
+      throw new Error(
+        `hyperliquid markets request failed: ${String(response.status)}`,
+      )
+    }
+    return response.json() as Promise<HyperliquidMarketsResponse>
+  }
 
 export const useHyperliquidClient = () => {
   const { client, credentials, networkMode, isConnected } = useWallet()
   return { client, credentials, isConnected, networkMode }
+}
+
+export const useHyperliquidMarkets = () => {
+  const { networkMode } = useWallet()
+
+  return useQuery(() => ({
+    queryKey: [...QUERY_KEYS.markets, networkMode()],
+    queryFn: fetchHyperliquidMarkets,
+    staleTime: MARKETS_STALE_TIME_MS,
+  }))
 }
 
 export const useHyperliquidBalance = () => {
@@ -117,35 +146,47 @@ export const useHyperliquidPositions = () => {
 }
 
 export const useHyperliquidTickers = () => {
-  const { client, networkMode, isConnected } = useHyperliquidClient()
+  const marketsQuery = useHyperliquidMarkets()
 
-  return useQuery(() => ({
-    queryKey: [...QUERY_KEYS.tickers, networkMode()],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      return c.listPerpTickers()
+  return {
+    get data() {
+      return marketsQuery.data?.tickers
     },
-    enabled: isConnected() && client() !== null,
-    staleTime: DATA_STALE_TIME_MS,
-  }))
+    get isLoading() {
+      return marketsQuery.isLoading
+    },
+    get isSuccess() {
+      return marketsQuery.isSuccess
+    },
+    get isError() {
+      return marketsQuery.isError
+    },
+    get error() {
+      return marketsQuery.error
+    },
+  }
 }
 
 export const useHyperliquidLeverageLimits = () => {
-  const { client, networkMode, isConnected } = useHyperliquidClient()
+  const marketsQuery = useHyperliquidMarkets()
 
-  return useQuery(() => ({
-    queryKey: [...QUERY_KEYS.leverageLimits, networkMode()],
-    queryFn: async () => {
-      const c = client()
-      if (!c) throw new Error("Wallet not connected")
-      const result = await c.getLeverageLimits()
-
-      return result
+  return {
+    get data() {
+      return marketsQuery.data?.leverageLimits
     },
-    enabled: isConnected() && client() !== null,
-    staleTime: DATA_STALE_TIME_MS,
-  }))
+    get isLoading() {
+      return marketsQuery.isLoading
+    },
+    get isSuccess() {
+      return marketsQuery.isSuccess
+    },
+    get isError() {
+      return marketsQuery.isError
+    },
+    get error() {
+      return marketsQuery.error
+    },
+  }
 }
 
 export const useHyperliquidFundingRates = () => {

--- a/frontend/src/hooks/useWallet.test.tsx
+++ b/frontend/src/hooks/useWallet.test.tsx
@@ -8,13 +8,10 @@ vi.mock("@/services/hyperliquid-client", () => ({
   HyperliquidClient: class MockHyperliquidClient {
     getBalance = vi.fn()
     getCurrentPositions = vi.fn()
-    listPerpTickers = vi.fn()
-    getLeverageLimits = vi.fn()
     rebalancePositions = vi.fn()
     getNetworkMode = vi.fn()
     getWalletAddress = vi.fn()
   },
-  preloadMarkets: vi.fn().mockResolvedValue(undefined),
 }))
 
 const wrapper = (props: ParentProps) => (

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanel.tsx
@@ -4,6 +4,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  type Accessor,
   type JSX,
 } from "solid-js"
 import { Settings } from "lucide-solid"
@@ -91,7 +92,7 @@ interface PositionsPanelProps {
     address: string,
     includeInBeta: boolean,
   ) => void
-  screenerSymbols: string[]
+  screenerSymbols: Accessor<string[]>
   onAddSymbol: (symbol: string) => void
 }
 
@@ -185,7 +186,7 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
 
   const allSymbolRows = createMemo(() =>
     buildAllSymbolRows(
-      props.screenerSymbols,
+      props.screenerSymbols(),
       factorScoresQuery.data ?? [],
       props.fundingRatesByBaseSymbol,
     ),

--- a/frontend/src/pages/Portfolio/index.tsx
+++ b/frontend/src/pages/Portfolio/index.tsx
@@ -173,7 +173,7 @@ const PortfolioPage = () => {
                 onReadonlyBtcIncludeInBetaChange={
                   portfolio.setReadonlyBtcIncludeInBeta
                 }
-                screenerSymbols={screenerSymbols()}
+                screenerSymbols={screenerSymbols}
                 onAddSymbol={portfolio.handleAddToken}
               />
             </div>

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -74,6 +74,7 @@ const stubBackendMarketsFetch = (
   tickers: Array<{
     symbol: string
     assetIndex: number
+    universeName?: string
     maxLeverage?: number
     szDecimals?: number
     markPx?: number
@@ -104,7 +105,7 @@ const stubBackendMarketsFetch = (
           json: async () => [
             {
               universe: tickers.map(entry => ({
-                name: entry.symbol.split("/")[0],
+                name: entry.universeName ?? entry.symbol.split("/")[0],
                 szDecimals: entry.szDecimals ?? 5,
               })),
             },
@@ -403,7 +404,11 @@ describe("HyperliquidClient", () => {
     await client.rebalancePositions(actions)
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining("api/hyperliquid/markets?network=mainnet"),
+      expect.stringContaining("/api/hyperliquid/markets?network=mainnet"),
+      expect.objectContaining({
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      }),
     )
     expect(mockExchange.setMarkets).toHaveBeenCalled()
     expect(mockExchange.markets?.["BTC/USDC:USDC"]).toMatchObject({
@@ -456,6 +461,89 @@ describe("HyperliquidClient", () => {
     expect(mockExchange.markets?.["AERO/USDC:USDC"]).toMatchObject({
       baseId: "198",
       precision: { amount: 1, price: 0.00001 },
+    })
+  })
+
+  it("rebalance hydrates markets when universe name casing differs from ccxt base", async () => {
+    stubBackendMarketsFetch("testnet", [
+      {
+        symbol: "KPEPE/USDC:USDC",
+        assetIndex: 42,
+        universeName: "kPEPE",
+        szDecimals: 5,
+        markPx: 0.007,
+      },
+    ])
+
+    const actions: RebalanceAction[] = [
+      {
+        kind: "rebalance",
+        symbol: "KPEPE/USDC:USDC",
+        signedNotionalDelta: -10,
+        leverage: 2,
+        leverageChanged: false,
+      },
+    ]
+
+    mockExchange.fetchTickers.mockResolvedValue({
+      "KPEPE/USDC:USDC": { last: 0.007 },
+    })
+    mockExchange.fetchPositions.mockResolvedValue([])
+    mockExchange.createOrdersWs.mockResolvedValue([
+      { status: "closed", info: {} },
+    ])
+
+    const client = new HyperliquidClient(credentials, "testnet")
+    await client.rebalancePositions(actions)
+
+    expect(mockExchange.setMarkets).toHaveBeenCalled()
+    expect(mockExchange.markets?.["KPEPE/USDC:USDC"]).toMatchObject({
+      baseId: "42",
+      precision: { amount: 0.00001, price: 0.1 },
+    })
+    expect(mockExchange.markets?.["KPEPE/USDC:USDC"]).not.toMatchObject({
+      precision: { amount: 1, price: 0.0001 },
+    })
+  })
+
+  it("rebalance hydrates markets when universe name contains colons", async () => {
+    stubBackendMarketsFetch("testnet", [
+      {
+        symbol: "FLX-CRCL/USDC:USDC",
+        assetIndex: 77,
+        universeName: "flx:crcl",
+        szDecimals: 3,
+        markPx: 12.5,
+      },
+    ])
+
+    const actions: RebalanceAction[] = [
+      {
+        kind: "rebalance",
+        symbol: "FLX-CRCL/USDC:USDC",
+        signedNotionalDelta: 10,
+        leverage: 2,
+        leverageChanged: false,
+      },
+    ]
+
+    mockExchange.fetchTickers.mockResolvedValue({
+      "FLX-CRCL/USDC:USDC": { last: 12.5 },
+    })
+    mockExchange.fetchPositions.mockResolvedValue([])
+    mockExchange.createOrdersWs.mockResolvedValue([
+      { status: "closed", info: {} },
+    ])
+
+    const client = new HyperliquidClient(credentials, "testnet")
+    await client.rebalancePositions(actions)
+
+    expect(mockExchange.markets?.["FLX-CRCL/USDC:USDC"]).toMatchObject({
+      baseId: "77",
+      precision: { amount: 0.001, price: 0.001 },
+    })
+    expect(mockExchange.markets?.["FLX-CRCL/USDC:USDC"]).not.toMatchObject({
+      precision: { amount: 1, price: 0.0001 },
     })
   })
 

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -10,6 +10,7 @@ const mockExchange = {
   walletAddress: "0xWallet",
   markets: undefined as Record<string, unknown> | undefined,
   markets_by_id: undefined as Record<string, unknown[]> | undefined,
+
   setMarkets: vi.fn(
     (
       markets: Array<{ id: string; symbol: string } & Record<string, unknown>>,
@@ -26,6 +27,7 @@ const mockExchange = {
       mockExchange.markets_by_id = byId
     },
   ),
+
   fetchBalance: vi.fn(),
   fetchTickers: vi.fn(),
   fetchTicker: vi.fn(),
@@ -43,6 +45,7 @@ vi.mock("ccxt", () => ({
       options = mockExchange.options
       urls = mockExchange.urls
       walletAddress = mockExchange.walletAddress
+
       get markets() {
         return mockExchange.markets
       }
@@ -55,6 +58,7 @@ vi.mock("ccxt", () => ({
       set markets_by_id(value) {
         mockExchange.markets_by_id = value
       }
+
       setMarkets = mockExchange.setMarkets
       fetchBalance = mockExchange.fetchBalance
       fetchTickers = mockExchange.fetchTickers
@@ -87,6 +91,7 @@ const stubBackendMarketsFetch = (
         : input instanceof URL
           ? input.href
           : input.url
+
     if (url.includes("/info")) {
       const rawBody = init?.body
       const bodyText =
@@ -95,9 +100,11 @@ const stubBackendMarketsFetch = (
           : rawBody === undefined
             ? "{}"
             : null
+
       if (bodyText === null) {
         throw new Error("unexpected fetch body type in test stub")
       }
+
       const body = JSON.parse(bodyText) as { type?: string }
       if (body.type === "metaAndAssetCtxs") {
         return {
@@ -116,9 +123,11 @@ const stubBackendMarketsFetch = (
         } as Response
       }
     }
+
     if (!url.includes(`network=${network}`)) {
       throw new Error(`unexpected fetch: ${url}`)
     }
+
     return {
       ok: true,
       headers: new Headers({ "cache-control": "public, max-age=86400" }),
@@ -146,14 +155,17 @@ describe("HyperliquidClient", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
+
     mockExchange.options = {}
     mockExchange.urls = {}
     mockExchange.markets = undefined
     mockExchange.markets_by_id = undefined
+
     stubBackendMarketsFetch("mainnet", [
       { symbol: "BTC/USDC:USDC", assetIndex: 0 },
       { symbol: "ETH/USDC:USDC", assetIndex: 1 },
     ])
+
     const globalAny = globalThis as { localStorage?: Storage }
     if (
       !globalAny.localStorage ||
@@ -253,6 +265,7 @@ describe("HyperliquidClient", () => {
       "BTC/USDC:USDC",
       undefined,
     )
+
     expect(mockExchange.createOrdersWs).toHaveBeenCalledTimes(2)
     expect(mockExchange.fetchPositions).toHaveBeenCalledTimes(1)
     expect(result).toHaveLength(2)
@@ -273,6 +286,7 @@ describe("HyperliquidClient", () => {
       symbol: "BTC/USDC:USDC",
       side: "buy",
     })
+
     expect(secondBatch[0].params).not.toMatchObject({
       reduceOnly: true,
     })
@@ -317,6 +331,7 @@ describe("HyperliquidClient", () => {
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
+
     mockExchange.fetchPositions.mockResolvedValue([
       {
         symbol: "BTC/USDC:USDC",
@@ -325,6 +340,7 @@ describe("HyperliquidClient", () => {
         notional: 100,
       },
     ])
+
     mockExchange.createOrdersWs.mockResolvedValue([
       { status: "closed", info: {} },
     ])
@@ -354,6 +370,7 @@ describe("HyperliquidClient", () => {
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
+
     mockExchange.fetchPositions.mockResolvedValue([])
     mockExchange.createOrdersWs.mockResolvedValue([
       { status: "closed", info: {} },
@@ -410,6 +427,7 @@ describe("HyperliquidClient", () => {
         signal: expect.any(AbortSignal),
       }),
     )
+
     expect(mockExchange.setMarkets).toHaveBeenCalled()
     expect(mockExchange.markets?.["BTC/USDC:USDC"]).toMatchObject({
       symbol: "BTC/USDC:USDC",
@@ -443,6 +461,7 @@ describe("HyperliquidClient", () => {
     mockExchange.fetchTickers.mockResolvedValue({
       "AERO/USDC:USDC": { last: 0.5288 },
     })
+
     mockExchange.fetchPositions.mockResolvedValue([
       {
         symbol: "AERO/USDC:USDC",
@@ -451,6 +470,7 @@ describe("HyperliquidClient", () => {
         notional: 10.5,
       },
     ])
+
     mockExchange.createOrdersWs.mockResolvedValue([
       { status: "closed", info: {} },
     ])
@@ -501,6 +521,7 @@ describe("HyperliquidClient", () => {
       baseId: "42",
       precision: { amount: 0.00001, price: 0.1 },
     })
+
     expect(mockExchange.markets?.["KPEPE/USDC:USDC"]).not.toMatchObject({
       precision: { amount: 1, price: 0.0001 },
     })
@@ -542,6 +563,7 @@ describe("HyperliquidClient", () => {
       baseId: "77",
       precision: { amount: 0.001, price: 0.001 },
     })
+
     expect(mockExchange.markets?.["FLX-CRCL/USDC:USDC"]).not.toMatchObject({
       precision: { amount: 1, price: 0.0001 },
     })
@@ -572,6 +594,7 @@ describe("HyperliquidClient", () => {
     expect(mockExchange.fetchTickers).toHaveBeenCalledWith(["BTC/USDC:USDC"], {
       type: "swap",
     })
+
     expect(mockExchange.fetchPositions).toHaveBeenCalledWith()
   })
 
@@ -580,6 +603,7 @@ describe("HyperliquidClient", () => {
       ...credentials,
       vaultAddress: "0xVault",
     }
+
     const actions: RebalanceAction[] = [
       {
         kind: "rebalance",
@@ -593,6 +617,7 @@ describe("HyperliquidClient", () => {
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
+
     mockExchange.fetchPositions.mockResolvedValue([])
     mockExchange.createOrdersWs.mockResolvedValue([
       { status: "closed", info: {} },
@@ -604,6 +629,7 @@ describe("HyperliquidClient", () => {
     expect(mockExchange.setLeverage).toHaveBeenCalledWith(3, "BTC/USDC:USDC", {
       vaultAddress: "0xVault",
     })
+
     expect(mockExchange.createOrdersWs).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
@@ -617,6 +643,7 @@ describe("HyperliquidClient", () => {
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
+
     mockExchange.fetchPositions.mockResolvedValue([
       {
         symbol: "BTC/USDC:USDC",
@@ -625,6 +652,7 @@ describe("HyperliquidClient", () => {
         notional: 100,
       },
     ])
+
     mockExchange.createOrdersWs.mockResolvedValue([
       { status: "closed", info: {} },
     ])

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -8,7 +8,24 @@ const mockExchange = {
   options: {} as Record<string, unknown>,
   urls: {} as Record<string, string | Record<string, string>>,
   walletAddress: "0xWallet",
-  loadMarkets: vi.fn(),
+  markets: undefined as Record<string, unknown> | undefined,
+  markets_by_id: undefined as Record<string, unknown[]> | undefined,
+  setMarkets: vi.fn(
+    (
+      markets: Array<{ id: string; symbol: string } & Record<string, unknown>>,
+    ) => {
+      const bySymbol: Record<string, unknown> = {}
+      const byId: Record<string, unknown[]> = {}
+      for (const market of markets) {
+        bySymbol[market.symbol] = market
+        const existing = byId[market.id] ?? []
+        existing.push(market)
+        byId[market.id] = existing
+      }
+      mockExchange.markets = bySymbol
+      mockExchange.markets_by_id = byId
+    },
+  ),
   fetchBalance: vi.fn(),
   fetchTickers: vi.fn(),
   fetchTicker: vi.fn(),
@@ -26,7 +43,19 @@ vi.mock("ccxt", () => ({
       options = mockExchange.options
       urls = mockExchange.urls
       walletAddress = mockExchange.walletAddress
-      loadMarkets = mockExchange.loadMarkets
+      get markets() {
+        return mockExchange.markets
+      }
+      set markets(value) {
+        mockExchange.markets = value
+      }
+      get markets_by_id() {
+        return mockExchange.markets_by_id
+      }
+      set markets_by_id(value) {
+        mockExchange.markets_by_id = value
+      }
+      setMarkets = mockExchange.setMarkets
       fetchBalance = mockExchange.fetchBalance
       fetchTickers = mockExchange.fetchTickers
       fetchTicker = mockExchange.fetchTicker
@@ -40,6 +69,72 @@ vi.mock("ccxt", () => ({
 
 import { HyperliquidClient } from "./hyperliquid-client"
 
+const stubBackendMarketsFetch = (
+  network: "mainnet" | "testnet",
+  tickers: Array<{
+    symbol: string
+    assetIndex: number
+    maxLeverage?: number
+    szDecimals?: number
+    markPx?: number
+  }>,
+): void => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url
+    if (url.includes("/info")) {
+      const rawBody = init?.body
+      const bodyText =
+        typeof rawBody === "string"
+          ? rawBody
+          : rawBody === undefined
+            ? "{}"
+            : null
+      if (bodyText === null) {
+        throw new Error("unexpected fetch body type in test stub")
+      }
+      const body = JSON.parse(bodyText) as { type?: string }
+      if (body.type === "metaAndAssetCtxs") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              universe: tickers.map(entry => ({
+                name: entry.symbol.split("/")[0],
+                szDecimals: entry.szDecimals ?? 5,
+              })),
+            },
+            tickers.map(entry => ({
+              markPx: String(entry.markPx ?? 50_000),
+            })),
+          ],
+        } as Response
+      }
+    }
+    if (!url.includes(`network=${network}`)) {
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+    return {
+      ok: true,
+      headers: new Headers({ "cache-control": "public, max-age=86400" }),
+      json: async () =>
+        ({
+          tickers: tickers.map(entry => entry.symbol),
+          leverageLimits: tickers.map(entry => ({
+            symbol: entry.symbol,
+            maxLeverage: entry.maxLeverage ?? 50,
+            assetIndex: entry.assetIndex,
+          })),
+          refreshedAt: new Date().toISOString(),
+        }) as const,
+    } as Response
+  })
+}
+
 describe("HyperliquidClient", () => {
   const credentials: WalletCredentials = {
     accountAddress: "0xAccount",
@@ -49,8 +144,15 @@ describe("HyperliquidClient", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.restoreAllMocks()
     mockExchange.options = {}
     mockExchange.urls = {}
+    mockExchange.markets = undefined
+    mockExchange.markets_by_id = undefined
+    stubBackendMarketsFetch("mainnet", [
+      { symbol: "BTC/USDC:USDC", assetIndex: 0 },
+      { symbol: "ETH/USDC:USDC", assetIndex: 1 },
+    ])
     const globalAny = globalThis as { localStorage?: Storage }
     if (
       !globalAny.localStorage ||
@@ -131,7 +233,6 @@ describe("HyperliquidClient", () => {
       },
     ]
 
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
       "ETH/USDC:USDC": { last: 4_000 },
@@ -192,7 +293,6 @@ describe("HyperliquidClient", () => {
       },
     ]
 
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
       "ETH/USDC:USDC": { last: 4_000 },
@@ -213,7 +313,6 @@ describe("HyperliquidClient", () => {
   })
 
   it("long shrink rebalance routes sell to the reduction phase (before any expansion batch)", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
@@ -251,7 +350,6 @@ describe("HyperliquidClient", () => {
   })
 
   it("rebalance with no open position sends only an expansion batch", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
@@ -282,7 +380,7 @@ describe("HyperliquidClient", () => {
     expect(batch[0].params).not.toMatchObject({ reduceOnly: true })
   })
 
-  it("fetchTickers and fetchPositions run together during rebalance", async () => {
+  it("rebalance hydrates ccxt markets from backend with asset indices", async () => {
     const actions: RebalanceAction[] = [
       {
         kind: "rebalance",
@@ -293,7 +391,6 @@ describe("HyperliquidClient", () => {
       },
     ]
 
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
@@ -305,7 +402,88 @@ describe("HyperliquidClient", () => {
     const client = new HyperliquidClient(credentials, "mainnet")
     await client.rebalancePositions(actions)
 
-    expect(mockExchange.fetchTickers).toHaveBeenCalledWith(["BTC/USDC:USDC"])
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("api/hyperliquid/markets?network=mainnet"),
+    )
+    expect(mockExchange.setMarkets).toHaveBeenCalled()
+    expect(mockExchange.markets?.["BTC/USDC:USDC"]).toMatchObject({
+      symbol: "BTC/USDC:USDC",
+      baseId: "0",
+      id: "0",
+      swap: true,
+      precision: { amount: 0.00001, price: 1 },
+    })
+  })
+
+  it("hydrates low-price perps with szDecimals-based precision", async () => {
+    stubBackendMarketsFetch("testnet", [
+      {
+        symbol: "AERO/USDC:USDC",
+        assetIndex: 198,
+        szDecimals: 0,
+        markPx: 0.5288,
+      },
+    ])
+
+    const actions: RebalanceAction[] = [
+      {
+        kind: "rebalance",
+        symbol: "AERO/USDC:USDC",
+        signedNotionalDelta: -10,
+        leverage: 2,
+        leverageChanged: false,
+      },
+    ]
+
+    mockExchange.fetchTickers.mockResolvedValue({
+      "AERO/USDC:USDC": { last: 0.5288 },
+    })
+    mockExchange.fetchPositions.mockResolvedValue([
+      {
+        symbol: "AERO/USDC:USDC",
+        side: "long",
+        contracts: 20,
+        notional: 10.5,
+      },
+    ])
+    mockExchange.createOrdersWs.mockResolvedValue([
+      { status: "closed", info: {} },
+    ])
+
+    const client = new HyperliquidClient(credentials, "testnet")
+    await client.rebalancePositions(actions)
+
+    expect(mockExchange.markets?.["AERO/USDC:USDC"]).toMatchObject({
+      baseId: "198",
+      precision: { amount: 1, price: 0.00001 },
+    })
+  })
+
+  it("fetchTickers and fetchPositions run together during rebalance", async () => {
+    const actions: RebalanceAction[] = [
+      {
+        kind: "rebalance",
+        symbol: "BTC/USDC:USDC",
+        signedNotionalDelta: 10,
+        leverage: 2,
+        leverageChanged: false,
+      },
+    ]
+
+    mockExchange.fetchTickers.mockResolvedValue({
+      "BTC/USDC:USDC": { last: 50_000 },
+    })
+    mockExchange.fetchPositions.mockResolvedValue([])
+    mockExchange.createOrdersWs.mockResolvedValue([
+      { status: "closed", info: {} },
+    ])
+
+    const client = new HyperliquidClient(credentials, "mainnet")
+    await client.rebalancePositions(actions)
+
+    expect(mockExchange.fetchTickers).toHaveBeenCalledWith(["BTC/USDC:USDC"], {
+      type: "swap",
+    })
     expect(mockExchange.fetchPositions).toHaveBeenCalledWith()
   })
 
@@ -324,7 +502,6 @@ describe("HyperliquidClient", () => {
       },
     ]
 
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
@@ -349,7 +526,6 @@ describe("HyperliquidClient", () => {
   })
 
   it("batches preciseRebalance close with other reductions then opens in phase two", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })
@@ -399,7 +575,6 @@ describe("HyperliquidClient", () => {
   })
 
   it("close on short position sends buy reduce-only in the reduction batch", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "ETH/USDC:USDC": { last: 4_000 },
     })
@@ -432,7 +607,6 @@ describe("HyperliquidClient", () => {
   })
 
   it("concatenates every reduction order into one createOrdersWs call", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
       "ETH/USDC:USDC": { last: 4_000 },
@@ -478,7 +652,6 @@ describe("HyperliquidClient", () => {
   })
 
   it("preciseRebalance uses full close when close notional wipes position", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({})
     mockExchange.fetchTickers.mockResolvedValue({
       "BTC/USDC:USDC": { last: 50_000 },
     })

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -100,19 +100,6 @@ describe("HyperliquidClient", () => {
     })
   })
 
-  it("returns only swap symbols from markets", async () => {
-    mockExchange.loadMarkets.mockResolvedValue({
-      "BTC/USDC:USDC": { swap: true },
-      "ETH/USDC:USDC": { swap: true },
-      "BTC/USDC": { swap: false },
-    })
-
-    const client = new HyperliquidClient(credentials, "mainnet")
-    const symbols = await client.listPerpTickers()
-
-    expect(symbols).toEqual(["BTC/USDC:USDC", "ETH/USDC:USDC"])
-  })
-
   it("maps positions to buy/sell current positions", async () => {
     mockExchange.fetchPositions.mockResolvedValue([
       { symbol: "BTC/USDC:USDC", side: "long", notional: 100, leverage: 2 },

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -39,8 +39,16 @@ const lookupPerpMarketContext = (
 ): PerpMarketContext | undefined =>
   contexts.get(normalizePerpMarketLookupKey(base))
 
+const decimalStep = (fractionDigits: number): number => {
+  if (fractionDigits <= 0) {
+    return 1
+  }
+
+  return Number(`0.${"0".repeat(fractionDigits - 1)}1`)
+}
+
 const amountPrecisionStepFromSzDecimals = (szDecimals: number): number =>
-  szDecimals <= 0 ? 1 : 10 ** -szDecimals
+  szDecimals <= 0 ? 1 : decimalStep(szDecimals)
 
 /** Mirrors CCXT hyperliquid.calculatePricePrecision for perps (maxDecimals = 6). */
 const calculateHyperliquidPricePrecision = (
@@ -78,7 +86,7 @@ const calculateHyperliquidPricePrecision = (
 }
 
 const pricePrecisionStepFromDecimals = (priceDecimals: number): number =>
-  priceDecimals <= 0 ? 1 : 10 ** -priceDecimals
+  priceDecimals <= 0 ? 1 : decimalStep(priceDecimals)
 
 const fetchPerpMarketContexts = async (
   network: NetworkMode,

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -3,17 +3,8 @@ import { pro } from "ccxt"
 import type { NetworkMode, WalletCredentials } from "@/contexts/wallet-context"
 import type { RebalanceAction } from "@/pages/Portfolio/hooks/portfolioRebalancer"
 
-const MARKETS_CACHE_KEY = "hyperliquid_markets_cache"
-const MARKETS_CACHE_TTL_MS = 24 * 60 * 60 * 1000
-
 const HYPERLIQUID_MAINNET_INFO_URL = "https://api.hyperliquid.xyz/info"
 const HYPERLIQUID_TESTNET_INFO_URL = "https://api.hyperliquid-testnet.xyz/info"
-
-interface MarketsCache {
-  markets: Record<string, unknown>
-  timestamp: number
-  networkMode: NetworkMode
-}
 
 const isDeployed = (): boolean =>
   typeof window !== "undefined" && window.location.hostname !== "localhost"
@@ -25,84 +16,6 @@ const applyApiProxy = (
   if (!isDeployed()) return
   const proxyBase = networkMode === "testnet" ? "/hl-testnet" : "/hl"
   exchange.urls["api"] = { public: proxyBase, private: proxyBase }
-}
-
-const createTempExchange = (networkMode: NetworkMode): HyperliquidExchange => {
-  const HyperliquidClass = pro.hyperliquid as unknown as new (
-    config: Record<string, unknown>,
-  ) => HyperliquidExchange
-
-  const exchange = new HyperliquidClass({
-    enableRateLimit: true,
-  })
-
-  if (networkMode === "testnet") {
-    exchange.setSandboxMode(true)
-  }
-
-  applyApiProxy(exchange, networkMode)
-
-  return exchange
-}
-
-const getCachedMarkets = (
-  networkMode: NetworkMode,
-): Record<string, unknown> | null => {
-  try {
-    const cached = localStorage.getItem(MARKETS_CACHE_KEY)
-    if (!cached) {
-      return null
-    }
-
-    const parsed: MarketsCache = JSON.parse(cached) as MarketsCache
-    const { markets, timestamp, networkMode: cachedMode } = parsed
-
-    if (cachedMode !== networkMode) {
-      return null
-    }
-
-    const ageMs = Date.now() - timestamp
-    if (ageMs >= MARKETS_CACHE_TTL_MS) {
-      return null
-    }
-
-    return markets
-  } catch {
-    return null
-  }
-}
-
-const setCachedMarkets = (
-  markets: Record<string, unknown>,
-  networkMode: NetworkMode,
-): void => {
-  const cacheData: MarketsCache = {
-    markets,
-    timestamp: Date.now(),
-    networkMode,
-  }
-  localStorage.setItem(MARKETS_CACHE_KEY, JSON.stringify(cacheData))
-}
-
-export const preloadMarkets = async (
-  networkMode: NetworkMode,
-): Promise<Record<string, unknown> | null> => {
-  const cached = getCachedMarkets(networkMode)
-  if (cached) {
-    return cached
-  }
-
-  try {
-    const tempExchange = createTempExchange(networkMode)
-    const markets = await tempExchange.loadMarkets()
-
-    setCachedMarkets(markets, networkMode)
-    return markets
-  } catch {
-    // Network errors are expected when offline or API is unreachable
-    // Markets will be loaded on-demand when needed
-    return null
-  }
 }
 
 export type OrderSide = "buy" | "sell"
@@ -202,11 +115,7 @@ export class HyperliquidClient {
   private networkMode: NetworkMode
   private vaultAddress: string | undefined
 
-  constructor(
-    credentials: WalletCredentials,
-    networkMode: NetworkMode,
-    markets?: Record<string, unknown>,
-  ) {
+  constructor(credentials: WalletCredentials, networkMode: NetworkMode) {
     this.networkMode = networkMode
     this.vaultAddress = credentials.vaultAddress
 
@@ -219,14 +128,10 @@ export class HyperliquidClient {
     const effectiveWalletAddress =
       credentials.vaultAddress ?? credentials.accountAddress
 
-    // Use pre-loaded markets if available, otherwise ccxt will load them on first use
-    const cachedMarkets = markets ?? getCachedMarkets(networkMode)
-
     this.exchange = new HyperliquidClass({
       walletAddress: effectiveWalletAddress,
       privateKey: credentials.privateKey,
       enableRateLimit: true,
-      ...(cachedMarkets && { markets: cachedMarkets }),
     })
 
     if (networkMode === "testnet") {
@@ -359,46 +264,6 @@ export class HyperliquidClient {
 
     const orderError = (info as { error: unknown }).error
     return typeof orderError === "string" ? orderError : null
-  }
-
-  async listPerpTickers(): Promise<string[]> {
-    const markets = await this.exchange.loadMarkets()
-
-    // Update cache with fresh markets data
-    setCachedMarkets(markets, this.networkMode)
-
-    const perpSymbols = Object.entries(markets)
-      .filter(
-        ([symbol, data]) =>
-          symbol.includes(":") && (data as { swap?: boolean }).swap,
-      )
-      .map(([symbol]) => symbol)
-      .sort()
-    return perpSymbols
-  }
-
-  async getLeverageLimits(): Promise<LeverageLimit[]> {
-    const tickers = await this.exchange.fetchTickers()
-    const results: LeverageLimit[] = []
-
-    for (const [symbol, ticker] of Object.entries(tickers)) {
-      if (!symbol.includes(":")) continue
-
-      let maxLeverage = 1.0
-      if (ticker.info !== undefined && ticker.info !== null) {
-        const info = ticker.info as Record<string, unknown>
-        const rawMaxLeverage = info["maxLeverage"]
-        if (typeof rawMaxLeverage === "number") {
-          maxLeverage = rawMaxLeverage
-        } else if (typeof rawMaxLeverage === "string") {
-          maxLeverage = parseFloat(rawMaxLeverage)
-        }
-      }
-
-      results.push({ symbol, maxLeverage })
-    }
-
-    return results.sort((a, b) => a.symbol.localeCompare(b.symbol))
   }
 
   async getCurrentPositions(): Promise<CurrentPosition[]> {

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -6,6 +6,101 @@ import type { RebalanceAction } from "@/pages/Portfolio/hooks/portfolioRebalance
 const HYPERLIQUID_MAINNET_INFO_URL = "https://api.hyperliquid.xyz/info"
 const HYPERLIQUID_TESTNET_INFO_URL = "https://api.hyperliquid-testnet.xyz/info"
 
+const hyperliquidInfoUrl = (network: NetworkMode): string =>
+  network === "testnet"
+    ? HYPERLIQUID_TESTNET_INFO_URL
+    : HYPERLIQUID_MAINNET_INFO_URL
+
+interface PerpMarketContext {
+  szDecimals: number
+  markPx: number
+}
+
+const amountPrecisionStepFromSzDecimals = (szDecimals: number): number =>
+  szDecimals <= 0 ? 1 : 10 ** -szDecimals
+
+/** Mirrors CCXT hyperliquid.calculatePricePrecision for perps (maxDecimals = 6). */
+const calculateHyperliquidPricePrecision = (
+  price: number,
+  szDecimals: number,
+  maxDecimals = 6,
+): number => {
+  if (!Number.isFinite(price) || price < 0) return 0
+
+  const priceText = String(price)
+
+  if (price === 0) {
+    return Math.min(maxDecimals - szDecimals, 5)
+  }
+
+  if (price > 0 && price < 1) {
+    const decimalPart = priceText.split(".")[1] ?? ""
+    let leadingZeros = 0
+    while (
+      leadingZeros < decimalPart.length &&
+      decimalPart.charAt(leadingZeros) === "0"
+    ) {
+      leadingZeros += 1
+    }
+    const pricePrecision = leadingZeros + 5
+    return Math.min(maxDecimals - szDecimals, pricePrecision)
+  }
+
+  const integerPart = priceText.split(".")[0] ?? "0"
+  const significantDigits = Math.max(5, integerPart.length)
+  return Math.min(
+    maxDecimals - szDecimals,
+    significantDigits - integerPart.length,
+  )
+}
+
+const pricePrecisionStepFromDecimals = (priceDecimals: number): number =>
+  priceDecimals <= 0 ? 1 : 10 ** -priceDecimals
+
+const fetchPerpMarketContexts = async (
+  network: NetworkMode,
+): Promise<Map<string, PerpMarketContext>> => {
+  const response = await fetch(hyperliquidInfoUrl(network), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type: "metaAndAssetCtxs" }),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch perp market contexts: ${response.statusText}`,
+    )
+  }
+
+  const json = (await response.json()) as unknown
+  if (!Array.isArray(json) || json.length < 2) {
+    throw new Error("Unexpected metaAndAssetCtxs payload shape")
+  }
+
+  const meta = json[0] as {
+    universe?: Array<{ name?: string; szDecimals?: number }>
+  }
+  const assetContexts = json[1] as Array<
+    { markPx?: string | number } | null | undefined
+  >
+  const universe = meta.universe ?? []
+  const contexts = new Map<string, PerpMarketContext>()
+
+  universe.forEach((asset, index) => {
+    const name = asset.name
+    if (!name) return
+    const rawMarkPx = assetContexts[index]?.markPx ?? 0
+    const markPx =
+      typeof rawMarkPx === "number" ? rawMarkPx : Number.parseFloat(rawMarkPx)
+    contexts.set(name, {
+      szDecimals: asset.szDecimals ?? 0,
+      markPx: Number.isFinite(markPx) ? markPx : 0,
+    })
+  })
+
+  return contexts
+}
+
 const isDeployed = (): boolean =>
   typeof window !== "undefined" && window.location.hostname !== "localhost"
 
@@ -56,6 +151,68 @@ export interface OrderResult {
 export interface LeverageLimit {
   symbol: string
   maxLeverage: number
+  assetIndex: number
+}
+
+export interface HyperliquidMarketsResponse {
+  tickers: string[]
+  leverageLimits: LeverageLimit[]
+  refreshedAt: string | null
+  marketsMaxAgeMs?: number
+}
+
+export const MARKETS_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+const parseCacheMaxAgeMs = (cacheControl: string | null): number | null => {
+  if (!cacheControl) return null
+  const match = cacheControl.match(/max-age=(\d+)/)
+  if (!match) return null
+  const maxAgeSeconds = Number(match[1])
+  return Number.isFinite(maxAgeSeconds) ? maxAgeSeconds * 1000 : null
+}
+
+export const fetchHyperliquidMarkets = async (
+  network: NetworkMode,
+): Promise<HyperliquidMarketsResponse> => {
+  const url = `${import.meta.env.BASE_URL}api/hyperliquid/markets?network=${network}`
+  const response = await fetch(url, { cache: "no-store" })
+  if (!response.ok) {
+    throw new Error(
+      `hyperliquid markets request failed: ${String(response.status)}`,
+    )
+  }
+  const markets = (await response.json()) as HyperliquidMarketsResponse
+  const marketsMaxAgeMs =
+    parseCacheMaxAgeMs(response.headers.get("cache-control")) ??
+    MARKETS_MAX_AGE_MS
+  return { ...markets, marketsMaxAgeMs }
+}
+
+interface CcxtMarket {
+  id: string
+  baseId: string
+  quoteId: string
+  settleId: string
+  symbol: string
+  base: string
+  quote: string
+  settle: string
+  type: string
+  spot: boolean
+  margin: boolean
+  swap: boolean
+  future: boolean
+  option: boolean
+  active: boolean
+  contract: boolean
+  linear: boolean
+  precision: { amount: number; price: number }
+  limits: {
+    amount: { min?: number; max?: number }
+    price: { min?: number; max?: number }
+    cost: { min?: number; max?: number }
+  }
+  info: Record<string, unknown>
 }
 
 // Minimum order size on Hyperliquid is $10, but we use $11 to guarantee orders will be opened
@@ -66,13 +223,16 @@ interface HyperliquidExchange {
   options: Record<string, unknown>
   urls: Record<string, string | Record<string, string>>
   walletAddress?: string
-  loadMarkets: () => Promise<Record<string, unknown>>
+  markets?: Record<string, CcxtMarket>
+  markets_by_id?: Record<string, CcxtMarket[]>
+  setMarkets: (markets: CcxtMarket[]) => void
   fetchBalance: () => Promise<{
     total: Record<string, unknown>
     info?: Record<string, unknown>
   }>
   fetchTickers: (
     symbols?: string[],
+    params?: { type?: "spot" | "swap" },
   ) => Promise<
     Record<
       string,
@@ -311,6 +471,69 @@ export class HyperliquidClient {
     return this.vaultAddress ? { vaultAddress: this.vaultAddress } : undefined
   }
 
+  private parseCcxtPerpSymbolParts(symbol: string): {
+    base: string
+    quote: string
+    settle: string
+  } {
+    const colonIndex = symbol.indexOf(":")
+    const pair = colonIndex === -1 ? symbol : symbol.slice(0, colonIndex)
+    const settle = colonIndex === -1 ? "" : symbol.slice(colonIndex + 1)
+    const slashIndex = pair.indexOf("/")
+    if (slashIndex === -1) {
+      return { base: pair, quote: "USDC", settle: settle || "USDC" }
+    }
+    const base = pair.slice(0, slashIndex)
+    const quote = pair.slice(slashIndex + 1)
+    return { base, quote, settle: settle || quote }
+  }
+
+  private hydrateMarketsFromBackend(
+    leverageLimits: LeverageLimit[],
+    perpContexts: Map<string, PerpMarketContext>,
+  ): void {
+    const markets = leverageLimits.map(entry => {
+      const { base, quote, settle } = this.parseCcxtPerpSymbolParts(
+        entry.symbol,
+      )
+      const baseId = String(entry.assetIndex)
+      const context = perpContexts.get(base) ?? { szDecimals: 0, markPx: 1 }
+      const amountStep = amountPrecisionStepFromSzDecimals(context.szDecimals)
+      const priceDecimals = calculateHyperliquidPricePrecision(
+        context.markPx,
+        context.szDecimals,
+      )
+      const priceStep = pricePrecisionStepFromDecimals(priceDecimals)
+      return {
+        id: baseId,
+        baseId,
+        quoteId: quote,
+        settleId: settle,
+        symbol: entry.symbol,
+        base,
+        quote,
+        settle,
+        type: "swap",
+        spot: false,
+        margin: false,
+        swap: true,
+        future: false,
+        option: false,
+        active: true,
+        contract: true,
+        linear: true,
+        precision: { amount: amountStep, price: priceStep },
+        limits: {
+          amount: { min: undefined, max: undefined },
+          price: { min: undefined, max: undefined },
+          cost: { min: 10, max: undefined },
+        },
+        info: { szDecimals: context.szDecimals },
+      } satisfies CcxtMarket
+    })
+    this.exchange.setMarkets(markets)
+  }
+
   private mapOrderResults(
     requests: OrderRequest[],
     responses: Order[],
@@ -427,7 +650,7 @@ export class HyperliquidClient {
       type: "market",
       side,
       amount,
-      price: side === "buy" ? price * (1 + SLIPPAGE) : price * (1 - SLIPPAGE),
+      price,
       params: reduceOnly
         ? { reduceOnly: true, ...this.vaultParams }
         : { ...this.vaultParams },
@@ -523,17 +746,25 @@ export class HyperliquidClient {
   }
 
   async rebalancePositions(actions: RebalanceAction[]): Promise<OrderResult[]> {
-    await this.exchange.loadMarkets()
     const allSymbols = [...new Set(actions.map(action => action.symbol))]
 
-    for (const action of actions) {
-      if ("leverageChanged" in action && action.leverageChanged) {
-        await this.setLeverage(action.symbol, action.leverage)
-      }
+    const [backendMarkets, perpContexts] = await Promise.all([
+      fetchHyperliquidMarkets(this.networkMode),
+      fetchPerpMarketContexts(this.networkMode),
+    ])
+
+    this.hydrateMarketsFromBackend(backendMarkets.leverageLimits, perpContexts)
+
+    const leverageActions = actions.filter(
+      action => "leverageChanged" in action && action.leverageChanged,
+    )
+    for (const action of leverageActions) {
+      if (!("leverageChanged" in action) || !action.leverageChanged) continue
+      await this.setLeverage(action.symbol, action.leverage)
     }
 
     const [tickers, positions] = await Promise.all([
-      this.exchange.fetchTickers(allSymbols),
+      this.exchange.fetchTickers(allSymbols, { type: "swap" }),
       this.exchange.fetchPositions(),
     ])
 
@@ -556,7 +787,11 @@ export class HyperliquidClient {
 
     if (expansion.length > 0) {
       const expansionResponses = await this.exchange.createOrdersWs(expansion)
-      results.push(...this.mapOrderResults(expansion, expansionResponses))
+      const expansionResults = this.mapOrderResults(
+        expansion,
+        expansionResponses,
+      )
+      results.push(...expansionResults)
     }
 
     return results

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -11,10 +11,33 @@ const hyperliquidInfoUrl = (network: NetworkMode): string =>
     ? HYPERLIQUID_TESTNET_INFO_URL
     : HYPERLIQUID_MAINNET_INFO_URL
 
+const HYPERLIQUID_REQUEST_TIMEOUT_MS = 10_000
+
+type LeverageChangedAction = Extract<
+  RebalanceAction,
+  { kind: "rebalance" } | { kind: "preciseRebalance" }
+> & { leverageChanged: true }
+
+const isLeverageChangedAction = (
+  action: RebalanceAction,
+): action is LeverageChangedAction =>
+  (action.kind === "rebalance" || action.kind === "preciseRebalance") &&
+  action.leverageChanged
+
 interface PerpMarketContext {
   szDecimals: number
   markPx: number
 }
+
+/** Matches `finance::hyperliquid_swap_ccxt_symbol` base normalization. */
+const normalizePerpMarketLookupKey = (base: string): string =>
+  base.toUpperCase().replace(/:/g, "-")
+
+const lookupPerpMarketContext = (
+  contexts: Map<string, PerpMarketContext>,
+  base: string,
+): PerpMarketContext | undefined =>
+  contexts.get(normalizePerpMarketLookupKey(base))
 
 const amountPrecisionStepFromSzDecimals = (szDecimals: number): number =>
   szDecimals <= 0 ? 1 : 10 ** -szDecimals
@@ -62,6 +85,7 @@ const fetchPerpMarketContexts = async (
 ): Promise<Map<string, PerpMarketContext>> => {
   const response = await fetch(hyperliquidInfoUrl(network), {
     method: "POST",
+    signal: AbortSignal.timeout(HYPERLIQUID_REQUEST_TIMEOUT_MS),
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ type: "metaAndAssetCtxs" }),
   })
@@ -92,7 +116,7 @@ const fetchPerpMarketContexts = async (
     const rawMarkPx = assetContexts[index]?.markPx ?? 0
     const markPx =
       typeof rawMarkPx === "number" ? rawMarkPx : Number.parseFloat(rawMarkPx)
-    contexts.set(name, {
+    contexts.set(normalizePerpMarketLookupKey(name), {
       szDecimals: asset.szDecimals ?? 0,
       markPx: Number.isFinite(markPx) ? markPx : 0,
     })
@@ -175,7 +199,10 @@ export const fetchHyperliquidMarkets = async (
   network: NetworkMode,
 ): Promise<HyperliquidMarketsResponse> => {
   const url = `${import.meta.env.BASE_URL}api/hyperliquid/markets?network=${network}`
-  const response = await fetch(url, { cache: "no-store" })
+  const response = await fetch(url, {
+    cache: "no-store",
+    signal: AbortSignal.timeout(HYPERLIQUID_REQUEST_TIMEOUT_MS),
+  })
   if (!response.ok) {
     throw new Error(
       `hyperliquid markets request failed: ${String(response.status)}`,
@@ -316,7 +343,7 @@ export class HyperliquidClient {
     const response = await fetch(infoUrl, {
       method: "POST",
       // Abort if the info endpoint is unresponsive for too long to avoid hanging the UI.
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(HYPERLIQUID_REQUEST_TIMEOUT_MS),
       headers: {
         "Content-Type": "application/json",
       },
@@ -497,7 +524,10 @@ export class HyperliquidClient {
         entry.symbol,
       )
       const baseId = String(entry.assetIndex)
-      const context = perpContexts.get(base) ?? { szDecimals: 0, markPx: 1 }
+      const context = lookupPerpMarketContext(perpContexts, base) ?? {
+        szDecimals: 0,
+        markPx: 1,
+      }
       const amountStep = amountPrecisionStepFromSzDecimals(context.szDecimals)
       const priceDecimals = calculateHyperliquidPricePrecision(
         context.markPx,
@@ -755,11 +785,8 @@ export class HyperliquidClient {
 
     this.hydrateMarketsFromBackend(backendMarkets.leverageLimits, perpContexts)
 
-    const leverageActions = actions.filter(
-      action => "leverageChanged" in action && action.leverageChanged,
-    )
+    const leverageActions = actions.filter(isLeverageChangedAction)
     for (const action of leverageActions) {
-      if (!("leverageChanged" in action) || !action.leverageChanged) continue
       await this.setLeverage(action.symbol, action.leverage)
     }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     proxy: {
+      "/api/hyperliquid": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+        rewrite: stripApiPrefix,
+      },
       "/api/beta": {
         target: "http://127.0.0.1:8000",
         changeOrigin: true,

--- a/infra/default.nix
+++ b/infra/default.nix
@@ -1,8 +1,17 @@
-{ pkgs, ragenix, nixos-anywhere, system }:
+{
+  pkgs,
+  ragenix,
+  nixos-anywhere,
+  system,
+}:
 
 let
-  buildInputs =
-    [ pkgs.terraform pkgs.rage pkgs.jq ragenix.packages.${system}.default ];
+  buildInputs = [
+    pkgs.terraform
+    pkgs.rage
+    pkgs.jq
+    ragenix.packages.${system}.default
+  ];
 
   tfState = "infra/terraform.tfstate";
   tfVars = "infra/terraform.tfvars";
@@ -25,9 +34,7 @@ let
 
   encryptState = ''
     if [ -f ${tfState} ]; then
-      nix eval --raw --file ${
-        ../keys.nix
-      } roles.infra --apply 'builtins.concatStringsSep "\n"' \
+      nix eval --raw --file ${../keys.nix} roles.infra --apply 'builtins.concatStringsSep "\n"' \
         | rage -e -R /dev/stdin -o ${tfState}.age ${tfState}
     fi
   '';
@@ -76,20 +83,20 @@ let
   '';
 
   encryptVars = ''
-    nix eval --raw --file ${
-      ../keys.nix
-    } roles.infra --apply 'builtins.concatStringsSep "\n"' \
+    nix eval --raw --file ${../keys.nix} roles.infra --apply 'builtins.concatStringsSep "\n"' \
       | rage -e -R /dev/stdin -o ${tfVars}.age ${tfVars}
   '';
 
-  mkTask = name: body:
+  mkTask =
+    name: body:
     pkgs.writeShellApplication {
       inherit name;
       runtimeInputs = buildInputs;
       text = body;
     };
 
-in {
+in
+{
   inherit buildInputs parseIdentity resolveIp;
 
   rekey = mkTask "rekey" ''
@@ -199,7 +206,11 @@ in {
 
   remote = pkgs.writeShellApplication {
     name = "remote";
-    runtimeInputs = [ pkgs.rage pkgs.jq pkgs.openssh ];
+    runtimeInputs = [
+      pkgs.rage
+      pkgs.jq
+      pkgs.openssh
+    ];
     text = ''
       ${resolveIp}
       exec ssh -i "$identity" "root@$host_ip" "$@"

--- a/keys.nix
+++ b/keys.nix
@@ -1,18 +1,26 @@
 rec {
   keys = {
-    gleb =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHepyxN9hvXzbCY/z0amzldy7DXjNdyetnVaQexRgDEX";
-    lev =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILODNt5kMDazw/bX0BpfBtktfbGalzqdIdBgAT5IIdbz lev";
-    ci =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHww2/XOFuvQONtwbJF5SFWtKazncH82P7iUmWw1duc6";
-    host =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAquGLnor6IRlNhpUuye7NIl/Kqm27+oKzglBXAMNAbj";
+    gleb = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHepyxN9hvXzbCY/z0amzldy7DXjNdyetnVaQexRgDEX";
+    lev = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILODNt5kMDazw/bX0BpfBtktfbGalzqdIdBgAT5IIdbz lev";
+    ci = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHww2/XOFuvQONtwbJF5SFWtKazncH82P7iUmWw1duc6";
+    host = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAquGLnor6IRlNhpUuye7NIl/Kqm27+oKzglBXAMNAbj";
   };
 
   roles = with keys; {
-    infra = [ ci gleb lev ];
-    service = [ host gleb lev ];
-    ssh = [ ci gleb lev ];
+    infra = [
+      ci
+      gleb
+      lev
+    ];
+    service = [
+      host
+      gleb
+      lev
+    ];
+    ssh = [
+      ci
+      gleb
+      lev
+    ];
   };
 }

--- a/os.nix
+++ b/os.nix
@@ -197,6 +197,28 @@ in {
           "${pkgs.curl}/bin/curl -sSf --max-time 300 -X POST http://127.0.0.1:8000/ingest";
       };
     };
+
+    moneymentum-markets-refresh = {
+      description = "Refresh Hyperliquid markets metadata";
+      unitConfig.ConditionPathExists = "/run/moneymentum/moneymentum.ready";
+      serviceConfig = {
+        Type = "oneshot";
+        DynamicUser = true;
+        ExecStart =
+          "${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST http://127.0.0.1:8000/hyperliquid/markets/refresh";
+      };
+    };
+
+    staging-markets-refresh = {
+      description = "Refresh Hyperliquid markets metadata (staging)";
+      unitConfig.ConditionPathExists = "/run/moneymentum/staging.ready";
+      serviceConfig = {
+        Type = "oneshot";
+        DynamicUser = true;
+        ExecStart =
+          "${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST http://127.0.0.1:8001/hyperliquid/markets/refresh";
+      };
+    };
   };
 
   systemd.timers.moneymentum-ingest = {
@@ -204,6 +226,22 @@ in {
     timerConfig = {
       OnBootSec = "5min";
       OnUnitActiveSec = "6h";
+      Persistent = true;
+    };
+  };
+
+  systemd.timers.moneymentum-markets-refresh = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "*-*-* 00:00:00";
+      Persistent = true;
+    };
+  };
+
+  systemd.timers.staging-markets-refresh = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "*-*-* 00:00:00";
       Persistent = true;
     };
   };

--- a/os.nix
+++ b/os.nix
@@ -7,14 +7,29 @@ let
 
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
 
-  moneymentumConfig =
-    builtins.fromTOML (builtins.readFile ./config/moneymentum.toml);
-  stagingConfig = builtins.fromTOML (builtins.readFile ./config/staging.toml);
+  mkMarketsRefreshService =
+    { description, readyMarker, port, runtimeTokenPath, }: {
+      inherit description;
+      unitConfig.ConditionPathExists = [ readyMarker runtimeTokenPath ];
+      serviceConfig = {
+        Type = "oneshot";
+        DynamicUser = true;
+        LoadCredential = "markets_refresh_token:${runtimeTokenPath}";
+        ExecStart = pkgs.writeShellScript
+          "markets-refresh-${builtins.baseNameOf runtimeTokenPath}" ''
+            ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST \
+              -H "X-Markets-Refresh-Token: $(<"$CREDENTIALS_DIRECTORY/markets_refresh_token")" \
+              http://127.0.0.1:${toString port}/hyperliquid/markets/refresh
+          '';
+      };
+    };
 
   mkService = name: cfg:
     let
       path = "/nix/var/nix/profiles/per-service/${name}/bin/${cfg.bin}";
       configFile = ./config/${name}.toml;
+      runtimeDir = "/run/moneymentum/${name}";
+      runtimeTokenPath = "${runtimeDir}/markets-refresh-token";
     in {
       description = "moneymentum ${cfg.bin} (${name})";
 
@@ -31,10 +46,11 @@ let
       serviceConfig = {
         User = "moneymentum";
         Group = "warehouse";
-        ExecStart = "${path} --config ${configFile}";
+        ExecStart =
+          "${path} --config ${configFile} --markets-refresh-token-publish-path ${runtimeTokenPath}";
         Restart = "always";
         RestartSec = 5;
-        ReadWritePaths = [ cfg.dataDir ];
+        ReadWritePaths = [ cfg.dataDir runtimeDir ];
       };
     };
 
@@ -202,26 +218,18 @@ in {
       };
     };
 
-    moneymentum-markets-refresh = {
+    moneymentum-markets-refresh = mkMarketsRefreshService {
       description = "Refresh Hyperliquid markets metadata";
-      unitConfig.ConditionPathExists = "/run/moneymentum/moneymentum.ready";
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        ExecStart = ''
-          ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST -H "X-Markets-Refresh-Token: ${moneymentumConfig.markets_refresh_token}" http://127.0.0.1:8000/hyperliquid/markets/refresh'';
-      };
+      readyMarker = "/run/moneymentum/moneymentum.ready";
+      port = 8000;
+      runtimeTokenPath = "/run/moneymentum/moneymentum/markets-refresh-token";
     };
 
-    staging-markets-refresh = {
+    staging-markets-refresh = mkMarketsRefreshService {
       description = "Refresh Hyperliquid markets metadata (staging)";
-      unitConfig.ConditionPathExists = "/run/moneymentum/staging.ready";
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        ExecStart = ''
-          ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST -H "X-Markets-Refresh-Token: ${stagingConfig.markets_refresh_token}" http://127.0.0.1:8001/hyperliquid/markets/refresh'';
-      };
+      readyMarker = "/run/moneymentum/staging.ready";
+      port = 8001;
+      runtimeTokenPath = "/run/moneymentum/staging/markets-refresh-token";
     };
   };
 
@@ -250,10 +258,13 @@ in {
     };
   };
 
-  systemd.tmpfiles.rules =
-    let dataDirs = lib.mapAttrsToList (_: cfg: cfg.dataDir) enabledServices;
-    in map (dir: "d ${dir} 0770 moneymentum warehouse -") dataDirs
-    ++ [ "d /var/lib/moneymentum/frontend 0755 root root -" ];
+  systemd.tmpfiles.rules = let
+    dataDirs = lib.mapAttrsToList (_: cfg: cfg.dataDir) enabledServices;
+    runtimeDirs = lib.mapAttrsToList
+      (name: _: "d /run/moneymentum/${name} 0770 moneymentum warehouse -")
+      enabledServices;
+  in map (dir: "d ${dir} 0770 moneymentum warehouse -") dataDirs ++ runtimeDirs
+  ++ [ "d /var/lib/moneymentum/frontend 0755 root root -" ];
 
   system.activationScripts.moneymentum-init.text = "mkdir -p /run/moneymentum";
 

--- a/os.nix
+++ b/os.nix
@@ -7,6 +7,10 @@ let
 
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
 
+  moneymentumConfig =
+    builtins.fromTOML (builtins.readFile ./config/moneymentum.toml);
+  stagingConfig = builtins.fromTOML (builtins.readFile ./config/staging.toml);
+
   mkService = name: cfg:
     let
       path = "/nix/var/nix/profiles/per-service/${name}/bin/${cfg.bin}";
@@ -204,8 +208,8 @@ in {
       serviceConfig = {
         Type = "oneshot";
         DynamicUser = true;
-        ExecStart =
-          "${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST http://127.0.0.1:8000/hyperliquid/markets/refresh";
+        ExecStart = ''
+          ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST -H "X-Markets-Refresh-Token: ${moneymentumConfig.markets_refresh_token}" http://127.0.0.1:8000/hyperliquid/markets/refresh'';
       };
     };
 
@@ -215,8 +219,8 @@ in {
       serviceConfig = {
         Type = "oneshot";
         DynamicUser = true;
-        ExecStart =
-          "${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST http://127.0.0.1:8001/hyperliquid/markets/refresh";
+        ExecStart = ''
+          ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST -H "X-Markets-Refresh-Token: ${stagingConfig.markets_refresh_token}" http://127.0.0.1:8001/hyperliquid/markets/refresh'';
       };
     };
   };

--- a/os.nix
+++ b/os.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, modulesPath, ... }:
+{
+  pkgs,
+  lib,
+  modulesPath,
+  ...
+}:
 
 let
   inherit (import ./keys.nix) roles;
@@ -8,29 +13,39 @@ let
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
 
   mkMarketsRefreshService =
-    { description, readyMarker, port, runtimeTokenPath, }: {
+    {
+      description,
+      readyMarker,
+      port,
+      runtimeTokenPath,
+    }:
+    {
       inherit description;
-      unitConfig.ConditionPathExists = [ readyMarker runtimeTokenPath ];
+      unitConfig.ConditionPathExists = [
+        readyMarker
+        runtimeTokenPath
+      ];
       serviceConfig = {
         Type = "oneshot";
         DynamicUser = true;
         LoadCredential = "markets_refresh_token:${runtimeTokenPath}";
-        ExecStart = pkgs.writeShellScript
-          "markets-refresh-${builtins.baseNameOf runtimeTokenPath}" ''
-            ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST \
-              -H "X-Markets-Refresh-Token: $(<"$CREDENTIALS_DIRECTORY/markets_refresh_token")" \
-              http://127.0.0.1:${toString port}/hyperliquid/markets/refresh
-          '';
+        ExecStart = pkgs.writeShellScript "markets-refresh-${builtins.baseNameOf runtimeTokenPath}" ''
+          ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST \
+            -H "X-Markets-Refresh-Token: $(<"$CREDENTIALS_DIRECTORY/markets_refresh_token")" \
+            http://127.0.0.1:${toString port}/hyperliquid/markets/refresh
+        '';
       };
     };
 
-  mkService = name: cfg:
+  mkService =
+    name: cfg:
     let
       path = "/nix/var/nix/profiles/per-service/${name}/bin/${cfg.bin}";
       configFile = ./config/${name}.toml;
       runtimeDir = "/run/moneymentum/${name}";
       runtimeTokenPath = "${runtimeDir}/markets-refresh-token";
-    in {
+    in
+    {
       description = "moneymentum ${cfg.bin} (${name})";
 
       wantedBy = [ ];
@@ -46,15 +61,18 @@ let
       serviceConfig = {
         User = "moneymentum";
         Group = "warehouse";
-        ExecStart =
-          "${path} --config ${configFile} --markets-refresh-token-publish-path ${runtimeTokenPath}";
+        ExecStart = "${path} --config ${configFile} --markets-refresh-token-publish-path ${runtimeTokenPath}";
         Restart = "always";
         RestartSec = 5;
-        ReadWritePaths = [ cfg.dataDir runtimeDir ];
+        ReadWritePaths = [
+          cfg.dataDir
+          runtimeDir
+        ];
       };
     };
 
-in {
+in
+{
   imports = [
     (modulesPath + "/virtualisation/digital-ocean-config.nix")
     (modulesPath + "/profiles/qemu-guest.nix")
@@ -73,7 +91,10 @@ in {
       enable = true;
       network.enable = true;
       settings = {
-        datasource_list = [ "ConfigDrive" "Digitalocean" ];
+        datasource_list = [
+          "ConfigDrive"
+          "Digitalocean"
+        ];
         datasource.ConfigDrive = { };
         datasource.Digitalocean = { };
         cloud_init_modules = [
@@ -86,8 +107,12 @@ in {
           "update_hostname"
           "set_password"
         ];
-        cloud_config_modules =
-          [ "ssh-import-id" "keyboard" "runcmd" "disable_ec2_metadata" ];
+        cloud_config_modules = [
+          "ssh-import-id"
+          "keyboard"
+          "runcmd"
+          "disable_ec2_metadata"
+        ];
         cloud_final_modules = [
           "write_files_deferred"
           "scripts_per_once"
@@ -115,14 +140,18 @@ in {
 
       virtualHosts.default = {
         default = true;
-        listen = [{
-          addr = "0.0.0.0";
-          port = 80;
-        }];
+        listen = [
+          {
+            addr = "0.0.0.0";
+            port = 80;
+          }
+        ];
         root = "/var/lib/moneymentum/frontend";
         locations = {
           "/".tryFiles = "$uri $uri/ /index.html";
-          "/api/" = { proxyPass = "http://127.0.0.1:8000/"; };
+          "/api/" = {
+            proxyPass = "http://127.0.0.1:8000/";
+          };
           "/hl/" = {
             proxyPass = "https://api.hyperliquid.xyz/";
             extraConfig = ''
@@ -141,14 +170,18 @@ in {
       };
 
       virtualHosts.staging = {
-        listen = [{
-          addr = "0.0.0.0";
-          port = 8080;
-        }];
+        listen = [
+          {
+            addr = "0.0.0.0";
+            port = 8080;
+          }
+        ];
         root = "/var/lib/moneymentum/frontend";
         locations = {
           "/".tryFiles = "$uri $uri/ /index.html";
-          "/api/" = { proxyPass = "http://127.0.0.1:8001/"; };
+          "/api/" = {
+            proxyPass = "http://127.0.0.1:8001/";
+          };
           "/hl/" = {
             proxyPass = "https://api.hyperliquid.xyz/";
             extraConfig = ''
@@ -186,7 +219,10 @@ in {
 
   nix = {
     settings = {
-      experimental-features = [ "nix-command" "flakes" ];
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
       auto-optimise-store = true;
       download-buffer-size = 268435456;
     };
@@ -213,8 +249,7 @@ in {
       serviceConfig = {
         Type = "oneshot";
         DynamicUser = true;
-        ExecStart =
-          "${pkgs.curl}/bin/curl -sSf --max-time 300 -X POST http://127.0.0.1:8000/ingest";
+        ExecStart = "${pkgs.curl}/bin/curl -sSf --max-time 300 -X POST http://127.0.0.1:8000/ingest";
       };
     };
 
@@ -258,18 +293,20 @@ in {
     };
   };
 
-  systemd.tmpfiles.rules = let
-    dataDirs = lib.mapAttrsToList (_: cfg: cfg.dataDir) enabledServices;
-    runtimeDirs = lib.mapAttrsToList
-      (name: _: "d /run/moneymentum/${name} 0770 moneymentum warehouse -")
-      enabledServices;
-  in map (dir: "d ${dir} 0770 moneymentum warehouse -") dataDirs ++ runtimeDirs
-  ++ [ "d /var/lib/moneymentum/frontend 0755 root root -" ];
+  systemd.tmpfiles.rules =
+    let
+      dataDirs = lib.mapAttrsToList (_: cfg: cfg.dataDir) enabledServices;
+      runtimeDirs = lib.mapAttrsToList (
+        name: _: "d /run/moneymentum/${name} 0770 moneymentum warehouse -"
+      ) enabledServices;
+    in
+    map (dir: "d ${dir} 0770 moneymentum warehouse -") dataDirs
+    ++ runtimeDirs
+    ++ [ "d /var/lib/moneymentum/frontend 0755 root root -" ];
 
   system.activationScripts.moneymentum-init.text = "mkdir -p /run/moneymentum";
 
-  system.activationScripts.per-service-profiles.text =
-    "mkdir -p /nix/var/nix/profiles/per-service";
+  system.activationScripts.per-service-profiles.text = "mkdir -p /nix/var/nix/profiles/per-service";
 
   environment.systemPackages = with pkgs; [
     bat

--- a/pkgs/gitbutler/default.nix
+++ b/pkgs/gitbutler/default.nix
@@ -3,8 +3,7 @@
 let
   version = "0.20.0";
   build = "3069";
-  baseUrl =
-    "https://releases.gitbutler.com/releases/release/${version}-${build}";
+  baseUrl = "https://releases.gitbutler.com/releases/release/${version}-${build}";
 
   sources = {
     aarch64-darwin = {
@@ -26,10 +25,9 @@ let
   };
 
   system = pkgs.stdenv.hostPlatform.system;
-  source = sources.${system} or (throw
-    "gitbutler-cli: unsupported platform '${system}'. Supported platforms: ${
-      builtins.concatStringsSep ", " (builtins.attrNames sources)
-    }");
+  source =
+    sources.${system}
+      or (throw "gitbutler-cli: unsupported platform '${system}'. Supported platforms: ${builtins.concatStringsSep ", " (builtins.attrNames sources)}");
 
   meta = {
     description = "GitButler CLI";
@@ -38,15 +36,19 @@ let
     platforms = builtins.attrNames sources;
     mainProgram = "but";
   };
-in if pkgs.stdenv.hostPlatform.isDarwin then
-# The macOS .app bundle ships no standalone `but`; the desktop binary
-# `gitbutler-tauri` dispatches into CLI mode when invoked as `but`.
+in
+if pkgs.stdenv.hostPlatform.isDarwin then
+  # The macOS .app bundle ships no standalone `but`; the desktop binary
+  # `gitbutler-tauri` dispatches into CLI mode when invoked as `but`.
   pkgs.stdenvNoCC.mkDerivation {
     pname = "gitbutler-cli";
     inherit version meta;
     src = pkgs.fetchurl { inherit (source) url hash; };
     sourceRoot = ".";
-    nativeBuildInputs = [ pkgs.darwin.sigtool pkgs.darwin.cctools ];
+    nativeBuildInputs = [
+      pkgs.darwin.sigtool
+      pkgs.darwin.cctools
+    ];
     installPhase = ''
       mkdir -p $out/bin
       cp GitButler.app/Contents/MacOS/gitbutler-tauri $out/bin/but
@@ -58,15 +60,23 @@ in if pkgs.stdenv.hostPlatform.isDarwin then
     '';
   }
 else
-# On Linux `usr/bin/but` is a symlink to `gitbutler-tauri`; copy the real
-# binary, which dispatches into CLI mode when invoked as `but`.
+  # On Linux `usr/bin/but` is a symlink to `gitbutler-tauri`; copy the real
+  # binary, which dispatches into CLI mode when invoked as `but`.
   pkgs.stdenvNoCC.mkDerivation {
     pname = "gitbutler-cli";
     inherit version meta;
     src = pkgs.fetchurl { inherit (source) url hash; };
     sourceRoot = ".";
-    nativeBuildInputs = [ pkgs.dpkg pkgs.autoPatchelfHook ];
-    buildInputs = [ pkgs.stdenv.cc.cc.lib pkgs.openssl pkgs.zlib pkgs.dbus ];
+    nativeBuildInputs = [
+      pkgs.dpkg
+      pkgs.autoPatchelfHook
+    ];
+    buildInputs = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.openssl
+      pkgs.zlib
+      pkgs.dbus
+    ];
     # gitbutler-tauri links GTK/WebKit for the desktop GUI, but we only run it
     # headlessly as a CLI. Ignore exactly the GUI libraries it never loads in
     # CLI mode (gitbutler-git-askpass needs only libc/libgcc_s, both provided).

--- a/rust.nix
+++ b/rust.nix
@@ -5,10 +5,15 @@ let
   # standard Cargo sources for tests.
   src = pkgs.lib.cleanSourceWith {
     src = ./.;
-    filter = path: type:
-      let base = builtins.baseNameOf path;
-      in (craneLib.filterCargoSources path type) || base == "fixtures" || base
-      == "migrations" || base == "data_test"
+    filter =
+      path: type:
+      let
+        base = builtins.baseNameOf path;
+      in
+      (craneLib.filterCargoSources path type)
+      || base == "fixtures"
+      || base == "migrations"
+      || base == "data_test"
       || (pkgs.lib.hasPrefix (toString ./fixtures) path)
       || (pkgs.lib.hasPrefix (toString ./migrations) path)
       || (pkgs.lib.hasPrefix (toString ./data_test) path);
@@ -17,9 +22,12 @@ let
   # Cargo manifests only -- deps derivation hash changes only when dependencies change
   depsSrc = pkgs.lib.cleanSourceWith {
     src = ./.;
-    filter = path: type:
-      let base = builtins.baseNameOf path;
-      in type == "directory" || base == "Cargo.toml" || base == "Cargo.lock";
+    filter =
+      path: type:
+      let
+        base = builtins.baseNameOf path;
+      in
+      type == "directory" || base == "Cargo.toml" || base == "Cargo.lock";
   };
 
   # Use depsSrc (Cargo manifests only) so the vendor hash is stable across
@@ -36,9 +44,11 @@ let
 
     nativeBuildInputs = [ pkgs.pkg-config ];
 
-    buildInputs = [ pkgs.openssl pkgs.sqlite ]
-      ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin
-      [ pkgs.apple-sdk_15 ];
+    buildInputs = [
+      pkgs.openssl
+      pkgs.sqlite
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk_15 ];
 
     RUSTFLAGS = "-D warnings";
 
@@ -50,17 +60,24 @@ let
 
   cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { src = depsSrc; });
 
-in {
-  package = craneLib.buildPackage (commonArgs // {
-    inherit cargoArtifacts;
-    doCheck = true;
-  });
+in
+{
+  package = craneLib.buildPackage (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      doCheck = true;
+    }
+  );
 
   # CI check derivations -- lighter than buildPackage (no final link step)
   test = craneLib.cargoTest (commonArgs // { inherit cargoArtifacts; });
 
-  clippy = craneLib.cargoClippy (commonArgs // {
-    inherit cargoArtifacts;
-    cargoClippyExtraArgs = "--all-targets -- -D clippy::all";
-  });
+  clippy = craneLib.cargoClippy (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      cargoClippyExtraArgs = "--all-targets -- -D clippy::all";
+    }
+  );
 }

--- a/src/factors/asset_beta.rs
+++ b/src/factors/asset_beta.rs
@@ -92,9 +92,11 @@ mod tests {
             .chain(0..count)
             .map(|index| format!("{index:04}"))
             .collect();
+
         let tickers: Vec<&str> = std::iter::repeat_n("BTC", count)
             .chain(std::iter::repeat_n("ETH", count))
             .collect();
+
         let log_returns: Vec<f64> = btc.iter().chain(eth.iter()).copied().collect();
         df! {
             "timestamp" => timestamps,
@@ -119,6 +121,7 @@ mod tests {
             (beta.get(0).unwrap() - 1.0).abs() < 1e-12,
             "the benchmark's beta to itself must be 1"
         );
+
         assert_eq!(tickers.get(1), Some("ETH"));
         assert!(
             (beta.get(1).unwrap() - 2.0).abs() < 1e-12,

--- a/src/factors/autocorrelation.rs
+++ b/src/factors/autocorrelation.rs
@@ -108,6 +108,7 @@ mod tests {
             .unwrap()
             .get(0)
             .unwrap();
+
         assert!(
             (autocorrelation - (-1.0)).abs() < 1e-12,
             "alternating returns must give autocorrelation -1, got {autocorrelation}"
@@ -134,23 +135,27 @@ mod tests {
             .chain(0..eth_closes.len())
             .map(|index| format!("{index:04}"))
             .collect();
+
         let tickers: Vec<&str> = std::iter::repeat_n("BTC", btc_closes.len())
             .chain(std::iter::repeat_n("ETH", eth_closes.len()))
             .collect();
+
         let closes: Vec<f64> = btc_closes
             .iter()
             .chain(eth_closes.iter())
             .copied()
             .collect();
+
         let candles = df! {
             "timestamp" => timestamps,
             "ticker" => tickers,
             "close" => closes,
         }
         .unwrap();
-        let with_returns = super::super::returns::compute_log_returns(&candles).unwrap();
 
+        let with_returns = super::super::returns::compute_log_returns(&candles).unwrap();
         let out = autocorrelation_by_ticker(&with_returns, 10).unwrap();
+
         let by_ticker = |ticker: &str| -> f64 {
             let index = out
                 .column("ticker")
@@ -160,6 +165,7 @@ mod tests {
                 .iter()
                 .position(|value| value == Some(ticker))
                 .expect("ticker present");
+
             out.column("autocorrelation")
                 .unwrap()
                 .f64()
@@ -190,9 +196,10 @@ mod tests {
             100.0, 110.0, 100.0, 110.0, 100.0, // alternating prefix
             101.0, 103.0, 106.0, 110.0, 115.0, 121.0_f64, // linear-return tail
         ];
-        let with_returns = log_returns_frame(&closes);
 
+        let with_returns = log_returns_frame(&closes);
         let out = autocorrelation_by_ticker(&with_returns, 4).unwrap();
+
         let autocorrelation = out
             .column("autocorrelation")
             .unwrap()
@@ -200,6 +207,7 @@ mod tests {
             .unwrap()
             .get(0)
             .unwrap();
+
         assert!(
             autocorrelation > 0.9,
             "the trailing window holds only the trend, so the alternating \
@@ -210,9 +218,9 @@ mod tests {
     #[test]
     fn autocorrelation_is_null_for_constant_prices() {
         let with_returns = log_returns_frame(&[100.0, 100.0, 100.0, 100.0, 100.0]);
-
         let out = autocorrelation_by_ticker(&with_returns, 10).unwrap();
         let autocorrelation = out.column("autocorrelation").unwrap().f64().unwrap().get(0);
+
         assert!(
             autocorrelation.is_none(),
             "constant prices have no return variation, so autocorrelation must be null, got {autocorrelation:?}"
@@ -227,6 +235,7 @@ mod tests {
         ) {
             let with_returns = log_returns_frame(&closes);
             let out = autocorrelation_by_ticker(&with_returns, 10).unwrap();
+
             if let Some(autocorrelation) = out.column("autocorrelation").unwrap().f64().unwrap().get(0) {
                 prop_assert!(
                     (-1.0 - 1e-9..=1.0 + 1e-9).contains(&autocorrelation),

--- a/src/factors/beta.rs
+++ b/src/factors/beta.rs
@@ -32,9 +32,11 @@ pub(crate) async fn compute_portfolio_beta_report(
 ) -> Result<PortfolioBetaReport, ReturnsError> {
     let path = daily_candles_path(data_dir);
     let df = crate::dataframe::read_csv(path.clone()).await?;
+
     let Some(df) = df else {
         return Err(ReturnsError::NoData { path });
     };
+
     let data_age_hours = data_age_hours_at(&df, Utc::now())?;
     let weights_clone = weights.to_vec();
     let benchmark_ticker_clone = benchmark_ticker.to_string();
@@ -43,6 +45,7 @@ pub(crate) async fn compute_portfolio_beta_report(
         load_log_returns_last_n_candles(&df, &weights_clone, &benchmark_ticker_clone, lookback)
     })
     .await??;
+
     compute_beta_report_from_log_returns(&log_returns_df, weights, benchmark_ticker, data_age_hours)
 }
 
@@ -69,6 +72,7 @@ pub(super) fn compute_beta_from_log_returns(
         .column("portfolio_log_return")?
         .as_materialized_series()
         .clone();
+
     let benchmark_series = clean_pair_df
         .column("benchmark_log_return")?
         .as_materialized_series()
@@ -90,11 +94,13 @@ fn data_age_hours_at(df: &DataFrame, now: DateTime<Utc>) -> Result<i64, ReturnsE
     let timestamp_col = df.column("timestamp")?;
     let latest_timestamp = any_value_to_string(timestamp_col.max_reduce()?.as_any_value())
         .ok_or(ReturnsError::NoTimestamps)?;
+
     let latest_timestamp = DateTime::parse_from_rfc3339(&latest_timestamp)
         .map(|parsed_timestamp| parsed_timestamp.with_timezone(&Utc))
         .map_err(|_| ReturnsError::InvalidTimestamp {
             timestamp: latest_timestamp,
         })?;
+
     if latest_timestamp > now {
         return Err(ReturnsError::FutureTimestamp {
             timestamp: latest_timestamp.to_rfc3339(),
@@ -123,6 +129,7 @@ fn load_log_returns_last_n_candles(
     let benchmark_ticker_df = DataFrame::new(vec![
         Series::new("ticker".into(), vec![benchmark_ticker.to_string()]).into(),
     ])?;
+
     let benchmark_rows = df.join(
         &benchmark_ticker_df,
         ["ticker"],
@@ -130,15 +137,18 @@ fn load_log_returns_last_n_candles(
         JoinArgs::new(JoinType::Inner),
         None,
     )?;
+
     let benchmark_timestamp_col = benchmark_rows.column("timestamp")?;
     let benchmark_unique_timestamps = benchmark_timestamp_col
         .unique()?
         .sort(SortOptions::default())?;
+
     let benchmark_timestamp_series = benchmark_unique_timestamps.as_materialized_series().clone();
     let timestamp_count = benchmark_timestamp_series.len();
     let start = i64::try_from(timestamp_count.saturating_sub(lookback)).unwrap_or(0);
     let last_benchmark_timestamps =
         benchmark_timestamp_series.slice(start, lookback.min(timestamp_count));
+
     let ts_window_df = DataFrame::new(vec![
         last_benchmark_timestamps
             .with_name("timestamp".into())
@@ -152,6 +162,7 @@ fn load_log_returns_last_n_candles(
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .collect();
+
     let ticker_df = DataFrame::new(vec![Series::new("ticker".into(), tickers).into()])?;
 
     let filtered = df.join(
@@ -236,6 +247,7 @@ fn build_portfolio_and_benchmark_df(
 
     let portfolio_series = Series::new("portfolio_log_return".into(), portfolio);
     let benchmark_series = Series::new("benchmark_log_return".into(), benchmark);
+
     DataFrame::new(vec![portfolio_series.into(), benchmark_series.into()])
         .map_err(ReturnsError::from)
 }
@@ -250,6 +262,7 @@ fn compute_beta_report_from_log_returns(
     let benchmark_return_timestamps = return_timestamps
         .get(benchmark_ticker)
         .ok_or(ReturnsError::BetaUndefined)?;
+
     if benchmark_return_timestamps.is_empty() {
         return Err(ReturnsError::BetaUndefined);
     }
@@ -278,10 +291,12 @@ fn compute_beta_report_from_log_returns(
         }
         Err(err) => return Err(err),
     };
+
     let beta_weights = effective_weights
         .iter()
         .map(|(ticker, weight)| (ticker.clone(), *weight))
         .collect::<Vec<_>>();
+
     let beta = compute_beta_from_log_returns(log_returns_df, &beta_weights, benchmark_ticker)?;
 
     Ok(PortfolioBetaReport {
@@ -316,11 +331,13 @@ fn finite_return_timestamps_by_ticker(
         let Some(ticker) = ticker else {
             continue;
         };
+
         let has_return = log_return_col
             .get(row_index)
             .ok()
             .and_then(|value| value.try_extract::<f64>().ok())
             .is_some_and(f64::is_finite);
+
         if has_return {
             return_timestamps
                 .entry(ticker)
@@ -339,6 +356,7 @@ fn renormalize_abs_weights(
         .iter()
         .map(|(_ticker, weight)| weight.abs())
         .sum::<f64>();
+
     if absolute_weight_sum <= 0.0 {
         return Err(ReturnsError::BetaUndefined);
     }
@@ -353,6 +371,7 @@ fn renormalize_abs_weights(
 fn covariance(portfolio: &Series, benchmark: &Series) -> Result<f64, ReturnsError> {
     let df = DataFrame::new(vec![portfolio.clone().into(), benchmark.clone().into()])
         .map_err(ReturnsError::from)?;
+
     let out = df
         .lazy()
         .select([
@@ -362,6 +381,7 @@ fn covariance(portfolio: &Series, benchmark: &Series) -> Result<f64, ReturnsErro
             .alias("_cov"),
         ])
         .collect()?;
+
     out.column("_cov")?
         .get(0)
         .ok()
@@ -381,20 +401,25 @@ fn variance(benchmark: &Series) -> Result<f64, ReturnsError> {
                 .alias("_var"),
         ])
         .collect()?;
+
     let variance = out
         .column("_var")?
         .get(0)
         .ok()
         .and_then(|value| value.try_extract::<f64>().ok())
         .ok_or(ReturnsError::BetaUndefined)?;
+
     if variance.abs() < 1e-20 {
         return Err(ReturnsError::BetaUndefined);
     }
+
     Ok(variance)
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::logs_contain_at;
+
     use super::*;
     use polars::prelude::df;
     use proptest::prelude::*;
@@ -427,7 +452,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             prop_assert!((beta - weight).abs() < 1e-9, "beta {beta} != weight {weight}");
-            prop_assert!(crate::logs_contain_at(
+            prop_assert!(logs_contain_at(
                 tracing::Level::INFO,
                 &["portfolio beta calculated", "beta="]
             ));
@@ -456,12 +481,12 @@ mod tests {
             "close" => &[100.0, 200.0],
         }
         .unwrap();
+
         let now = DateTime::parse_from_rfc3339("2024-01-03T12:00:00.000Z")
             .unwrap()
             .with_timezone(&Utc);
 
         let age_hours = data_age_hours_at(&df, now).unwrap();
-
         assert_eq!(age_hours, 36);
     }
 
@@ -473,12 +498,12 @@ mod tests {
             "close" => &[100.0],
         }
         .unwrap();
+
         let now = DateTime::parse_from_rfc3339("2024-01-03T12:00:00.000Z")
             .unwrap()
             .with_timezone(&Utc);
 
         let age_hours = data_age_hours_at(&df, now);
-
         assert!(matches!(
             age_hours,
             Err(ReturnsError::FutureTimestamp { .. })
@@ -494,14 +519,17 @@ mod tests {
             "log_return" => &[0.01_f64, -0.02, 0.015],
         }
         .unwrap();
+
         let weights = [("BTC".to_string(), 1.0)];
         let result = compute_beta_from_log_returns(&log_returns_df, &weights, "BTC").unwrap();
         let beta = result.expect("beta defined");
+
         assert!(
             (beta - 1.0).abs() < 1e-10,
             "beta of portfolio vs self should be 1, got {beta}"
         );
-        assert!(crate::logs_contain_at(
+
+        assert!(logs_contain_at(
             tracing::Level::INFO,
             &["portfolio beta calculated"]
         ));
@@ -515,8 +543,10 @@ mod tests {
             "log_return" => &[0.0_f64, 0.0],
         }
         .unwrap();
+
         let weights = [("BTC".to_string(), 1.0)];
         let result = compute_beta_from_log_returns(&log_returns_df, &weights, "BTC");
+
         assert!(matches!(result, Err(ReturnsError::BetaUndefined)));
     }
 
@@ -533,8 +563,8 @@ mod tests {
             "close" => &[100.0_f64, 101.0, 102.0, 50.0, 51.0, 52.0, 53.0, 54.0],
         }
         .unwrap();
-        let weights = [("ETH".to_string(), 1.0_f64)];
 
+        let weights = [("ETH".to_string(), 1.0_f64)];
         let log_returns = load_log_returns_last_n_candles(&candles, &weights, "BTC", 3).unwrap();
         let timestamp_col = log_returns.column("timestamp").unwrap();
         let ticker_col = log_returns.column("ticker").unwrap();
@@ -544,6 +574,7 @@ mod tests {
             "2024-01-02T00:00:00Z".to_string(),
             "2024-01-03T00:00:00Z".to_string(),
         ];
+
         let timestamps_for_ticker = |target_ticker: &str| {
             (0..log_returns.height())
                 .filter_map(|row_index| {
@@ -562,12 +593,13 @@ mod tests {
                 })
                 .collect::<Vec<_>>()
         };
+
         let benchmark_timestamps = timestamps_for_ticker("BTC");
         let portfolio_timestamps = timestamps_for_ticker("ETH");
 
         assert_eq!(benchmark_timestamps, expected_timestamps);
         assert_eq!(portfolio_timestamps, expected_timestamps);
-        assert!(crate::logs_contain_at(
+        assert!(logs_contain_at(
             tracing::Level::DEBUG,
             &["log returns computed", "rows=6"]
         ));
@@ -595,7 +627,7 @@ mod tests {
         assert_eq!(report.effective_weights.get("ETH"), Some(&1.0));
         assert_eq!(report.data_age_hours, 12);
         assert!((report.beta.expect("beta") - 1.0).abs() < 1e-10);
-        assert!(crate::logs_contain_at(
+        assert!(logs_contain_at(
             tracing::Level::INFO,
             &["portfolio beta calculated"]
         ));
@@ -627,7 +659,7 @@ mod tests {
         // "portfolio beta calculated" would trip a bare negative assertion.
         // Scope it to this test's own span (traced_test prefixes every line
         // emitted here with the test name).
-        assert!(!crate::logs_contain_at(
+        assert!(!logs_contain_at(
             tracing::Level::INFO,
             &[
                 "beta_report_returns_none_when_all_portfolio_assets_are_excluded",
@@ -658,7 +690,7 @@ mod tests {
         assert_eq!(report.effective_weights.get("ETH"), Some(&1.0));
         assert_eq!(report.data_age_hours, 12);
         assert!((report.beta.expect("beta") - 1.0).abs() < 1e-10);
-        assert!(crate::logs_contain_at(
+        assert!(logs_contain_at(
             tracing::Level::INFO,
             &["portfolio beta calculated"]
         ));
@@ -685,7 +717,7 @@ mod tests {
             (beta - 0.592_091_722_3_f64).abs() < 1e-10,
             "beta mismatch: got {beta}"
         );
-        assert!(crate::logs_contain_at(
+        assert!(logs_contain_at(
             tracing::Level::INFO,
             &["portfolio beta calculated"]
         ));

--- a/src/factors/carry.rs
+++ b/src/factors/carry.rs
@@ -80,6 +80,7 @@ mod tests {
             (carry.get(0).unwrap() - 0.0003).abs() < 1e-12,
             "BTC carry should be the latest funding rate 0.0003"
         );
+
         assert_eq!(tickers.get(1), Some("ETH"));
         assert!(
             (carry.get(1).unwrap() - (-0.0002)).abs() < 1e-12,

--- a/src/factors/fixture_tests.rs
+++ b/src/factors/fixture_tests.rs
@@ -50,6 +50,7 @@ fn aave_fixture_portfolio_beta_to_btc_is_102() -> Result<(), FixtureTestError> {
         Level::DEBUG,
         &["log returns computed", "rows=740"]
     ));
+
     assert!(crate::logs_contain_at(
         Level::INFO,
         &["portfolio beta calculated", "beta="]

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -60,6 +60,7 @@ fn hyperliquid_swap_ccxt_symbol_with_collateral(base_name: &str, collateral: &st
 fn safe_currency_code(currency_code: &str) -> String {
     currency_code.to_uppercase()
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -7,6 +7,8 @@
 //! [`Symbol`] normalizes these representations for consistent storage and lookup.
 //! [`Market`] preserves the exchange's native identifier for API calls.
 
+use serde::Serialize;
+
 /// Normalized trading symbol (e.g., "BTC", "ETH").
 ///
 /// Normalizes input like "BTC/USDC:USDC" to just "BTC".
@@ -38,22 +40,46 @@ impl Market {
     }
 }
 
-/// CCXT unified swap symbol for a Hyperliquid main-meta perp.
+/// CCXT unified swap symbol for a Hyperliquid perp (e.g., "BTC/USDC:USDC").
+///
+/// Serializes transparently as its string form, so API consumers still receive
+/// a plain ticker string.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub(crate) struct CcxtSymbol(String);
+
+impl CcxtSymbol {
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for CcxtSymbol {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Builds the [`CcxtSymbol`] for a Hyperliquid main-meta perp.
 ///
 /// Mirrors `ccxt` `hyperliquid.parseMarket` for the default-collateral case
 /// (`quote` and `settle` are `USDC` when `collateralTokenName` is absent):
 /// `safeCurrencyCode(baseName)`, then `:` -> `-` in the base, then
 /// `{base}/{quote}:{settle}`.
-pub(crate) fn hyperliquid_swap_ccxt_symbol(base_name: &str) -> String {
+pub(crate) fn hyperliquid_swap_ccxt_symbol(base_name: &str) -> CcxtSymbol {
     hyperliquid_swap_ccxt_symbol_with_collateral(base_name, "USDC")
 }
 
-fn hyperliquid_swap_ccxt_symbol_with_collateral(base_name: &str, collateral: &str) -> String {
+fn hyperliquid_swap_ccxt_symbol_with_collateral(base_name: &str, collateral: &str) -> CcxtSymbol {
     let mut base = safe_currency_code(base_name);
     base = base.replace(':', "-");
     let quote = safe_currency_code(collateral);
     let settle = safe_currency_code(collateral);
-    format!("{base}/{quote}:{settle}")
+    CcxtSymbol(format!("{base}/{quote}:{settle}"))
 }
 
 /// CCXT `safeCurrencyCode` for Hyperliquid meta asset names.
@@ -114,12 +140,24 @@ mod tests {
 
     #[test]
     fn hyperliquid_swap_ccxt_symbol_matches_ccxt_parse_market() {
-        assert_eq!(hyperliquid_swap_ccxt_symbol("BTC"), "BTC/USDC:USDC");
-        assert_eq!(hyperliquid_swap_ccxt_symbol("FRIEND"), "FRIEND/USDC:USDC");
-        assert_eq!(hyperliquid_swap_ccxt_symbol("kPEPE"), "KPEPE/USDC:USDC");
-        assert_eq!(hyperliquid_swap_ccxt_symbol("kDOGS"), "KDOGS/USDC:USDC");
         assert_eq!(
-            hyperliquid_swap_ccxt_symbol("flx:crcl"),
+            hyperliquid_swap_ccxt_symbol("BTC").as_str(),
+            "BTC/USDC:USDC"
+        );
+        assert_eq!(
+            hyperliquid_swap_ccxt_symbol("FRIEND").as_str(),
+            "FRIEND/USDC:USDC"
+        );
+        assert_eq!(
+            hyperliquid_swap_ccxt_symbol("kPEPE").as_str(),
+            "KPEPE/USDC:USDC"
+        );
+        assert_eq!(
+            hyperliquid_swap_ccxt_symbol("kDOGS").as_str(),
+            "KDOGS/USDC:USDC"
+        );
+        assert_eq!(
+            hyperliquid_swap_ccxt_symbol("flx:crcl").as_str(),
             "FLX-CRCL/USDC:USDC"
         );
     }
@@ -127,7 +165,7 @@ mod tests {
     #[test]
     fn hyperliquid_swap_ccxt_symbol_supports_non_usdc_collateral() {
         assert_eq!(
-            hyperliquid_swap_ccxt_symbol_with_collateral("HYNA-BTC", "USDE"),
+            hyperliquid_swap_ccxt_symbol_with_collateral("HYNA-BTC", "USDE").as_str(),
             "HYNA-BTC/USDE:USDE"
         );
     }

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -37,6 +37,29 @@ impl Market {
         &self.0
     }
 }
+
+/// CCXT unified swap symbol for a Hyperliquid main-meta perp.
+///
+/// Mirrors `ccxt` `hyperliquid.parseMarket` for the default-collateral case
+/// (`quote` and `settle` are `USDC` when `collateralTokenName` is absent):
+/// `safeCurrencyCode(baseName)`, then `:` -> `-` in the base, then
+/// `{base}/{quote}:{settle}`.
+pub(crate) fn hyperliquid_swap_ccxt_symbol(base_name: &str) -> String {
+    hyperliquid_swap_ccxt_symbol_with_collateral(base_name, "USDC")
+}
+
+fn hyperliquid_swap_ccxt_symbol_with_collateral(base_name: &str, collateral: &str) -> String {
+    let mut base = safe_currency_code(base_name);
+    base = base.replace(':', "-");
+    let quote = safe_currency_code(collateral);
+    let settle = safe_currency_code(collateral);
+    format!("{base}/{quote}:{settle}")
+}
+
+/// CCXT `safeCurrencyCode` for Hyperliquid meta asset names.
+fn safe_currency_code(currency_code: &str) -> String {
+    currency_code.to_uppercase()
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,5 +109,25 @@ mod tests {
     fn uppercases() {
         assert_eq!(Symbol::from_raw("btc/usdc:usdc").as_str(), "BTC");
         assert_eq!(Symbol::from_raw("kdogs").as_str(), "KDOGS");
+    }
+
+    #[test]
+    fn hyperliquid_swap_ccxt_symbol_matches_ccxt_parse_market() {
+        assert_eq!(hyperliquid_swap_ccxt_symbol("BTC"), "BTC/USDC:USDC");
+        assert_eq!(hyperliquid_swap_ccxt_symbol("FRIEND"), "FRIEND/USDC:USDC");
+        assert_eq!(hyperliquid_swap_ccxt_symbol("kPEPE"), "KPEPE/USDC:USDC");
+        assert_eq!(hyperliquid_swap_ccxt_symbol("kDOGS"), "KDOGS/USDC:USDC");
+        assert_eq!(
+            hyperliquid_swap_ccxt_symbol("flx:crcl"),
+            "FLX-CRCL/USDC:USDC"
+        );
+    }
+
+    #[test]
+    fn hyperliquid_swap_ccxt_symbol_supports_non_usdc_collateral() {
+        assert_eq!(
+            hyperliquid_swap_ccxt_symbol_with_collateral("HYNA-BTC", "USDE"),
+            "HYNA-BTC/USDE:USDE"
+        );
     }
 }

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -23,7 +23,7 @@ use crate::candle::{Candle, CandleError, candles_to_dataframe};
 use crate::dataframe::{self, DataFrameError};
 use crate::finance::{self, Market, Symbol};
 use crate::funding::{self, FundingError, FundingRate};
-use crate::market_metadata::MarketMetadata;
+use crate::market_metadata::{MarketMetadata, MarketsLedger};
 use crate::timeframe::Timeframe;
 
 /// Maximum number of data points returned by Hyperliquid's historical data endpoints.
@@ -99,13 +99,10 @@ impl HyperliquidClients {
         Ok(Self { mainnet, testnet })
     }
 
-    pub(crate) fn for_ledger(
-        &self,
-        ledger: crate::market_metadata::MarketsLedger,
-    ) -> &dyn Hyperliquid {
+    pub(crate) fn for_ledger(&self, ledger: MarketsLedger) -> &dyn Hyperliquid {
         match ledger {
-            crate::market_metadata::MarketsLedger::Mainnet => self.mainnet.as_ref(),
-            crate::market_metadata::MarketsLedger::Testnet => self.testnet.as_ref(),
+            MarketsLedger::Mainnet => self.mainnet.as_ref(),
+            MarketsLedger::Testnet => self.testnet.as_ref(),
         }
     }
 }

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -155,12 +155,17 @@ impl Hyperliquid for HyperliquidClient {
         struct RawAsset {
             name: String,
             max_leverage: u32,
+            is_delisted: Option<bool>,
         }
 
         let url = format!("{}/info", self.info.http_client.base_url);
+        // Bound each attempt so a hung upstream cannot stall startup or the
+        // markets endpoint indefinitely (matches the frontend's 10s guard).
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
         let raw = (|| async {
-            reqwest::Client::new()
-                .post(&url)
+            http.post(&url)
                 .json(&MetaRequest {
                     request_type: "meta",
                 })
@@ -184,6 +189,7 @@ impl Hyperliquid for HyperliquidClient {
             .universe
             .into_iter()
             .enumerate()
+            .filter(|(_, asset)| asset.is_delisted != Some(true))
             .map(
                 |(asset_index, asset)| -> Result<MarketMetadata, HyperliquidError> {
                     Ok(MarketMetadata {

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use crate::candle::{Candle, CandleError, candles_to_dataframe};
 use crate::dataframe::{self, DataFrameError};
-use crate::finance::{Market, Symbol};
+use crate::finance::{self, Market, Symbol};
 use crate::funding::{self, FundingError, FundingRate};
 use crate::market_metadata::MarketMetadata;
 use crate::timeframe::Timeframe;
@@ -204,7 +204,7 @@ impl Hyperliquid for HyperliquidClient {
                     close,
                     volume,
                     // CCXT perpetual format: BASE/USDC:USDC
-                    symbol: format!("{}/USDC:USDC", market.as_str()),
+                    symbol: finance::hyperliquid_swap_ccxt_symbol(market.as_str()),
                     ticker: Symbol::from_raw(market.as_str()),
                 })
             })

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -85,11 +85,15 @@ pub(crate) struct HyperliquidClients {
 impl HyperliquidClients {
     pub(crate) async fn from_config(
         mainnet_base_url: Option<&Url>,
+        testnet_base_url: Option<&Url>,
         max_retries: usize,
     ) -> Result<Self, HyperliquidError> {
         let mainnet = Arc::new(HyperliquidClient::new(mainnet_base_url, max_retries).await?)
             as Arc<dyn Hyperliquid>;
-        let testnet_url = Url::parse(HYPERLIQUID_TESTNET_BASE_URL)?;
+        let testnet_url = match testnet_base_url {
+            Some(url) => url.clone(),
+            None => Url::parse(HYPERLIQUID_TESTNET_BASE_URL)?,
+        };
         let testnet = Arc::new(HyperliquidClient::new(Some(&testnet_url), max_retries).await?)
             as Arc<dyn Hyperliquid>;
         Ok(Self { mainnet, testnet })

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -48,6 +48,8 @@ pub(crate) enum HyperliquidError {
     #[error(transparent)]
     Http(#[from] reqwest::Error),
     #[error(transparent)]
+    Url(#[from] url::ParseError),
+    #[error(transparent)]
     Polars(#[from] polars::prelude::PolarsError),
 }
 
@@ -70,6 +72,38 @@ pub(crate) trait Hyperliquid: Send + Sync {
         market: &Market,
         start: DateTime<Utc>,
     ) -> Result<Vec<FundingRate>, HyperliquidError>;
+}
+
+pub(crate) const HYPERLIQUID_TESTNET_BASE_URL: &str = "https://api.hyperliquid-testnet.xyz";
+
+/// Mainnet and testnet Hyperliquid info clients for markets refresh and ingestion.
+pub(crate) struct HyperliquidClients {
+    pub(crate) mainnet: Arc<dyn Hyperliquid>,
+    pub(crate) testnet: Arc<dyn Hyperliquid>,
+}
+
+impl HyperliquidClients {
+    pub(crate) async fn from_config(
+        mainnet_base_url: Option<&Url>,
+        max_retries: usize,
+    ) -> Result<Self, HyperliquidError> {
+        let mainnet = Arc::new(HyperliquidClient::new(mainnet_base_url, max_retries).await?)
+            as Arc<dyn Hyperliquid>;
+        let testnet_url = Url::parse(HYPERLIQUID_TESTNET_BASE_URL)?;
+        let testnet = Arc::new(HyperliquidClient::new(Some(&testnet_url), max_retries).await?)
+            as Arc<dyn Hyperliquid>;
+        Ok(Self { mainnet, testnet })
+    }
+
+    pub(crate) fn for_ledger(
+        &self,
+        ledger: crate::market_metadata::MarketsLedger,
+    ) -> &dyn Hyperliquid {
+        match ledger {
+            crate::market_metadata::MarketsLedger::Mainnet => self.mainnet.as_ref(),
+            crate::market_metadata::MarketsLedger::Testnet => self.testnet.as_ref(),
+        }
+    }
 }
 
 pub(crate) struct HyperliquidClient {
@@ -145,11 +179,18 @@ impl Hyperliquid for HyperliquidClient {
         let metadata: Vec<MarketMetadata> = raw
             .universe
             .into_iter()
-            .map(|asset| MarketMetadata {
-                symbol: Market::new(asset.name),
-                max_leverage: asset.max_leverage,
-            })
-            .collect();
+            .enumerate()
+            .map(
+                |(asset_index, asset)| -> Result<MarketMetadata, HyperliquidError> {
+                    Ok(MarketMetadata {
+                        symbol: Market::new(asset.name),
+                        max_leverage: asset.max_leverage,
+                        asset_index: u32::try_from(asset_index)
+                            .map_err(HyperliquidError::IntConversion)?,
+                    })
+                },
+            )
+            .collect::<Result<Vec<_>, _>>()?;
         debug!(count = metadata.len(), "fetched market metadata");
         Ok(metadata)
     }
@@ -465,6 +506,7 @@ mod tests {
                 market_metadata: vec![MarketMetadata {
                     symbol: Market::new("BTC".to_string()),
                     max_leverage: 50,
+                    asset_index: 0,
                 }],
                 candles: vec![Candle {
                     timestamp: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -252,7 +252,7 @@ impl Hyperliquid for HyperliquidClient {
                     close,
                     volume,
                     // CCXT perpetual format: BASE/USDC:USDC
-                    symbol: finance::hyperliquid_swap_ccxt_symbol(market.as_str()),
+                    symbol: finance::hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
                     ticker: Symbol::from_raw(market.as_str()),
                 })
             })

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -359,7 +359,7 @@ mod tests {
                 low: 95.0,
                 close: 102.0,
                 volume: 1000.0,
-                symbol: format!("{}/USDC:USDC", market.as_str()),
+                symbol: crate::finance::hyperliquid_swap_ccxt_symbol(market.as_str()),
                 ticker: Symbol::from_raw(market.as_str()),
             }])
         }

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -97,7 +97,12 @@ async fn ingest_all(
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
     data_dir: &Path,
 ) -> Result<DateTime<Utc>, HyperliquidError> {
-    let markets = crate::market_metadata::refresh_markets(client, data_dir).await?;
+    let markets = crate::market_metadata::refresh_markets(
+        client,
+        data_dir,
+        crate::market_metadata::MarketsLedger::Mainnet,
+    )
+    .await?;
 
     funding_ingester
         .ingest_with_markets(data_dir, &markets)
@@ -343,6 +348,7 @@ mod tests {
             Ok(vec![crate::market_metadata::MarketMetadata {
                 symbol: Market::new("BTC".into()),
                 max_leverage: 50,
+                asset_index: 0,
             }])
         }
 

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -366,7 +366,7 @@ mod tests {
                 low: 95.0,
                 close: 102.0,
                 volume: 1000.0,
-                symbol: hyperliquid_swap_ccxt_symbol(market.as_str()),
+                symbol: hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
                 ticker: Symbol::from_raw(market.as_str()),
             }])
         }

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
 use crate::hyperliquid::{CandleIngester, FundingRateIngester, Hyperliquid, HyperliquidError};
+use crate::market_metadata::{MarketsLedger, refresh_markets};
 use crate::timeframe::Timeframe;
 
 const TIMEFRAMES: &[Timeframe] = &[
@@ -34,6 +35,12 @@ impl IngestionRunId {
 
     fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl std::fmt::Display for IngestionRunId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
     }
 }
 
@@ -97,12 +104,7 @@ async fn ingest_all(
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
     data_dir: &Path,
 ) -> Result<DateTime<Utc>, HyperliquidError> {
-    let markets = crate::market_metadata::refresh_markets(
-        client,
-        data_dir,
-        crate::market_metadata::MarketsLedger::Mainnet,
-    )
-    .await?;
+    let markets = refresh_markets(client, data_dir, MarketsLedger::Mainnet).await?;
 
     funding_ingester
         .ingest_with_markets(data_dir, &markets)
@@ -151,7 +153,7 @@ pub(crate) enum IngestionRunError {
     #[error("ingestion already running")]
     AlreadyRunning,
     #[error("ingestion run is not running: {run_id}")]
-    RunNotRunning { run_id: String },
+    RunNotRunning { run_id: IngestionRunId },
     #[error("unknown ingestion status: {status}")]
     UnknownStatus { status: String },
     #[error(transparent)]
@@ -256,7 +258,7 @@ async fn touch_run(pool: &SqlitePool, run_id: &IngestionRunId) -> Result<(), Ing
 
     if affected_rows == 0 {
         return Err(IngestionRunError::RunNotRunning {
-            run_id: run_id.as_str().to_string(),
+            run_id: run_id.clone(),
         });
     }
 
@@ -332,20 +334,19 @@ mod tests {
 
     use super::*;
     use crate::candle::Candle;
-    use crate::finance::{Market, Symbol};
+    use crate::finance::{Market, Symbol, hyperliquid_swap_ccxt_symbol};
     use crate::funding::FundingRate;
     use crate::hyperliquid::HyperliquidError;
     use crate::logs_contain_at;
+    use crate::market_metadata::MarketMetadata;
     use crate::timeframe::Timeframe;
 
     struct MockHyperliquid;
 
     #[async_trait]
     impl Hyperliquid for MockHyperliquid {
-        async fn fetch_market_metadata(
-            &self,
-        ) -> Result<Vec<crate::market_metadata::MarketMetadata>, HyperliquidError> {
-            Ok(vec![crate::market_metadata::MarketMetadata {
+        async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            Ok(vec![MarketMetadata {
                 symbol: Market::new("BTC".into()),
                 max_leverage: 50,
                 asset_index: 0,
@@ -365,7 +366,7 @@ mod tests {
                 low: 95.0,
                 close: 102.0,
                 volume: 1000.0,
-                symbol: crate::finance::hyperliquid_swap_ccxt_symbol(market.as_str()),
+                symbol: hyperliquid_swap_ccxt_symbol(market.as_str()),
                 ticker: Symbol::from_raw(market.as_str()),
             }])
         }
@@ -398,7 +399,9 @@ mod tests {
             CREATE TABLE ingestion_runs
             (
                 id text NOT NULL,
-                status text NOT NULL CHECK (status IN ('running', 'completed', 'failed', 'cancelled')),
+                status text NOT NULL CHECK (
+                    status IN ('running', 'completed', 'failed', 'cancelled')
+                ),
                 started_at text NOT NULL,
                 finished_at text,
                 heartbeat_at text NOT NULL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,8 +286,10 @@ impl<'request> Responder<'request, 'static> for MarketsJson {
     ) -> rocket::response::Result<'static> {
         let max_age = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| markets_cache_max_age_seconds(duration.as_secs()))
-            .unwrap_or(market_metadata::MARKETS_REFRESH_INTERVAL.as_secs());
+            .map_or(
+                market_metadata::MARKETS_REFRESH_INTERVAL.as_secs(),
+                |duration| markets_cache_max_age_seconds(duration.as_secs()),
+            );
         Response::build_from(self.0.respond_to(request)?)
             .raw_header(
                 "Cache-Control",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use thiserror::Error;
 use tracing::{debug, error, info};
 use tracing_subscriber::EnvFilter;
 
+use crate::hyperliquid::Hyperliquid;
 use ingestion::{IngestionJob, IngestionRunError, IngestionServices, IngestionStatus};
 use timeframe::Timeframe;
 
@@ -169,6 +170,52 @@ async fn post_screener(
         }
         Err(err) => {
             error!(error = %err, "failed to screen perps");
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+struct MarketsJson(Json<market_metadata::MarketsApiResponse>);
+
+impl<'request> Responder<'request, 'static> for MarketsJson {
+    fn respond_to(
+        self,
+        request: &'request rocket::request::Request<'_>,
+    ) -> rocket::response::Result<'static> {
+        Response::build_from(self.0.respond_to(request)?)
+            .raw_header("Cache-Control", "public, max-age=86400")
+            .ok()
+    }
+}
+
+#[get("/hyperliquid/markets")]
+async fn get_hyperliquid_markets(
+    config: &State<Config>,
+    hyperliquid: &State<Arc<dyn Hyperliquid>>,
+) -> Result<MarketsJson, Status> {
+    match market_metadata::refresh_markets_if_stale(hyperliquid.as_ref(), &config.data_dir).await {
+        Ok(response) => Ok(MarketsJson(Json(response))),
+        Err(err) => {
+            error!(error = %err, "failed to load hyperliquid markets");
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+#[post("/hyperliquid/markets/refresh")]
+async fn post_hyperliquid_markets_refresh(
+    config: &State<Config>,
+    hyperliquid: &State<Arc<dyn Hyperliquid>>,
+) -> Result<MarketsJson, Status> {
+    match market_metadata::refresh_markets_and_load_api_response(
+        hyperliquid.as_ref(),
+        &config.data_dir,
+    )
+    .await
+    {
+        Ok(response) => Ok(MarketsJson(Json(response))),
+        Err(err) => {
+            error!(error = %err, "failed to refresh hyperliquid markets");
             Err(Status::InternalServerError)
         }
     }
@@ -434,8 +481,15 @@ pub async fn rocket(
         config.max_retries,
     )
     .await?;
+    let hyperliquid: Arc<dyn Hyperliquid> = Arc::new(hyperliquid_client);
+    if market_metadata::markets_need_refresh(&config.data_dir).await
+        && let Err(err) =
+            market_metadata::refresh_markets(hyperliquid.as_ref(), &config.data_dir).await
+    {
+        error!(error = %err, "failed to refresh markets metadata on startup");
+    }
     let services = Arc::new(IngestionServices {
-        hyperliquid: Arc::new(hyperliquid_client),
+        hyperliquid: Arc::clone(&hyperliquid),
         data_dir: config.data_dir.clone(),
         max_concurrent_requests: config.max_concurrent_requests,
     });
@@ -465,6 +519,7 @@ pub async fn rocket(
         .manage(config)
         .manage(pool)
         .manage(job_queue)
+        .manage(hyperliquid)
         .mount(
             "/",
             routes![
@@ -476,7 +531,9 @@ pub async fn rocket(
                 get_ingestion_status,
                 post_beta,
                 post_portfolio_readonly_btc,
-                post_portfolio_exposure
+                post_portfolio_exposure,
+                get_hyperliquid_markets,
+                post_hyperliquid_markets_refresh
             ],
         ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,12 @@ use apalis::prelude::{Monitor, Storage, WorkerBuilder, WorkerFactoryFn};
 use apalis_sql::sqlite::SqliteStorage;
 use rocket::config::Config as RocketConfig;
 use rocket::http::Status;
-use rocket::request::FromParam;
+use rocket::request::{FromParam, FromRequest, Outcome};
 use rocket::response::content::RawJson;
 use rocket::response::status::Custom;
 use rocket::response::{Responder, Response};
 use rocket::serde::json::Json;
-use rocket::{Rocket, State, get, post, routes};
+use rocket::{Request, Rocket, State, get, post, routes};
 use serde::Deserialize;
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
@@ -32,7 +32,7 @@ use thiserror::Error;
 use tracing::{debug, error, info};
 use tracing_subscriber::EnvFilter;
 
-use crate::hyperliquid::Hyperliquid;
+use crate::hyperliquid::HyperliquidClients;
 use ingestion::{IngestionJob, IngestionRunError, IngestionServices, IngestionStatus};
 use timeframe::Timeframe;
 
@@ -75,6 +75,7 @@ pub struct Config {
     log_level: LogLevel,
     max_concurrent_requests: usize,
     max_retries: usize,
+    markets_refresh_token: String,
 }
 
 impl Config {
@@ -177,26 +178,53 @@ async fn post_screener(
 
 struct MarketsJson(Json<market_metadata::MarketsApiResponse>);
 
+/// Seconds until the next UTC midnight, for `Cache-Control: max-age`.
+///
+/// Markets refresh on a daily midnight schedule; bounding shared-cache TTL to
+/// the next midnight keeps GET responses from outliving the ledger refresh.
+fn markets_cache_max_age_seconds(unix_now: u64) -> u64 {
+    const SECONDS_PER_DAY: u64 = 86_400;
+    let seconds_into_day = unix_now % SECONDS_PER_DAY;
+    (SECONDS_PER_DAY - seconds_into_day).max(1)
+}
+
 impl<'request> Responder<'request, 'static> for MarketsJson {
     fn respond_to(
         self,
         request: &'request rocket::request::Request<'_>,
     ) -> rocket::response::Result<'static> {
+        let max_age = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| markets_cache_max_age_seconds(duration.as_secs()))
+            .unwrap_or(market_metadata::MARKETS_REFRESH_INTERVAL.as_secs());
         Response::build_from(self.0.respond_to(request)?)
-            .raw_header("Cache-Control", "public, max-age=86400")
+            .raw_header(
+                "Cache-Control",
+                format!("private, max-age={max_age}, must-revalidate"),
+            )
             .ok()
     }
 }
 
-#[get("/hyperliquid/markets")]
+#[get("/hyperliquid/markets?<network>")]
 async fn get_hyperliquid_markets(
+    network: Option<&str>,
     config: &State<Config>,
-    hyperliquid: &State<Arc<dyn Hyperliquid>>,
+    hyperliquid_clients: &State<HyperliquidClients>,
 ) -> Result<MarketsJson, Status> {
-    match market_metadata::refresh_markets_if_stale(hyperliquid.as_ref(), &config.data_dir).await {
+    let ledger = network
+        .and_then(market_metadata::MarketsLedger::parse_query)
+        .unwrap_or(market_metadata::MarketsLedger::Mainnet);
+    match market_metadata::refresh_markets_if_stale(
+        hyperliquid_clients.for_ledger(ledger),
+        &config.data_dir,
+        ledger,
+    )
+    .await
+    {
         Ok(response) => Ok(MarketsJson(Json(response))),
         Err(err) => {
-            error!(error = %err, "failed to load hyperliquid markets");
+            error!(error = %err, ?ledger, "failed to load hyperliquid markets");
             Err(Status::InternalServerError)
         }
     }
@@ -204,21 +232,72 @@ async fn get_hyperliquid_markets(
 
 #[post("/hyperliquid/markets/refresh")]
 async fn post_hyperliquid_markets_refresh(
+    _auth: AuthorizedMarketsRefresh,
     config: &State<Config>,
-    hyperliquid: &State<Arc<dyn Hyperliquid>>,
+    hyperliquid_clients: &State<HyperliquidClients>,
 ) -> Result<MarketsJson, Status> {
-    match market_metadata::refresh_markets_and_load_api_response(
-        hyperliquid.as_ref(),
-        &config.data_dir,
-    )
-    .await
+    match market_metadata::refresh_all_markets(hyperliquid_clients.inner(), &config.data_dir).await
     {
-        Ok(response) => Ok(MarketsJson(Json(response))),
+        Ok(()) => match market_metadata::load_markets_api_response(
+            &config.data_dir,
+            market_metadata::MarketsLedger::Mainnet,
+        )
+        .await
+        {
+            Ok(response) => Ok(MarketsJson(Json(response))),
+            Err(err) => {
+                error!(error = %err, "failed to load hyperliquid markets after refresh");
+                Err(Status::InternalServerError)
+            }
+        },
         Err(err) => {
             error!(error = %err, "failed to refresh hyperliquid markets");
             Err(Status::InternalServerError)
         }
     }
+}
+
+struct AuthorizedMarketsRefresh;
+
+#[rocket::async_trait]
+impl<'request> FromRequest<'request> for AuthorizedMarketsRefresh {
+    type Error = Status;
+
+    async fn from_request(request: &'request Request<'_>) -> Outcome<Self, Self::Error> {
+        let Some(config) = request.rocket().state::<Config>() else {
+            return Outcome::Error((Status::InternalServerError, Status::InternalServerError));
+        };
+
+        match authorize_markets_refresh(request, config) {
+            Ok(()) => Outcome::Success(Self),
+            Err(status) => Outcome::Error((status, status)),
+        }
+    }
+}
+
+const MARKETS_REFRESH_TOKEN_HEADER: &str = "X-Markets-Refresh-Token";
+
+fn authorize_markets_refresh(request: &Request<'_>, config: &Config) -> Result<(), Status> {
+    let provided = request.headers().get_one(MARKETS_REFRESH_TOKEN_HEADER);
+    match provided {
+        None => Err(Status::Unauthorized),
+        Some(token) if markets_refresh_token_matches(token, &config.markets_refresh_token) => {
+            Ok(())
+        }
+        Some(_) => Err(Status::Forbidden),
+    }
+}
+
+fn markets_refresh_token_matches(provided: &str, expected: &str) -> bool {
+    if provided.len() != expected.len() {
+        return false;
+    }
+
+    provided
+        .bytes()
+        .zip(expected.bytes())
+        .fold(0_u8, |mismatch, (left, right)| mismatch | (left ^ right))
+        == 0
 }
 
 #[post("/ingest")]
@@ -476,20 +555,16 @@ pub async fn rocket(
     let job_queue = SqliteStorage::<IngestionJob>::new(pool.clone());
     ingestion::recover_abandoned_runs(&pool).await?;
 
-    let hyperliquid_client = hyperliquid::HyperliquidClient::new(
-        config.hyperliquid_base_url.as_ref(),
-        config.max_retries,
-    )
-    .await?;
-    let hyperliquid: Arc<dyn Hyperliquid> = Arc::new(hyperliquid_client);
-    if market_metadata::markets_need_refresh(&config.data_dir).await
-        && let Err(err) =
-            market_metadata::refresh_markets(hyperliquid.as_ref(), &config.data_dir).await
+    let hyperliquid_clients =
+        HyperliquidClients::from_config(config.hyperliquid_base_url.as_ref(), config.max_retries)
+            .await?;
+    if let Err(err) =
+        market_metadata::refresh_all_markets_if_stale(&hyperliquid_clients, &config.data_dir).await
     {
         error!(error = %err, "failed to refresh markets metadata on startup");
     }
     let services = Arc::new(IngestionServices {
-        hyperliquid: Arc::clone(&hyperliquid),
+        hyperliquid: Arc::clone(&hyperliquid_clients.mainnet),
         data_dir: config.data_dir.clone(),
         max_concurrent_requests: config.max_concurrent_requests,
     });
@@ -519,7 +594,7 @@ pub async fn rocket(
         .manage(config)
         .manage(pool)
         .manage(job_queue)
-        .manage(hyperliquid)
+        .manage(hyperliquid_clients)
         .mount(
             "/",
             routes![
@@ -578,6 +653,7 @@ mod tests {
             log_level: LogLevel::Info,
             max_concurrent_requests: 3,
             max_retries: 5,
+            markets_refresh_token: "test-markets-refresh-token".to_string(),
         };
         rocket::build().manage(config).mount(
             "/",
@@ -595,6 +671,7 @@ mod tests {
                 log_level = "info"
                 max_concurrent_requests = 3
                 max_retries = 5
+                markets_refresh_token = "test-markets-refresh-token"
             "#);
             let config: Config = toml::from_str(&toml).unwrap();
             prop_assert_eq!(config.port, port);
@@ -614,6 +691,27 @@ mod tests {
     fn config_load_returns_error_for_missing_file() {
         let result = Config::load("/nonexistent/path.toml");
         assert!(matches!(result, Err(ConfigError::Io(_))));
+    }
+
+    #[test]
+    fn markets_refresh_token_matches_expected_value() {
+        assert!(markets_refresh_token_matches(
+            "test-markets-refresh-token",
+            "test-markets-refresh-token"
+        ));
+        assert!(!markets_refresh_token_matches(
+            "wrong-markets-refresh-token",
+            "test-markets-refresh-token"
+        ));
+    }
+
+    #[test]
+    fn markets_cache_max_age_seconds_reaches_next_utc_midnight() {
+        const SECONDS_PER_DAY: u64 = 86_400;
+        let noon_utc = 12 * 60 * 60;
+        assert_eq!(markets_cache_max_age_seconds(noon_utc), 12 * 60 * 60);
+        assert_eq!(markets_cache_max_age_seconds(SECONDS_PER_DAY - 1), 1);
+        assert_eq!(markets_cache_max_age_seconds(0), SECONDS_PER_DAY);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,16 +96,15 @@ struct ConfigSource {
 
 impl ConfigSource {
     fn into_config(self, publish_path: Option<&Path>) -> Result<Config, ConfigError> {
-        let markets_refresh_token = match self.markets_refresh_token {
-            Some(token) => token,
-            None => {
-                let publish_path =
-                    publish_path.ok_or(ConfigError::MissingMarketsRefreshTokenPublishPath)?;
-                let token = generate_markets_refresh_token()?;
-                publish_markets_refresh_token(publish_path, &token)?;
-                debug!(path = %publish_path.display(), "markets refresh token published");
-                token
-            }
+        let markets_refresh_token = if let Some(token) = self.markets_refresh_token {
+            token
+        } else {
+            let publish_path =
+                publish_path.ok_or(ConfigError::MissingMarketsRefreshTokenPublishPath)?;
+            let token = generate_markets_refresh_token()?;
+            publish_markets_refresh_token(publish_path, &token)?;
+            debug!(path = %publish_path.display(), "markets refresh token published");
+            token
         };
 
         Ok(Config {
@@ -301,10 +300,9 @@ impl<'request> Responder<'request, 'static> for MarketsJson {
 fn markets_ledger_from_query(
     network: Option<&str>,
 ) -> Result<market_metadata::MarketsLedger, Status> {
-    match network {
-        None => Ok(market_metadata::MarketsLedger::Mainnet),
-        Some(value) => market_metadata::MarketsLedger::parse_query(value).ok_or(Status::BadRequest),
-    }
+    network.map_or(Ok(market_metadata::MarketsLedger::Mainnet), |value| {
+        market_metadata::MarketsLedger::parse_query(value).ok_or(Status::BadRequest)
+    })
 }
 
 #[get("/hyperliquid/markets?<network>")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ mod readonly_portfolio;
 mod screener;
 mod timeframe;
 
+use std::fmt::Write as FmtWrite;
+use std::io::Write;
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -29,7 +31,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
 use thiserror::Error;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use crate::hyperliquid::HyperliquidClients;
@@ -72,22 +74,106 @@ pub struct Config {
     data_dir: PathBuf,
     database_url: String,
     hyperliquid_base_url: Option<url::Url>,
+    hyperliquid_testnet_base_url: Option<url::Url>,
     log_level: LogLevel,
     max_concurrent_requests: usize,
     max_retries: usize,
     markets_refresh_token: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ConfigSource {
+    port: u16,
+    data_dir: PathBuf,
+    database_url: String,
+    hyperliquid_base_url: Option<url::Url>,
+    hyperliquid_testnet_base_url: Option<url::Url>,
+    log_level: LogLevel,
+    max_concurrent_requests: usize,
+    max_retries: usize,
+    markets_refresh_token: Option<String>,
+}
+
+impl ConfigSource {
+    fn into_config(self, publish_path: Option<&Path>) -> Result<Config, ConfigError> {
+        let markets_refresh_token = match self.markets_refresh_token {
+            Some(token) => token,
+            None => {
+                let publish_path =
+                    publish_path.ok_or(ConfigError::MissingMarketsRefreshTokenPublishPath)?;
+                let token = generate_markets_refresh_token()?;
+                publish_markets_refresh_token(publish_path, &token)?;
+                debug!(path = %publish_path.display(), "markets refresh token published");
+                token
+            }
+        };
+
+        Ok(Config {
+            port: self.port,
+            data_dir: self.data_dir,
+            database_url: self.database_url,
+            hyperliquid_base_url: self.hyperliquid_base_url,
+            hyperliquid_testnet_base_url: self.hyperliquid_testnet_base_url,
+            log_level: self.log_level,
+            max_concurrent_requests: self.max_concurrent_requests,
+            max_retries: self.max_retries,
+            markets_refresh_token,
+        })
+    }
+}
+
+fn generate_markets_refresh_token() -> Result<String, ConfigError> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes).map_err(ConfigError::Getrandom)?;
+
+    Ok(bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut token, byte| {
+            let _ = FmtWrite::write_fmt(&mut token, format_args!("{byte:02x}"));
+            token
+        }))
+}
+
+fn publish_markets_refresh_token(path: &Path, token: &str) -> Result<(), ConfigError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = path.with_extension("tmp");
+    {
+        #[cfg(unix)]
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = {
+            let mut open_options = std::fs::OpenOptions::new();
+            open_options.write(true).create(true).truncate(true);
+            #[cfg(unix)]
+            open_options.mode(0o640);
+            open_options.open(&temp_path)?
+        };
+        file.write_all(token.as_bytes())?;
+        file.write_all(b"\n")?;
+    }
+    std::fs::rename(&temp_path, path)?;
+
+    Ok(())
+}
+
 impl Config {
     /// Load configuration from a TOML file on disk.
     ///
+    /// When `markets_refresh_token` is omitted, `publish_path` must be set so a
+    /// fresh token can be generated and written for the local refresh timer.
+    ///
     /// # Errors
     ///
-    /// Returns [`ConfigError::Io`] if the file cannot be read, or
-    /// [`ConfigError::Toml`] if the contents are not valid TOML for [`Config`].
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+    /// Returns [`ConfigError::Io`] if the file cannot be read,
+    /// [`ConfigError::Toml`] if the contents are not valid TOML, or other
+    /// [`ConfigError`] variants when markets refresh token settings are invalid.
+    pub fn load<P: AsRef<Path>>(path: P, publish_path: Option<&Path>) -> Result<Self, ConfigError> {
         let content = std::fs::read_to_string(path.as_ref())?;
-        Ok(toml::from_str(&content)?)
+        let source: ConfigSource = toml::from_str(&content)?;
+        source.into_config(publish_path)
     }
 }
 
@@ -97,6 +183,12 @@ pub enum ConfigError {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Toml(#[from] toml::de::Error),
+    #[error(transparent)]
+    Getrandom(#[from] getrandom::Error),
+    #[error(
+        "--markets-refresh-token-publish-path is required when markets_refresh_token is omitted"
+    )]
+    MissingMarketsRefreshTokenPublishPath,
 }
 
 type IngestionJobQueue = SqliteStorage<IngestionJob>;
@@ -206,15 +298,22 @@ impl<'request> Responder<'request, 'static> for MarketsJson {
     }
 }
 
+fn markets_ledger_from_query(
+    network: Option<&str>,
+) -> Result<market_metadata::MarketsLedger, Status> {
+    match network {
+        None => Ok(market_metadata::MarketsLedger::Mainnet),
+        Some(value) => market_metadata::MarketsLedger::parse_query(value).ok_or(Status::BadRequest),
+    }
+}
+
 #[get("/hyperliquid/markets?<network>")]
 async fn get_hyperliquid_markets(
     network: Option<&str>,
     config: &State<Config>,
     hyperliquid_clients: &State<HyperliquidClients>,
 ) -> Result<MarketsJson, Status> {
-    let ledger = network
-        .and_then(market_metadata::MarketsLedger::parse_query)
-        .unwrap_or(market_metadata::MarketsLedger::Mainnet);
+    let ledger = markets_ledger_from_query(network)?;
     match market_metadata::refresh_markets_if_stale(
         hyperliquid_clients.for_ledger(ledger),
         &config.data_dir,
@@ -224,7 +323,7 @@ async fn get_hyperliquid_markets(
     {
         Ok(response) => Ok(MarketsJson(Json(response))),
         Err(err) => {
-            error!(error = %err, ?ledger, "failed to load hyperliquid markets");
+            warn!(error = %err, ?ledger, "failed to load hyperliquid markets");
             Err(Status::InternalServerError)
         }
     }
@@ -246,12 +345,12 @@ async fn post_hyperliquid_markets_refresh(
         {
             Ok(response) => Ok(MarketsJson(Json(response))),
             Err(err) => {
-                error!(error = %err, "failed to load hyperliquid markets after refresh");
+                warn!(error = %err, "failed to load hyperliquid markets after refresh");
                 Err(Status::InternalServerError)
             }
         },
         Err(err) => {
-            error!(error = %err, "failed to refresh hyperliquid markets");
+            warn!(error = %err, "failed to refresh hyperliquid markets");
             Err(Status::InternalServerError)
         }
     }
@@ -555,13 +654,16 @@ pub async fn rocket(
     let job_queue = SqliteStorage::<IngestionJob>::new(pool.clone());
     ingestion::recover_abandoned_runs(&pool).await?;
 
-    let hyperliquid_clients =
-        HyperliquidClients::from_config(config.hyperliquid_base_url.as_ref(), config.max_retries)
-            .await?;
+    let hyperliquid_clients = HyperliquidClients::from_config(
+        config.hyperliquid_base_url.as_ref(),
+        config.hyperliquid_testnet_base_url.as_ref(),
+        config.max_retries,
+    )
+    .await?;
     if let Err(err) =
         market_metadata::refresh_all_markets_if_stale(&hyperliquid_clients, &config.data_dir).await
     {
-        error!(error = %err, "failed to refresh markets metadata on startup");
+        warn!(error = %err, "failed to refresh markets metadata on startup");
     }
     let services = Arc::new(IngestionServices {
         hyperliquid: Arc::clone(&hyperliquid_clients.mainnet),
@@ -650,6 +752,7 @@ mod tests {
             data_dir: data_dir.to_path_buf(),
             database_url: "sqlite::memory:".to_string(),
             hyperliquid_base_url: None,
+            hyperliquid_testnet_base_url: None,
             log_level: LogLevel::Info,
             max_concurrent_requests: 3,
             max_retries: 5,
@@ -689,20 +792,109 @@ mod tests {
 
     #[test]
     fn config_load_returns_error_for_missing_file() {
-        let result = Config::load("/nonexistent/path.toml");
+        let result = Config::load("/nonexistent/path.toml", None);
         assert!(matches!(result, Err(ConfigError::Io(_))));
     }
 
     #[test]
-    fn markets_refresh_token_matches_expected_value() {
+    fn config_load_generates_and_publishes_markets_refresh_token() {
+        let temp_dir = TempDir::new().unwrap();
+        let token_path = temp_dir.path().join("markets-refresh-token");
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+            port = 8000
+            data_dir = "data"
+            database_url = "sqlite::memory:"
+            log_level = "info"
+            max_concurrent_requests = 3
+            max_retries = 5
+            "#,
+        )
+        .unwrap();
+
+        let config = Config::load(&config_path, Some(&token_path)).unwrap();
+        let published = std::fs::read_to_string(&token_path).unwrap();
+        let published_token = published.trim();
+
+        assert_eq!(config.markets_refresh_token, published_token);
+        assert_eq!(published_token.len(), 64);
         assert!(markets_refresh_token_matches(
-            "test-markets-refresh-token",
-            "test-markets-refresh-token"
+            published_token,
+            &config.markets_refresh_token
         ));
-        assert!(!markets_refresh_token_matches(
-            "wrong-markets-refresh-token",
-            "test-markets-refresh-token"
+    }
+
+    #[test]
+    fn config_load_requires_publish_path_without_inline_token() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+            port = 8000
+            data_dir = "data"
+            database_url = "sqlite::memory:"
+            log_level = "info"
+            max_concurrent_requests = 3
+            max_retries = 5
+            "#,
+        )
+        .unwrap();
+
+        let result = Config::load(&config_path, None);
+        assert!(matches!(
+            result,
+            Err(ConfigError::MissingMarketsRefreshTokenPublishPath)
         ));
+    }
+
+    #[test]
+    fn markets_refresh_token_matches_expected_value() {
+        assert!(
+            markets_refresh_token_matches(
+                "test-markets-refresh-token",
+                "test-markets-refresh-token"
+            ),
+            "identical refresh tokens should authorize"
+        );
+        assert!(
+            !markets_refresh_token_matches(
+                "wrong-markets-refresh-token",
+                "test-markets-refresh-token"
+            ),
+            "a different refresh token should be rejected"
+        );
+    }
+
+    #[test]
+    fn markets_ledger_from_query_defaults_to_mainnet_when_absent() {
+        assert_eq!(
+            markets_ledger_from_query(None).unwrap(),
+            market_metadata::MarketsLedger::Mainnet
+        );
+    }
+
+    #[test]
+    fn markets_ledger_from_query_parses_known_network_values() {
+        assert_eq!(
+            markets_ledger_from_query(Some("mainnet")).unwrap(),
+            market_metadata::MarketsLedger::Mainnet
+        );
+        assert_eq!(
+            markets_ledger_from_query(Some("testnet")).unwrap(),
+            market_metadata::MarketsLedger::Testnet
+        );
+    }
+
+    #[test]
+    fn markets_ledger_from_query_rejects_unknown_network_values() {
+        assert_eq!(
+            markets_ledger_from_query(Some("banana")),
+            Err(Status::BadRequest)
+        );
+        assert_eq!(markets_ledger_from_query(Some("")), Err(Status::BadRequest));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,22 @@
 use clap::Parser;
 use moneymentum::{Config, rocket};
+use std::path::PathBuf;
 
 #[derive(Parser)]
 struct Env {
     #[arg(long = "config", env)]
     config_path: String,
+    #[arg(long = "markets-refresh-token-publish-path")]
+    markets_refresh_token_publish_path: Option<PathBuf>,
 }
 
 #[rocket::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let env = Env::parse();
-    let config = Config::load(&env.config_path)?;
+    let config = Config::load(
+        &env.config_path,
+        env.markets_refresh_token_publish_path.as_deref(),
+    )?;
     rocket(config).await?.launch().await?;
     Ok(())
 }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -307,10 +307,7 @@ pub(crate) async fn refresh_all_markets_if_stale(
     }
     // Refresh each stale ledger independently so one ledger's outage does not
     // skip refreshing the others.
-    match last_error {
-        Some(error) => Err(error.into()),
-        None => Ok(()),
-    }
+    last_error.map_or_else(|| Ok(()), |error| Err(error.into()))
 }
 
 pub(crate) async fn refresh_all_markets(

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-use crate::finance::{self, Market};
+use crate::finance::{self, CcxtSymbol, Market};
 use crate::hyperliquid::{Hyperliquid, HyperliquidError};
 
 /// Markets metadata is refreshed at most once per day on the server.
@@ -48,7 +48,7 @@ pub(crate) enum MarketsMetadataError {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LeverageLimitEntry {
-    pub(crate) symbol: String,
+    pub(crate) symbol: CcxtSymbol,
     pub(crate) max_leverage: u32,
     pub(crate) asset_index: u32,
 }
@@ -56,7 +56,7 @@ pub(crate) struct LeverageLimitEntry {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct MarketsApiResponse {
-    pub(crate) tickers: Vec<String>,
+    pub(crate) tickers: Vec<CcxtSymbol>,
     pub(crate) leverage_limits: Vec<LeverageLimitEntry>,
     pub(crate) refreshed_at: Option<String>,
 }
@@ -586,14 +586,15 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            response.tickers,
-            vec!["BTC/USDC:USDC".to_string(), "ETH/USDC:USDC".to_string()]
+            response
+                .tickers
+                .iter()
+                .map(CcxtSymbol::as_str)
+                .collect::<Vec<_>>(),
+            vec!["BTC/USDC:USDC", "ETH/USDC:USDC"]
         );
         assert_eq!(response.leverage_limits.len(), 2);
-        assert_eq!(
-            response.leverage_limits[0].symbol,
-            "BTC/USDC:USDC".to_string()
-        );
+        assert_eq!(response.leverage_limits[0].symbol.as_str(), "BTC/USDC:USDC");
         assert_eq!(response.leverage_limits[0].max_leverage, 50);
         assert_eq!(response.leverage_limits[0].asset_index, 0);
         assert!(response.refreshed_at.is_some());
@@ -619,10 +620,17 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.tickers, vec!["KPEPE/USDC:USDC".to_string()]);
         assert_eq!(
-            response.leverage_limits[0].symbol,
-            "KPEPE/USDC:USDC".to_string()
+            response
+                .tickers
+                .iter()
+                .map(CcxtSymbol::as_str)
+                .collect::<Vec<_>>(),
+            vec!["KPEPE/USDC:USDC"]
+        );
+        assert_eq!(
+            response.leverage_limits[0].symbol.as_str(),
+            "KPEPE/USDC:USDC"
         );
     }
 
@@ -694,6 +702,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.tickers, vec!["FLX-CRCL/USDC:USDC".to_string()]);
+        assert_eq!(
+            response
+                .tickers
+                .iter()
+                .map(CcxtSymbol::as_str)
+                .collect::<Vec<_>>(),
+            vec!["FLX-CRCL/USDC:USDC"]
+        );
     }
 }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -1,18 +1,48 @@
-//! Markets metadata: the perp universe with each market's max leverage and a
-//! persisted `disable` flag, stored in `markets.csv`.
-//!
-//! The `disable` flag is operator-controlled (edited by hand) and preserved
-//! across refreshes; metadata like max leverage is refreshed from the exchange.
+//! Markets metadata: the perp universe with each market's max leverage,
+//! stored in `markets.csv` and refreshed from Hyperliquid.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
-use polars::prelude::{
-    DataFrame, IntoLazy, JoinArgs, JoinType, NamedFrom, PolarsError, Series, col, df, lit,
-};
+use polars::prelude::{DataFrame, PolarsError, df};
+use serde::Serialize;
+use thiserror::Error;
 use tracing::info;
 
-use crate::finance::Market;
+use crate::finance::{self, Market};
 use crate::hyperliquid::{Hyperliquid, HyperliquidError};
+
+/// Markets metadata is refreshed at most once per day on the server.
+pub(crate) const MARKETS_REFRESH_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug, Error)]
+pub(crate) enum MarketsMetadataError {
+    #[error(transparent)]
+    Hyperliquid(#[from] HyperliquidError),
+    #[error(transparent)]
+    DataFrame(#[from] crate::dataframe::DataFrameError),
+    #[error(transparent)]
+    Polars(#[from] PolarsError),
+    #[error("markets metadata file is missing")]
+    MissingFile,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LeverageLimitEntry {
+    pub(crate) symbol: String,
+    pub(crate) max_leverage: u32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MarketsApiResponse {
+    pub(crate) tickers: Vec<String>,
+    pub(crate) leverage_limits: Vec<LeverageLimitEntry>,
+    pub(crate) refreshed_at: Option<String>,
+}
 
 /// A market's exchange metadata as fetched from Hyperliquid.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,37 +56,118 @@ pub(crate) fn file_name() -> &'static str {
     "markets.csv"
 }
 
-/// Refreshes `markets.csv` from the live exchange and returns the tradable
-/// markets: every fetched market that is not disabled.
-///
-/// Market discovery is driven by the exchange fetch; the ledger only persists
-/// the operator-controlled `disable` flags. Ingestion consumes the returned
-/// list directly, so it never depends on re-reading the CSV.
+/// Refreshes `markets.csv` from the live exchange and returns the current
+/// perp universe. Ingestion consumes the returned list directly.
 pub(crate) async fn refresh_markets(
     client: &dyn Hyperliquid,
     data_dir: &Path,
 ) -> Result<Vec<Market>, HyperliquidError> {
     let fetched = client.fetch_market_metadata().await?;
     let path = data_dir.join(file_name());
-    let existing = crate::dataframe::read_csv(path.clone()).await?;
-    let frame = build_markets_frame(&fetched, existing.as_ref())?;
-    let tradable = tradable_from_frame(&frame)?;
+    let frame = build_markets_frame(&fetched)?;
+    let markets = markets_from_frame(&frame)?;
     crate::dataframe::write_csv(path, frame).await?;
-    info!(
-        markets = fetched.len(),
-        tradable = tradable.len(),
-        "markets metadata refreshed"
-    );
-    Ok(tradable)
+    info!(markets = markets.len(), "markets metadata refreshed");
+    Ok(markets)
 }
 
-/// The tradable markets in a freshly built ledger frame: every market whose
-/// `disable` flag is not set.
-fn tradable_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
+pub(crate) fn markets_file_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(file_name())
+}
+
+pub(crate) async fn markets_need_refresh(data_dir: &Path) -> bool {
+    let path = markets_file_path(data_dir);
+    let Ok(metadata) = tokio::fs::metadata(&path).await else {
+        return true;
+    };
+    let Ok(modified_at) = metadata.modified() else {
+        return true;
+    };
+    let age = SystemTime::now()
+        .duration_since(modified_at)
+        .unwrap_or(MARKETS_REFRESH_INTERVAL);
+    age >= MARKETS_REFRESH_INTERVAL
+}
+
+pub(crate) async fn load_markets_api_response(
+    data_dir: &Path,
+) -> Result<MarketsApiResponse, MarketsMetadataError> {
+    let path = markets_file_path(data_dir);
+    let frame = crate::dataframe::read_csv(path.clone())
+        .await?
+        .ok_or(MarketsMetadataError::MissingFile)?;
+    let refreshed_at = file_modified_at_rfc3339(&path).await?;
+    markets_api_response_from_frame(&frame, refreshed_at)
+}
+
+fn markets_api_response_from_frame(
+    frame: &DataFrame,
+    refreshed_at: Option<String>,
+) -> Result<MarketsApiResponse, MarketsMetadataError> {
     let symbols = frame.column("symbol")?.str()?;
-    let disable = frame.column("disable")?.bool()?;
+    let max_leverages = frame.column("max_leverage")?.i64()?;
+
+    let mut tickers = Vec::new();
+    let mut leverage_limits = Vec::new();
+
+    for index in 0..symbols.len() {
+        let Some(symbol) = symbols.get(index) else {
+            continue;
+        };
+        let ccxt_symbol = finance::hyperliquid_swap_ccxt_symbol(symbol);
+        let raw_max_leverage = max_leverages.get(index).unwrap_or(1);
+        let max_leverage = u32::try_from(raw_max_leverage).map_err(|_| {
+            MarketsMetadataError::Polars(PolarsError::ComputeError(
+                "max_leverage out of range".into(),
+            ))
+        })?;
+        tickers.push(ccxt_symbol.clone());
+        leverage_limits.push(LeverageLimitEntry {
+            symbol: ccxt_symbol,
+            max_leverage,
+        });
+    }
+
+    tickers.sort_unstable();
+    leverage_limits.sort_unstable_by(|left, right| left.symbol.cmp(&right.symbol));
+
+    Ok(MarketsApiResponse {
+        tickers,
+        leverage_limits,
+        refreshed_at,
+    })
+}
+
+async fn file_modified_at_rfc3339(path: &Path) -> Result<Option<String>, MarketsMetadataError> {
+    let metadata = tokio::fs::metadata(path).await?;
+    let modified_at = metadata.modified()?;
+    let timestamp = chrono::DateTime::<chrono::Utc>::from(modified_at);
+    Ok(Some(timestamp.to_rfc3339()))
+}
+
+/// Refreshes markets from Hyperliquid when stale, then returns the API payload.
+pub(crate) async fn refresh_markets_if_stale(
+    client: &dyn Hyperliquid,
+    data_dir: &Path,
+) -> Result<MarketsApiResponse, MarketsMetadataError> {
+    if markets_need_refresh(data_dir).await {
+        refresh_markets(client, data_dir).await?;
+    }
+    load_markets_api_response(data_dir).await
+}
+
+/// Refreshes markets from Hyperliquid unconditionally, then returns the API payload.
+pub(crate) async fn refresh_markets_and_load_api_response(
+    client: &dyn Hyperliquid,
+    data_dir: &Path,
+) -> Result<MarketsApiResponse, MarketsMetadataError> {
+    refresh_markets(client, data_dir).await?;
+    load_markets_api_response(data_dir).await
+}
+
+fn markets_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
+    let symbols = frame.column("symbol")?.str()?;
     let markets: Vec<Market> = (0..symbols.len())
-        .filter(|&index| disable.get(index) == Some(false))
         .filter_map(|index| {
             symbols
                 .get(index)
@@ -66,50 +177,16 @@ fn tradable_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
     Ok(markets)
 }
 
-/// Builds the markets ledger `DataFrame` (`symbol`, `max_leverage`, `disable`)
-/// from freshly fetched metadata, preserving the `disable` flag of any symbol
-/// already in `existing` and defaulting new symbols to enabled (`disable` false).
-fn build_markets_frame(
-    fetched: &[MarketMetadata],
-    existing: Option<&DataFrame>,
-) -> Result<DataFrame, PolarsError> {
+fn build_markets_frame(fetched: &[MarketMetadata]) -> Result<DataFrame, PolarsError> {
     let symbols: Vec<&str> = fetched
         .iter()
         .map(|market| market.symbol.as_str())
         .collect();
     let max_leverages: Vec<u32> = fetched.iter().map(|market| market.max_leverage).collect();
-    let fresh = df! {
+    df! {
         "symbol" => symbols,
         "max_leverage" => max_leverages,
-    }?;
-
-    let Some(existing) = existing else {
-        let mut fresh = fresh;
-        let disable = Series::new("disable".into(), vec![false; fresh.height()]);
-        fresh.with_column(disable)?;
-        return Ok(fresh);
-    };
-
-    let previous_flags = existing
-        .clone()
-        .lazy()
-        .select([col("symbol"), col("disable").alias("previous_disable")]);
-
-    fresh
-        .lazy()
-        .join(
-            previous_flags,
-            [col("symbol")],
-            [col("symbol")],
-            JoinArgs::new(JoinType::Left),
-        )
-        .with_column(
-            col("previous_disable")
-                .fill_null(lit(false))
-                .alias("disable"),
-        )
-        .select([col("symbol"), col("max_leverage"), col("disable")])
-        .collect()
+    }
 }
 
 #[cfg(test)]
@@ -160,65 +237,50 @@ mod tests {
         }
     }
 
-    fn disable_for(frame: &DataFrame, symbol: &str) -> Option<bool> {
-        let symbols = frame.column("symbol").unwrap().str().unwrap();
-        let disable = frame.column("disable").unwrap().bool().unwrap();
-        (0..symbols.len())
-            .find(|&index| symbols.get(index) == Some(symbol))
-            .and_then(|index| disable.get(index))
-    }
-
     #[test]
-    fn new_markets_default_to_enabled() {
+    fn build_markets_frame_writes_symbol_and_max_leverage() {
         let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
 
-        let frame = build_markets_frame(&fetched, None).unwrap();
+        let frame = build_markets_frame(&fetched).unwrap();
+
         assert_eq!(frame.height(), 2);
-        assert_eq!(disable_for(&frame, "BTC"), Some(false));
-        assert_eq!(disable_for(&frame, "ETH"), Some(false));
-    }
-
-    #[test]
-    fn refresh_preserves_disable_flag_and_drops_vanished_markets() {
-        let existing = df! {
-            "symbol" => &["BTC", "SOL"],
-            "max_leverage" => &[40_u32, 20],
-            "disable" => &[true, false],
-        }
-        .unwrap();
-        let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
-
-        let frame = build_markets_frame(&fetched, Some(&existing)).unwrap();
-
-        // BTC keeps its operator-set disable flag; ETH is new (enabled); SOL
-        // vanished from the exchange and is dropped.
-        assert_eq!(frame.height(), 2);
-        assert_eq!(disable_for(&frame, "BTC"), Some(true));
-        assert_eq!(disable_for(&frame, "ETH"), Some(false));
-        assert_eq!(disable_for(&frame, "SOL"), None);
-
-        // max leverage is refreshed from the fetched metadata.
+        assert_eq!(frame.get_column_names(), ["symbol", "max_leverage"]);
         let symbols = frame.column("symbol").unwrap().str().unwrap();
         let leverage = frame.column("max_leverage").unwrap().u32().unwrap();
-        let btc_index = (0..symbols.len())
-            .find(|&index| symbols.get(index) == Some("BTC"))
-            .unwrap();
-        assert_eq!(leverage.get(btc_index), Some(50));
+        assert_eq!(symbols.get(0), Some("BTC"));
+        assert_eq!(symbols.get(1), Some("ETH"));
+        assert_eq!(leverage.get(0), Some(50));
+        assert_eq!(leverage.get(1), Some(25));
+    }
+
+    #[test]
+    fn markets_from_frame_maps_all_rows() {
+        let frame = df! {
+            "symbol" => &["BTC", "ETH"],
+            "max_leverage" => &[50_u32, 25],
+        }
+        .unwrap();
+
+        let markets = markets_from_frame(&frame).unwrap();
+
+        assert_eq!(
+            markets.iter().map(Market::as_str).collect::<Vec<_>>(),
+            vec!["BTC", "ETH"]
+        );
     }
 
     #[traced_test]
     #[tokio::test]
-    async fn refresh_writes_markets_csv_and_preserves_disable_across_runs() {
+    async fn refresh_writes_markets_csv_from_exchange() {
         let data_dir = TempDir::new().unwrap();
         let client = StubClient {
             metadata: vec![metadata("BTC", 50), metadata("ETH", 25)],
         };
 
-        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
+        let markets = refresh_markets(&client, data_dir.path()).await.unwrap();
         assert_eq!(
-            tradable.len(),
-            2,
-            "both markets are tradable on first refresh"
+            markets.iter().map(Market::as_str).collect::<Vec<_>>(),
+            vec!["BTC", "ETH"]
         );
         assert!(data_dir.path().join("markets.csv").exists());
         assert!(crate::logs_contain_at(
@@ -226,67 +288,26 @@ mod tests {
             &["markets metadata refreshed"]
         ));
 
-        // Operator disables BTC by editing the ledger, then a later refresh keeps it.
-        let path = data_dir.path().join(file_name());
-        let edited = crate::dataframe::read_csv(path.clone())
-            .await
-            .unwrap()
-            .unwrap()
-            .lazy()
-            .with_column(col("symbol").eq(lit("BTC")).alias("disable"))
-            .collect()
-            .unwrap();
-        crate::dataframe::write_csv(path, edited).await.unwrap();
-
-        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
-        assert_eq!(
-            tradable.iter().map(Market::as_str).collect::<Vec<_>>(),
-            vec!["ETH"],
-            "BTC is excluded from the tradable set once disabled"
-        );
-
         let reloaded = crate::dataframe::read_csv(data_dir.path().join(file_name()))
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(disable_for(&reloaded, "BTC"), Some(true));
-        assert_eq!(disable_for(&reloaded, "ETH"), Some(false));
-    }
-
-    #[test]
-    fn tradable_from_frame_excludes_disabled_markets() {
-        let frame = df! {
-            "symbol" => &["BTC", "ETH", "SOL"],
-            "max_leverage" => &[50_u32, 25, 20],
-            "disable" => &[false, true, false],
-        }
-        .unwrap();
-
-        let markets = tradable_from_frame(&frame).unwrap();
-        let symbols: Vec<&str> = markets.iter().map(Market::as_str).collect();
-
-        assert_eq!(markets.len(), 2, "the disabled market is excluded");
-        assert!(symbols.contains(&"BTC"));
-        assert!(symbols.contains(&"SOL"));
-        assert!(!symbols.contains(&"ETH"), "ETH is disabled");
+        assert_eq!(reloaded.get_column_names(), ["symbol", "max_leverage"]);
     }
 
     #[traced_test]
     #[tokio::test]
     async fn refresh_discovers_markets_from_the_exchange_not_the_ledger() {
         let data_dir = TempDir::new().unwrap();
-        // The persisted ledger only knows BTC, which the operator disabled.
-        let existing = df! {
-            "symbol" => &["BTC"],
-            "max_leverage" => &[40_u32],
-            "disable" => &[true],
+        let stale_ledger = df! {
+            "symbol" => &["SOL"],
+            "max_leverage" => &[20_u32],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), existing)
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), stale_ledger)
             .await
             .unwrap();
 
-        // The exchange now lists BTC, ETH, and SOL.
         let client = StubClient {
             metadata: vec![
                 metadata("BTC", 50),
@@ -295,21 +316,81 @@ mod tests {
             ],
         };
 
-        let tradable = refresh_markets(&client, data_dir.path()).await.unwrap();
-        let symbols: Vec<&str> = tradable.iter().map(Market::as_str).collect();
+        let markets = refresh_markets(&client, data_dir.path()).await.unwrap();
+        let symbols: Vec<&str> = markets.iter().map(Market::as_str).collect();
 
-        // ETH and SOL are discovered from the live fetch even though the ledger
-        // never listed them; BTC stays excluded by its persisted disable flag.
-        assert_eq!(tradable.len(), 2, "newly listed markets are discovered");
+        assert_eq!(markets.len(), 3);
+        assert!(symbols.contains(&"BTC"));
         assert!(symbols.contains(&"ETH"));
         assert!(symbols.contains(&"SOL"));
-        assert!(
-            !symbols.contains(&"BTC"),
-            "operator-disabled BTC stays excluded"
-        );
         assert!(crate::logs_contain_at(
             Level::INFO,
             &["markets metadata refreshed"]
         ));
+    }
+
+    #[tokio::test]
+    async fn load_markets_api_response_returns_ccxt_symbols_and_leverage_limits() {
+        let data_dir = TempDir::new().unwrap();
+        let frame = df! {
+            "symbol" => &["ETH", "BTC"],
+            "max_leverage" => &[25_u32, 50],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
+            .await
+            .unwrap();
+
+        let response = load_markets_api_response(data_dir.path()).await.unwrap();
+
+        assert_eq!(
+            response.tickers,
+            vec!["BTC/USDC:USDC".to_string(), "ETH/USDC:USDC".to_string()]
+        );
+        assert_eq!(response.leverage_limits.len(), 2);
+        assert_eq!(
+            response.leverage_limits[0].symbol,
+            "BTC/USDC:USDC".to_string()
+        );
+        assert_eq!(response.leverage_limits[0].max_leverage, 50);
+        assert!(response.refreshed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn load_markets_api_response_uppercases_mixed_case_hyperliquid_names() {
+        let data_dir = TempDir::new().unwrap();
+        let frame = df! {
+            "symbol" => &["kPEPE"],
+            "max_leverage" => &[10_u32],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
+            .await
+            .unwrap();
+
+        let response = load_markets_api_response(data_dir.path()).await.unwrap();
+
+        assert_eq!(response.tickers, vec!["KPEPE/USDC:USDC".to_string()]);
+        assert_eq!(
+            response.leverage_limits[0].symbol,
+            "KPEPE/USDC:USDC".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn load_markets_api_response_formats_colon_names_like_ccxt() {
+        let data_dir = TempDir::new().unwrap();
+        let frame = df! {
+            "symbol" => &["flx:crcl"],
+            "max_leverage" => &[5_u32],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
+            .await
+            .unwrap();
+
+        let response = load_markets_api_response(data_dir.path()).await.unwrap();
+
+        assert_eq!(response.tickers, vec!["FLX-CRCL/USDC:USDC".to_string()]);
     }
 }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -4,7 +4,9 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use polars::prelude::{DataFrame, PolarsError, df};
+use polars::prelude::{
+    ChunkedArray, DataFrame, DataType, Int64Type, PolarsError, StringChunked, df,
+};
 use serde::Serialize;
 use thiserror::Error;
 use tracing::info;
@@ -34,6 +36,7 @@ pub(crate) enum MarketsMetadataError {
 pub(crate) struct LeverageLimitEntry {
     pub(crate) symbol: String,
     pub(crate) max_leverage: u32,
+    pub(crate) asset_index: u32,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -49,11 +52,36 @@ pub(crate) struct MarketsApiResponse {
 pub(crate) struct MarketMetadata {
     pub(crate) symbol: Market,
     pub(crate) max_leverage: u32,
+    pub(crate) asset_index: u32,
 }
 
-/// File name of the markets ledger inside the data directory.
+/// Hyperliquid deployment whose perp universe is stored in the data directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MarketsLedger {
+    Mainnet,
+    Testnet,
+}
+
+impl MarketsLedger {
+    pub(crate) fn file_name(self) -> &'static str {
+        match self {
+            Self::Mainnet => "markets.csv",
+            Self::Testnet => "testnet_markets.csv",
+        }
+    }
+
+    pub(crate) fn parse_query(value: &str) -> Option<Self> {
+        match value {
+            "mainnet" => Some(Self::Mainnet),
+            "testnet" => Some(Self::Testnet),
+            _ => None,
+        }
+    }
+}
+
+/// Mainnet markets ledger file name inside the data directory.
 pub(crate) fn file_name() -> &'static str {
-    "markets.csv"
+    MarketsLedger::Mainnet.file_name()
 }
 
 /// Refreshes `markets.csv` from the live exchange and returns the current
@@ -61,25 +89,43 @@ pub(crate) fn file_name() -> &'static str {
 pub(crate) async fn refresh_markets(
     client: &dyn Hyperliquid,
     data_dir: &Path,
+    ledger: MarketsLedger,
 ) -> Result<Vec<Market>, HyperliquidError> {
     let fetched = client.fetch_market_metadata().await?;
-    let path = data_dir.join(file_name());
+    let path = data_dir.join(ledger.file_name());
     let frame = build_markets_frame(&fetched)?;
     let markets = markets_from_frame(&frame)?;
     crate::dataframe::write_csv(path, frame).await?;
-    info!(markets = markets.len(), "markets metadata refreshed");
+    info!(
+        markets = markets.len(),
+        ledger = ?ledger,
+        "markets metadata refreshed"
+    );
     Ok(markets)
 }
 
-pub(crate) fn markets_file_path(data_dir: &Path) -> PathBuf {
-    data_dir.join(file_name())
+pub(crate) fn markets_file_path(data_dir: &Path, ledger: MarketsLedger) -> PathBuf {
+    data_dir.join(ledger.file_name())
 }
 
-pub(crate) async fn markets_need_refresh(data_dir: &Path) -> bool {
-    let path = markets_file_path(data_dir);
+pub(crate) async fn markets_need_refresh(data_dir: &Path, ledger: MarketsLedger) -> bool {
+    let path = markets_file_path(data_dir, ledger);
     let Ok(metadata) = tokio::fs::metadata(&path).await else {
         return true;
     };
+    let Ok(frame) = crate::dataframe::read_csv(path.clone()).await else {
+        return true;
+    };
+    let Some(frame) = frame else {
+        return true;
+    };
+    if !frame
+        .get_column_names()
+        .iter()
+        .any(|column| column.as_str() == "asset_index")
+    {
+        return true;
+    }
     let Ok(modified_at) = metadata.modified() else {
         return true;
     };
@@ -91,8 +137,9 @@ pub(crate) async fn markets_need_refresh(data_dir: &Path) -> bool {
 
 pub(crate) async fn load_markets_api_response(
     data_dir: &Path,
+    ledger: MarketsLedger,
 ) -> Result<MarketsApiResponse, MarketsMetadataError> {
-    let path = markets_file_path(data_dir);
+    let path = markets_file_path(data_dir, ledger);
     let frame = crate::dataframe::read_csv(path.clone())
         .await?
         .ok_or(MarketsMetadataError::MissingFile)?;
@@ -100,31 +147,50 @@ pub(crate) async fn load_markets_api_response(
     markets_api_response_from_frame(&frame, refreshed_at)
 }
 
+fn max_leverage_column(frame: &DataFrame) -> Result<ChunkedArray<Int64Type>, PolarsError> {
+    frame
+        .column("max_leverage")?
+        .cast(&DataType::Int64)?
+        .i64()
+        .cloned()
+}
+
 fn markets_api_response_from_frame(
     frame: &DataFrame,
     refreshed_at: Option<String>,
 ) -> Result<MarketsApiResponse, MarketsMetadataError> {
     let symbols = frame.column("symbol")?.str()?;
-    let max_leverages = frame.column("max_leverage")?.i64()?;
+    let max_leverages = max_leverage_column(frame)?;
+    let asset_indices = asset_index_column(frame)?;
+    validate_ledger_columns(symbols, &max_leverages, &asset_indices)?;
 
-    let mut tickers = Vec::new();
-    let mut leverage_limits = Vec::new();
+    let mut tickers = Vec::with_capacity(symbols.len());
+    let mut leverage_limits = Vec::with_capacity(symbols.len());
 
     for index in 0..symbols.len() {
-        let Some(symbol) = symbols.get(index) else {
-            continue;
-        };
+        let (symbol, raw_max_leverage) =
+            ledger_symbol_and_max_leverage(index, symbols, &max_leverages)?;
+        let raw_asset_index = asset_indices.get(index).ok_or_else(|| {
+            MarketsMetadataError::Polars(PolarsError::ComputeError(
+                format!("markets ledger row {index} has null asset_index").into(),
+            ))
+        })?;
         let ccxt_symbol = finance::hyperliquid_swap_ccxt_symbol(symbol);
-        let raw_max_leverage = max_leverages.get(index).unwrap_or(1);
         let max_leverage = u32::try_from(raw_max_leverage).map_err(|_| {
             MarketsMetadataError::Polars(PolarsError::ComputeError(
-                "max_leverage out of range".into(),
+                format!("markets ledger row {index} max_leverage out of range").into(),
+            ))
+        })?;
+        let asset_index = u32::try_from(raw_asset_index).map_err(|_| {
+            MarketsMetadataError::Polars(PolarsError::ComputeError(
+                format!("markets ledger row {index} asset_index out of range").into(),
             ))
         })?;
         tickers.push(ccxt_symbol.clone());
         leverage_limits.push(LeverageLimitEntry {
             symbol: ccxt_symbol,
             max_leverage,
+            asset_index,
         });
     }
 
@@ -138,6 +204,48 @@ fn markets_api_response_from_frame(
     })
 }
 
+fn asset_index_column(frame: &DataFrame) -> Result<ChunkedArray<Int64Type>, PolarsError> {
+    frame
+        .column("asset_index")?
+        .cast(&DataType::Int64)?
+        .i64()
+        .cloned()
+}
+
+fn validate_ledger_columns(
+    symbols: &StringChunked,
+    max_leverages: &ChunkedArray<Int64Type>,
+    asset_indices: &ChunkedArray<Int64Type>,
+) -> Result<(), PolarsError> {
+    if symbols.len() != max_leverages.len() || symbols.len() != asset_indices.len() {
+        return Err(PolarsError::ComputeError(
+            "markets ledger symbol, max_leverage, and asset_index column lengths differ".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn ledger_symbol_and_max_leverage<'ledger>(
+    index: usize,
+    symbols: &'ledger StringChunked,
+    max_leverages: &ChunkedArray<Int64Type>,
+) -> Result<(&'ledger str, i64), PolarsError> {
+    let symbol = symbols.get(index).ok_or_else(|| {
+        PolarsError::ComputeError(format!("markets ledger row {index} has null symbol").into())
+    })?;
+    if symbol.is_empty() {
+        return Err(PolarsError::ComputeError(
+            format!("markets ledger row {index} has empty symbol").into(),
+        ));
+    }
+    let raw_max_leverage = max_leverages.get(index).ok_or_else(|| {
+        PolarsError::ComputeError(
+            format!("markets ledger row {index} has null max_leverage").into(),
+        )
+    })?;
+    Ok((symbol, raw_max_leverage))
+}
+
 async fn file_modified_at_rfc3339(path: &Path) -> Result<Option<String>, MarketsMetadataError> {
     let metadata = tokio::fs::metadata(path).await?;
     let modified_at = metadata.modified()?;
@@ -149,43 +257,81 @@ async fn file_modified_at_rfc3339(path: &Path) -> Result<Option<String>, Markets
 pub(crate) async fn refresh_markets_if_stale(
     client: &dyn Hyperliquid,
     data_dir: &Path,
+    ledger: MarketsLedger,
 ) -> Result<MarketsApiResponse, MarketsMetadataError> {
-    if markets_need_refresh(data_dir).await {
-        refresh_markets(client, data_dir).await?;
+    if markets_need_refresh(data_dir, ledger).await {
+        refresh_markets(client, data_dir, ledger).await?;
     }
-    load_markets_api_response(data_dir).await
+    load_markets_api_response(data_dir, ledger).await
 }
 
 /// Refreshes markets from Hyperliquid unconditionally, then returns the API payload.
 pub(crate) async fn refresh_markets_and_load_api_response(
     client: &dyn Hyperliquid,
     data_dir: &Path,
+    ledger: MarketsLedger,
 ) -> Result<MarketsApiResponse, MarketsMetadataError> {
-    refresh_markets(client, data_dir).await?;
-    load_markets_api_response(data_dir).await
+    refresh_markets(client, data_dir, ledger).await?;
+    load_markets_api_response(data_dir, ledger).await
+}
+
+pub(crate) async fn refresh_all_markets_if_stale(
+    clients: &crate::hyperliquid::HyperliquidClients,
+    data_dir: &Path,
+) -> Result<(), MarketsMetadataError> {
+    for ledger in [MarketsLedger::Mainnet, MarketsLedger::Testnet] {
+        if markets_need_refresh(data_dir, ledger).await {
+            refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn refresh_all_markets(
+    clients: &crate::hyperliquid::HyperliquidClients,
+    data_dir: &Path,
+) -> Result<(), MarketsMetadataError> {
+    for ledger in [MarketsLedger::Mainnet, MarketsLedger::Testnet] {
+        refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await?;
+    }
+    Ok(())
 }
 
 fn markets_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
     let symbols = frame.column("symbol")?.str()?;
-    let markets: Vec<Market> = (0..symbols.len())
-        .filter_map(|index| {
-            symbols
-                .get(index)
-                .map(|symbol| Market::new(symbol.to_string()))
+    let max_leverages = max_leverage_column(frame)?;
+    let asset_indices = asset_index_column(frame)?;
+    validate_ledger_columns(symbols, &max_leverages, &asset_indices)?;
+
+    (0..symbols.len())
+        .map(|index| {
+            let (symbol, _) = ledger_symbol_and_max_leverage(index, symbols, &max_leverages)?;
+            Ok(Market::new(symbol.to_string()))
         })
-        .collect();
-    Ok(markets)
+        .collect()
 }
 
 fn build_markets_frame(fetched: &[MarketMetadata]) -> Result<DataFrame, PolarsError> {
+    let mut seen_symbols = std::collections::HashSet::new();
+    for market in fetched {
+        let symbol = market.symbol.as_str();
+        if !seen_symbols.insert(symbol) {
+            return Err(PolarsError::ComputeError(
+                format!("duplicate market symbol in fetched metadata: {symbol}").into(),
+            ));
+        }
+    }
+
     let symbols: Vec<&str> = fetched
         .iter()
         .map(|market| market.symbol.as_str())
         .collect();
     let max_leverages: Vec<u32> = fetched.iter().map(|market| market.max_leverage).collect();
+    let asset_indices: Vec<u32> = fetched.iter().map(|market| market.asset_index).collect();
     df! {
         "symbol" => symbols,
         "max_leverage" => max_leverages,
+        "asset_index" => asset_indices,
     }
 }
 
@@ -202,10 +348,11 @@ mod tests {
     use crate::funding::FundingRate;
     use crate::timeframe::Timeframe;
 
-    fn metadata(symbol: &str, max_leverage: u32) -> MarketMetadata {
+    fn metadata(symbol: &str, max_leverage: u32, asset_index: u32) -> MarketMetadata {
         MarketMetadata {
             symbol: Market::new(symbol.to_string()),
             max_leverage,
+            asset_index,
         }
     }
 
@@ -239,12 +386,15 @@ mod tests {
 
     #[test]
     fn build_markets_frame_writes_symbol_and_max_leverage() {
-        let fetched = [metadata("BTC", 50), metadata("ETH", 25)];
+        let fetched = [metadata("BTC", 50, 0), metadata("ETH", 25, 1)];
 
         let frame = build_markets_frame(&fetched).unwrap();
 
         assert_eq!(frame.height(), 2);
-        assert_eq!(frame.get_column_names(), ["symbol", "max_leverage"]);
+        assert_eq!(
+            frame.get_column_names(),
+            ["symbol", "max_leverage", "asset_index"]
+        );
         let symbols = frame.column("symbol").unwrap().str().unwrap();
         let leverage = frame.column("max_leverage").unwrap().u32().unwrap();
         assert_eq!(symbols.get(0), Some("BTC"));
@@ -254,10 +404,24 @@ mod tests {
     }
 
     #[test]
+    fn build_markets_frame_rejects_duplicate_symbols() {
+        let fetched = [metadata("BTC", 50, 0), metadata("BTC", 25, 1)];
+
+        let error = build_markets_frame(&fetched).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate market symbol in fetched metadata: BTC")
+        );
+    }
+
+    #[test]
     fn markets_from_frame_maps_all_rows() {
         let frame = df! {
             "symbol" => &["BTC", "ETH"],
             "max_leverage" => &[50_u32, 25],
+            "asset_index" => &[0_u32, 1],
         }
         .unwrap();
 
@@ -274,10 +438,12 @@ mod tests {
     async fn refresh_writes_markets_csv_from_exchange() {
         let data_dir = TempDir::new().unwrap();
         let client = StubClient {
-            metadata: vec![metadata("BTC", 50), metadata("ETH", 25)],
+            metadata: vec![metadata("BTC", 50, 0), metadata("ETH", 25, 1)],
         };
 
-        let markets = refresh_markets(&client, data_dir.path()).await.unwrap();
+        let markets = refresh_markets(&client, data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap();
         assert_eq!(
             markets.iter().map(Market::as_str).collect::<Vec<_>>(),
             vec!["BTC", "ETH"]
@@ -292,7 +458,10 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reloaded.get_column_names(), ["symbol", "max_leverage"]);
+        assert_eq!(
+            reloaded.get_column_names(),
+            ["symbol", "max_leverage", "asset_index"]
+        );
     }
 
     #[traced_test]
@@ -302,6 +471,7 @@ mod tests {
         let stale_ledger = df! {
             "symbol" => &["SOL"],
             "max_leverage" => &[20_u32],
+            "asset_index" => &[0_u32],
         }
         .unwrap();
         crate::dataframe::write_csv(data_dir.path().join(file_name()), stale_ledger)
@@ -310,13 +480,15 @@ mod tests {
 
         let client = StubClient {
             metadata: vec![
-                metadata("BTC", 50),
-                metadata("ETH", 25),
-                metadata("SOL", 20),
+                metadata("BTC", 50, 0),
+                metadata("ETH", 25, 1),
+                metadata("SOL", 20, 2),
             ],
         };
 
-        let markets = refresh_markets(&client, data_dir.path()).await.unwrap();
+        let markets = refresh_markets(&client, data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap();
         let symbols: Vec<&str> = markets.iter().map(Market::as_str).collect();
 
         assert_eq!(markets.len(), 3);
@@ -335,13 +507,16 @@ mod tests {
         let frame = df! {
             "symbol" => &["ETH", "BTC"],
             "max_leverage" => &[25_u32, 50],
+            "asset_index" => &[1_u32, 0],
         }
         .unwrap();
         crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
             .await
             .unwrap();
 
-        let response = load_markets_api_response(data_dir.path()).await.unwrap();
+        let response = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap();
 
         assert_eq!(
             response.tickers,
@@ -353,6 +528,7 @@ mod tests {
             "BTC/USDC:USDC".to_string()
         );
         assert_eq!(response.leverage_limits[0].max_leverage, 50);
+        assert_eq!(response.leverage_limits[0].asset_index, 0);
         assert!(response.refreshed_at.is_some());
     }
 
@@ -362,13 +538,16 @@ mod tests {
         let frame = df! {
             "symbol" => &["kPEPE"],
             "max_leverage" => &[10_u32],
+            "asset_index" => &[0_u32],
         }
         .unwrap();
         crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
             .await
             .unwrap();
 
-        let response = load_markets_api_response(data_dir.path()).await.unwrap();
+        let response = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap();
 
         assert_eq!(response.tickers, vec!["KPEPE/USDC:USDC".to_string()]);
         assert_eq!(
@@ -378,18 +557,63 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_markets_api_response_formats_colon_names_like_ccxt() {
+    async fn load_markets_api_response_rejects_null_symbol_rows() {
         let data_dir = TempDir::new().unwrap();
         let frame = df! {
-            "symbol" => &["flx:crcl"],
-            "max_leverage" => &[5_u32],
+            "symbol" => &[Some("BTC"), None],
+            "max_leverage" => &[50_i64, 25],
+            "asset_index" => &[0_i64, 1],
         }
         .unwrap();
         crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
             .await
             .unwrap();
 
-        let response = load_markets_api_response(data_dir.path()).await.unwrap();
+        let error = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, MarketsMetadataError::Polars(_)));
+        assert!(error.to_string().contains("null symbol"));
+    }
+
+    #[tokio::test]
+    async fn load_markets_api_response_rejects_null_max_leverage_rows() {
+        let data_dir = TempDir::new().unwrap();
+        let frame = df! {
+            "symbol" => &["BTC", "ETH"],
+            "max_leverage" => &[Some(50_i64), None],
+            "asset_index" => &[0_i64, 1],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
+            .await
+            .unwrap();
+
+        let error = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, MarketsMetadataError::Polars(_)));
+        assert!(error.to_string().contains("null max_leverage"));
+    }
+
+    #[tokio::test]
+    async fn load_markets_api_response_formats_colon_names_like_ccxt() {
+        let data_dir = TempDir::new().unwrap();
+        let frame = df! {
+            "symbol" => &["flx:crcl"],
+            "max_leverage" => &[5_u32],
+            "asset_index" => &[0_u32],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
+            .await
+            .unwrap();
+
+        let response = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
+            .await
+            .unwrap();
 
         assert_eq!(response.tickers, vec!["FLX-CRCL/USDC:USDC".to_string()]);
     }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -9,13 +9,27 @@ use polars::prelude::{
 };
 use serde::Serialize;
 use thiserror::Error;
-use tracing::info;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
 
 use crate::finance::{self, Market};
 use crate::hyperliquid::{Hyperliquid, HyperliquidError};
 
 /// Markets metadata is refreshed at most once per day on the server.
 pub(crate) const MARKETS_REFRESH_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Serializes refreshes per ledger so concurrent requests cannot both pass the
+/// staleness check and double-fetch from Hyperliquid or race writes to the same
+/// CSV ledger.
+static MAINNET_REFRESH_LOCK: Mutex<()> = Mutex::const_new(());
+static TESTNET_REFRESH_LOCK: Mutex<()> = Mutex::const_new(());
+
+fn refresh_lock(ledger: MarketsLedger) -> &'static Mutex<()> {
+    match ledger {
+        MarketsLedger::Mainnet => &MAINNET_REFRESH_LOCK,
+        MarketsLedger::Testnet => &TESTNET_REFRESH_LOCK,
+    }
+}
 
 #[derive(Debug, Error)]
 pub(crate) enum MarketsMetadataError {
@@ -255,7 +269,20 @@ pub(crate) async fn refresh_markets_if_stale(
     ledger: MarketsLedger,
 ) -> Result<MarketsApiResponse, MarketsMetadataError> {
     if markets_need_refresh(data_dir, ledger).await {
-        refresh_markets(client, data_dir, ledger).await?;
+        let _guard = refresh_lock(ledger).lock().await;
+        // Re-check under the lock: a concurrent request may have refreshed this
+        // ledger while we waited, so we skip the redundant upstream fetch.
+        if markets_need_refresh(data_dir, ledger).await {
+            if let Err(error) = refresh_markets(client, data_dir, ledger).await {
+                // A stale-but-valid ledger on disk is strictly more useful than
+                // a 500 in a trading-critical path, so fall back to it when the
+                // upstream refresh fails. Only propagate if no ledger exists.
+                if !markets_file_path(data_dir, ledger).exists() {
+                    return Err(error.into());
+                }
+                warn!(%error, ?ledger, "markets refresh failed; serving stale ledger");
+            }
+        }
     }
     load_markets_api_response(data_dir, ledger).await
 }
@@ -266,7 +293,10 @@ pub(crate) async fn refresh_all_markets_if_stale(
 ) -> Result<(), MarketsMetadataError> {
     for ledger in [MarketsLedger::Mainnet, MarketsLedger::Testnet] {
         if markets_need_refresh(data_dir, ledger).await {
-            refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await?;
+            let _guard = refresh_lock(ledger).lock().await;
+            if markets_need_refresh(data_dir, ledger).await {
+                refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await?;
+            }
         }
     }
     Ok(())
@@ -276,10 +306,24 @@ pub(crate) async fn refresh_all_markets(
     clients: &crate::hyperliquid::HyperliquidClients,
     data_dir: &Path,
 ) -> Result<(), MarketsMetadataError> {
+    let mut any_succeeded = false;
+    let mut last_error = None;
     for ledger in [MarketsLedger::Mainnet, MarketsLedger::Testnet] {
-        refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await?;
+        let _guard = refresh_lock(ledger).lock().await;
+        match refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await {
+            Ok(_markets) => any_succeeded = true,
+            Err(error) => {
+                warn!(%error, ?ledger, "markets refresh failed for ledger");
+                last_error = Some(error);
+            }
+        }
     }
-    Ok(())
+    // Refresh each ledger independently so one ledger's outage does not abort
+    // the others; only fail when every ledger failed.
+    match last_error {
+        Some(error) if !any_succeeded => Err(error.into()),
+        _ => Ok(()),
+    }
 }
 
 fn markets_from_frame(frame: &DataFrame) -> Result<Vec<Market>, PolarsError> {
@@ -488,6 +532,30 @@ mod tests {
             Level::INFO,
             &["markets metadata refreshed"]
         ));
+    }
+
+    #[tokio::test]
+    async fn markets_need_refresh_when_ledger_lacks_asset_index_column() {
+        let data_dir = TempDir::new().unwrap();
+        // Pre-asset_index ledger schema: a refresh must rebuild it so the
+        // asset_index column the API response depends on gets populated.
+        let legacy_ledger = df! {
+            "symbol" => &["BTC"],
+            "max_leverage" => &[50_u32],
+            "disable" => &[false],
+        }
+        .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            legacy_ledger,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            markets_need_refresh(data_dir.path(), MarketsLedger::Mainnet).await,
+            "a ledger missing the asset_index column must be treated as stale"
+        );
     }
 
     #[tokio::test]

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -16,7 +16,7 @@ use crate::finance::{self, Market};
 use crate::hyperliquid::{Hyperliquid, HyperliquidError};
 
 /// Markets metadata is refreshed at most once per day on the server.
-pub(crate) const MARKETS_REFRESH_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+pub(crate) const MARKETS_REFRESH_INTERVAL: Duration = Duration::from_hours(24);
 
 /// Serializes refreshes per ledger so concurrent requests cannot both pass the
 /// staleness check and double-fetch from Hyperliquid or race writes to the same
@@ -272,16 +272,16 @@ pub(crate) async fn refresh_markets_if_stale(
         let _guard = refresh_lock(ledger).lock().await;
         // Re-check under the lock: a concurrent request may have refreshed this
         // ledger while we waited, so we skip the redundant upstream fetch.
-        if markets_need_refresh(data_dir, ledger).await {
-            if let Err(error) = refresh_markets(client, data_dir, ledger).await {
-                // A stale-but-valid ledger on disk is strictly more useful than
-                // a 500 in a trading-critical path, so fall back to it when the
-                // upstream refresh fails. Only propagate if no ledger exists.
-                if !markets_file_path(data_dir, ledger).exists() {
-                    return Err(error.into());
-                }
-                warn!(%error, ?ledger, "markets refresh failed; serving stale ledger");
+        if markets_need_refresh(data_dir, ledger).await
+            && let Err(error) = refresh_markets(client, data_dir, ledger).await
+        {
+            // A stale-but-valid ledger on disk is strictly more useful than a
+            // 500 in a trading-critical path, so fall back to it when the
+            // upstream refresh fails. Only propagate if no ledger exists.
+            if !markets_file_path(data_dir, ledger).exists() {
+                return Err(error.into());
             }
+            warn!(%error, ?ledger, "markets refresh failed; serving stale ledger");
         }
     }
     load_markets_api_response(data_dir, ledger).await
@@ -295,13 +295,12 @@ pub(crate) async fn refresh_all_markets_if_stale(
     for ledger in [MarketsLedger::Mainnet, MarketsLedger::Testnet] {
         if markets_need_refresh(data_dir, ledger).await {
             let _guard = refresh_lock(ledger).lock().await;
-            if markets_need_refresh(data_dir, ledger).await {
-                if let Err(error) =
+            if markets_need_refresh(data_dir, ledger).await
+                && let Err(error) =
                     refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await
-                {
-                    warn!(%error, ?ledger, "markets refresh failed for ledger");
-                    last_error = Some(error);
-                }
+            {
+                warn!(%error, ?ledger, "markets refresh failed for ledger");
+                last_error = Some(error);
             }
         }
     }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -79,11 +79,6 @@ impl MarketsLedger {
     }
 }
 
-/// Mainnet markets ledger file name inside the data directory.
-pub(crate) fn file_name() -> &'static str {
-    MarketsLedger::Mainnet.file_name()
-}
-
 /// Refreshes `markets.csv` from the live exchange and returns the current
 /// perp universe. Ingestion consumes the returned list directly.
 pub(crate) async fn refresh_markets(
@@ -262,16 +257,6 @@ pub(crate) async fn refresh_markets_if_stale(
     if markets_need_refresh(data_dir, ledger).await {
         refresh_markets(client, data_dir, ledger).await?;
     }
-    load_markets_api_response(data_dir, ledger).await
-}
-
-/// Refreshes markets from Hyperliquid unconditionally, then returns the API payload.
-pub(crate) async fn refresh_markets_and_load_api_response(
-    client: &dyn Hyperliquid,
-    data_dir: &Path,
-    ledger: MarketsLedger,
-) -> Result<MarketsApiResponse, MarketsMetadataError> {
-    refresh_markets(client, data_dir, ledger).await?;
     load_markets_api_response(data_dir, ledger).await
 }
 
@@ -454,10 +439,11 @@ mod tests {
             &["markets metadata refreshed"]
         ));
 
-        let reloaded = crate::dataframe::read_csv(data_dir.path().join(file_name()))
-            .await
-            .unwrap()
-            .unwrap();
+        let reloaded =
+            crate::dataframe::read_csv(data_dir.path().join(MarketsLedger::Mainnet.file_name()))
+                .await
+                .unwrap()
+                .unwrap();
         assert_eq!(
             reloaded.get_column_names(),
             ["symbol", "max_leverage", "asset_index"]
@@ -474,9 +460,12 @@ mod tests {
             "asset_index" => &[0_u32],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), stale_ledger)
-            .await
-            .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            stale_ledger,
+        )
+        .await
+        .unwrap();
 
         let client = StubClient {
             metadata: vec![
@@ -510,9 +499,12 @@ mod tests {
             "asset_index" => &[1_u32, 0],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
-            .await
-            .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            frame,
+        )
+        .await
+        .unwrap();
 
         let response = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
             .await
@@ -541,9 +533,12 @@ mod tests {
             "asset_index" => &[0_u32],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
-            .await
-            .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            frame,
+        )
+        .await
+        .unwrap();
 
         let response = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
             .await
@@ -565,9 +560,12 @@ mod tests {
             "asset_index" => &[0_i64, 1],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
-            .await
-            .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            frame,
+        )
+        .await
+        .unwrap();
 
         let error = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
             .await
@@ -586,9 +584,12 @@ mod tests {
             "asset_index" => &[0_i64, 1],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
-            .await
-            .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            frame,
+        )
+        .await
+        .unwrap();
 
         let error = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
             .await
@@ -607,9 +608,12 @@ mod tests {
             "asset_index" => &[0_u32],
         }
         .unwrap();
-        crate::dataframe::write_csv(data_dir.path().join(file_name()), frame)
-            .await
-            .unwrap();
+        crate::dataframe::write_csv(
+            data_dir.path().join(MarketsLedger::Mainnet.file_name()),
+            frame,
+        )
+        .await
+        .unwrap();
 
         let response = load_markets_api_response(data_dir.path(), MarketsLedger::Mainnet)
             .await

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -291,15 +291,26 @@ pub(crate) async fn refresh_all_markets_if_stale(
     clients: &crate::hyperliquid::HyperliquidClients,
     data_dir: &Path,
 ) -> Result<(), MarketsMetadataError> {
+    let mut last_error = None;
     for ledger in [MarketsLedger::Mainnet, MarketsLedger::Testnet] {
         if markets_need_refresh(data_dir, ledger).await {
             let _guard = refresh_lock(ledger).lock().await;
             if markets_need_refresh(data_dir, ledger).await {
-                refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await?;
+                if let Err(error) =
+                    refresh_markets(clients.for_ledger(ledger), data_dir, ledger).await
+                {
+                    warn!(%error, ?ledger, "markets refresh failed for ledger");
+                    last_error = Some(error);
+                }
             }
         }
     }
-    Ok(())
+    // Refresh each stale ledger independently so one ledger's outage does not
+    // skip refreshing the others.
+    match last_error {
+        Some(error) => Err(error.into()),
+        None => Ok(()),
+    }
 }
 
 pub(crate) async fn refresh_all_markets(

--- a/src/readonly_portfolio.rs
+++ b/src/readonly_portfolio.rs
@@ -367,7 +367,7 @@ pub(crate) async fn load_portfolio_exposure(
         for (entry, holding) in request
             .readonly_btc_entries
             .iter()
-            .zip(readonly_balances.holdings.into_iter())
+            .zip(readonly_balances.holdings)
         {
             merged_positions.push(ExposurePosition {
                 source: ExposureSource::BtcAddress,

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -69,6 +69,7 @@ async fn create_test_client(mock_server: &MockServer, data_dir: &TempDir) -> Cli
         data_dir = "{}"
         database_url = "sqlite://{}?mode=rwc"
         hyperliquid_base_url = "{}"
+        hyperliquid_testnet_base_url = "{}"
         log_level = "debug"
         max_concurrent_requests = 3
         max_retries = 2
@@ -76,6 +77,7 @@ async fn create_test_client(mock_server: &MockServer, data_dir: &TempDir) -> Cli
         "#,
         data_dir.path().display(),
         database_path.display(),
+        mock_server.uri(),
         mock_server.uri()
     );
     let config: Config = toml::from_str(&toml_str).unwrap();

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -72,6 +72,7 @@ async fn create_test_client(mock_server: &MockServer, data_dir: &TempDir) -> Cli
         log_level = "debug"
         max_concurrent_requests = 3
         max_retries = 2
+        markets_refresh_token = "test-markets-refresh-token"
         "#,
         data_dir.path().display(),
         database_path.display(),

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -221,3 +221,61 @@ async fn status_shows_running_after_restart_from_failed() {
         "status should transition to Running (or Completed) after restart from Failed"
     );
 }
+
+async fn info_request_count(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/info")
+        .count()
+}
+
+#[rocket::async_test]
+async fn get_hyperliquid_markets_serves_universe_with_cache_header() {
+    let mock_server = MockServer::start().await;
+    mount_meta_mock(&mock_server).await;
+
+    let data_dir = TempDir::new().unwrap();
+    let client = create_test_client(&mock_server, &data_dir).await;
+
+    let response = client.get("/hyperliquid/markets").dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let cache_control = response
+        .headers()
+        .get_one("Cache-Control")
+        .unwrap_or_default()
+        .to_owned();
+    let body = response.into_string().await.unwrap();
+    assert!(
+        body.contains("BTC"),
+        "markets response should list the BTC ticker: {body}"
+    );
+    assert!(
+        cache_control.contains("max-age"),
+        "markets response should carry a Cache-Control max-age header, got: {cache_control:?}"
+    );
+}
+
+#[rocket::async_test]
+async fn get_hyperliquid_markets_serves_fresh_ledger_without_refetching() {
+    let mock_server = MockServer::start().await;
+    mount_meta_mock(&mock_server).await;
+
+    let data_dir = TempDir::new().unwrap();
+    let client = create_test_client(&mock_server, &data_dir).await;
+
+    let first = client.get("/hyperliquid/markets").dispatch().await;
+    assert_eq!(first.status(), Status::Ok);
+    let after_first = info_request_count(&mock_server).await;
+
+    let second = client.get("/hyperliquid/markets").dispatch().await;
+    assert_eq!(second.status(), Status::Ok);
+    let after_second = info_request_count(&mock_server).await;
+
+    assert_eq!(
+        after_first, after_second,
+        "a second GET against a fresh ledger must not re-fetch from Hyperliquid"
+    );
+}


### PR DESCRIPTION
Перенес фетч маркетов с фронта на бэк.
Теперь не каждый пользователь мучительно грузит маркеты на своей машине, а у нас есть свежие маркеты за последние 24 часа на сервере и они быстренько с maxLeverage отдаются

И теперь маркеты автоматически в полночь обновляются прямо на сервере

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ledger-aware Hyperliquid markets support (mainnet/testnet) with a unified markets feed, authenticated refresh endpoint, and scheduled daily refresh.
  * Frontend now derives tickers and leverage limits from the shared markets feed.
  * Added a dev-server proxy for `/api/hyperliquid`.
* **Bug Fixes**
  * Improved swap symbol formatting and backend-driven CCXT markets hydration.
  * Network switching now updates query invalidation after applying the new network mode.
  * Updated the portfolio “screener symbols” table to react to live changes.
* **Tests**
  * Expanded integration and hook tests for refresh-token authorization, caching behavior, and backend-driven markets hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->