### PR TITLE
feat: serve per-market max leverage limits from the catalog

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,9 @@ Design: [adrs/0001](./adrs/0001-event-sorcery-persistence-foundation.md).
 - [ ] Enqueue the ingestion job atomically with the Started event --
       [#404](https://github.com/dataclique/moneymentum/issues/404) /
       [#406](https://github.com/dataclique/moneymentum/pull/406)
+- [ ] Serve per-market max leverage limits from the catalog --
+      [#379](https://github.com/dataclique/moneymentum/issues/379) /
+      [#380](https://github.com/dataclique/moneymentum/pull/380)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ Design: [adrs/0001](./adrs/0001-event-sorcery-persistence-foundation.md).
 - [ ] Enqueue the ingestion job atomically with the Started event --
       [#404](https://github.com/dataclique/moneymentum/issues/404) /
       [#406](https://github.com/dataclique/moneymentum/pull/406)
-- [ ] Serve per-market max leverage limits from the catalog --
+- [x] Serve per-market max leverage limits from the catalog --
       [#379](https://github.com/dataclique/moneymentum/issues/379) /
       [#380](https://github.com/dataclique/moneymentum/pull/380)
 

--- a/src/candle.rs
+++ b/src/candle.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tracing::{debug, instrument};
 
 use crate::dataframe::{self, DataFrameError};
-use crate::finance::Symbol;
+use crate::finance::{CcxtSymbol, Symbol};
 use crate::timeframe::Timeframe;
 
 #[derive(Debug, Error)]
@@ -33,10 +33,10 @@ pub(crate) struct Candle {
     pub(crate) low: f64,
     pub(crate) close: f64,
     pub(crate) volume: f64,
-    /// Full market identifier in CCXT format (e.g., "BTC/USDC:USDC")
-    pub(crate) symbol: String,
+    /// CCXT unified swap symbol (e.g., "BTC/USDC:USDC")
+    pub(crate) market: CcxtSymbol,
     /// Normalized base symbol (e.g., "BTC")
-    pub(crate) ticker: Symbol,
+    pub(crate) symbol: Symbol,
 }
 
 #[instrument(skip_all, fields(count = candles.len()))]
@@ -59,13 +59,13 @@ pub(crate) async fn candles_to_dataframe(candles: Vec<Candle>) -> Result<DataFra
         let lows: Vec<f64> = candles.iter().map(|candle| candle.low).collect();
         let closes: Vec<f64> = candles.iter().map(|candle| candle.close).collect();
         let volumes: Vec<f64> = candles.iter().map(|candle| candle.volume).collect();
+        let markets: Vec<&str> = candles
+            .iter()
+            .map(|candle| candle.market.as_str())
+            .collect();
         let symbols: Vec<&str> = candles
             .iter()
             .map(|candle| candle.symbol.as_str())
-            .collect();
-        let tickers: Vec<&str> = candles
-            .iter()
-            .map(|candle| candle.ticker.as_str())
             .collect();
 
         Ok(df! {
@@ -75,8 +75,9 @@ pub(crate) async fn candles_to_dataframe(candles: Vec<Candle>) -> Result<DataFra
             "low" => lows,
             "close" => closes,
             "volume" => volumes,
-            "symbol" => symbols,
-            "ticker" => tickers,
+            // Legacy column names: "symbol" holds the CCXT market id, "ticker" the base.
+            "symbol" => markets,
+            "ticker" => symbols,
         }?)
     })
     .await?
@@ -105,6 +106,7 @@ mod tests {
     use tracing::Level;
     use tracing_test::traced_test;
 
+    use crate::finance;
     use crate::logs_contain_at;
 
     fn sample_candles() -> Vec<Candle> {
@@ -116,8 +118,8 @@ mod tests {
                 low: 95.0,
                 close: 105.0,
                 volume: 1000.0,
-                symbol: "BTC/USDC:USDC".to_string(),
-                ticker: Symbol::from_raw("BTC"),
+                market: finance::hyperliquid_swap_ccxt_symbol("BTC"),
+                symbol: Symbol::from_raw("BTC"),
             },
             Candle {
                 timestamp: Utc.with_ymd_and_hms(2024, 1, 1, 1, 0, 0).unwrap(),
@@ -126,8 +128,8 @@ mod tests {
                 low: 100.0,
                 close: 110.0,
                 volume: 1500.0,
-                symbol: "BTC/USDC:USDC".to_string(),
-                ticker: Symbol::from_raw("BTC"),
+                market: finance::hyperliquid_swap_ccxt_symbol("BTC"),
+                symbol: Symbol::from_raw("BTC"),
             },
         ]
     }
@@ -147,8 +149,8 @@ mod tests {
                             low: 90.0,
                             close: 105.0,
                             volume: 1000.0,
-                            symbol: "BTC/USDC:USDC".to_string(),
-                            ticker: Symbol::from_raw("BTC"),
+                            market: finance::hyperliquid_swap_ccxt_symbol("BTC"),
+                            symbol: Symbol::from_raw("BTC"),
                         }
                     })
                     .collect();

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -66,10 +66,6 @@ impl CcxtSymbol {
     pub(crate) fn as_str(&self) -> &str {
         &self.0
     }
-
-    pub(crate) fn into_string(self) -> String {
-        self.0
-    }
 }
 
 impl std::fmt::Display for CcxtSymbol {

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -218,9 +218,8 @@ impl Hyperliquid for HyperliquidClient {
                     low,
                     close,
                     volume,
-                    // CCXT perpetual format: BASE/USDC:USDC
-                    symbol: finance::hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
-                    ticker: Symbol::from_raw(market.as_str()),
+                    market: finance::hyperliquid_swap_ccxt_symbol(market.as_str()),
+                    symbol: Symbol::from_raw(market.as_str()),
                 })
             })
             .collect();
@@ -489,8 +488,8 @@ mod tests {
                     low: 41000.0,
                     close: 42500.0,
                     volume: 1000.0,
-                    symbol: "BTC/USDC:USDC".to_string(),
-                    ticker: Symbol::from_raw("BTC"),
+                    market: finance::hyperliquid_swap_ccxt_symbol("BTC"),
+                    symbol: Symbol::from_raw("BTC"),
                 }],
                 funding_rates: vec![FundingRate {
                     timestamp: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -848,8 +848,8 @@ mod tests {
                 low: 95.0,
                 close: 102.0,
                 volume: 1000.0,
-                symbol: hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
-                ticker: Symbol::from_raw(market.as_str()),
+                market: hyperliquid_swap_ccxt_symbol(market.as_str()),
+                symbol: Symbol::from_raw(market.as_str()),
             }])
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -982,21 +982,27 @@ pub(crate) fn logs_contain_at(level: tracing::Level, snippets: &[&str]) -> bool 
 mod tests {
     use std::str::FromStr;
 
-    use super::*;
     use axum::body::Body;
     use axum::http::Request;
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
     use proptest::prelude::*;
     use tempfile::TempDir;
     use tower::ServiceExt;
     use tracing_test::traced_test;
 
-    use market_catalog::{CatalogMarket, MarketCatalogCommand};
+    use crate::market_catalog::{CatalogMarket, MarketCatalogCommand};
+
+    use super::*;
+
+    struct TestHarness {
+        router: Router,
+        market_catalog: Arc<Store<MarketCatalog>>,
+    }
 
     /// Builds the full production router backed by a temp-dir SQLite database, so
     /// tests exercise the real route wiring and shared state, not a hand-rolled
     /// subset.
-    async fn test_router(data_dir: &std::path::Path) -> Router {
+    async fn test_harness(data_dir: &std::path::Path) -> TestHarness {
         let config = Config {
             port: 0,
             data_dir: data_dir.to_path_buf(),
@@ -1029,7 +1035,7 @@ mod tests {
                 .build()
                 .await
                 .unwrap();
-        let (_market_catalog, market_catalog_projection) =
+        let (market_catalog, market_catalog_projection) =
             StoreBuilder::<MarketCatalog>::new(pool.clone())
                 .build()
                 .await
@@ -1040,7 +1046,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        build_router(Arc::new(AppState {
+        let router = build_router(Arc::new(AppState {
             config,
             database_pool: pool,
             portfolio_store,
@@ -1050,7 +1056,16 @@ mod tests {
             market_enablement,
             market_enablement_projection,
             market_catalog_projection,
-        }))
+        }));
+
+        TestHarness {
+            router,
+            market_catalog,
+        }
+    }
+
+    async fn test_router(data_dir: &std::path::Path) -> Router {
+        test_harness(data_dir).await.router
     }
 
     fn get_request(uri: &str) -> Request<Body> {
@@ -1164,50 +1179,11 @@ mod tests {
     #[tokio::test]
     async fn markets_leverage_serves_catalog_limits_and_rejects_unknown_venue() {
         let data_dir = TempDir::new().unwrap();
-        let config = Config {
-            port: 0,
-            data_dir: data_dir.path().to_path_buf(),
-            database_url: format!(
-                "sqlite://{}?mode=rwc",
-                data_dir.path().join("leverage-test.db").display()
-            ),
-            hyperliquid_base_url: None,
-            log_level: LogLevel::Info,
-            max_concurrent_requests: 3,
-            max_retries: 5,
-            ingestion_schedule: "0 0 * * * *".to_string(),
-            derive: None,
-        };
-        let database_options = SqliteConnectOptions::from_str(&config.database_url)
-            .unwrap()
-            .journal_mode(SqliteJournalMode::Wal)
-            .busy_timeout(std::time::Duration::from_secs(5));
-        let pool = SqlitePool::connect_with(database_options).await.unwrap();
-        sqlx::migrate!("./migrations")
-            .set_ignore_missing(true)
-            .run(&pool)
-            .await
-            .unwrap();
-
-        let (portfolio_store, portfolio_projection) = StoreBuilder::<Portfolio>::new(pool.clone())
-            .build()
-            .await
-            .unwrap();
-        let (ingestion_store, ingestion_projection) =
-            StoreBuilder::<IngestionRun>::new(pool.clone())
-                .build()
-                .await
-                .unwrap();
-        let (market_catalog, market_catalog_projection) =
-            StoreBuilder::<MarketCatalog>::new(pool.clone())
-                .build()
-                .await
-                .unwrap();
-        let (market_enablement, market_enablement_projection) =
-            StoreBuilder::<MarketEnablement>::new(pool.clone())
-                .build()
-                .await
-                .unwrap();
+        let TestHarness {
+            router,
+            market_catalog,
+        } = test_harness(data_dir.path()).await;
+        let observed_at = Utc.with_ymd_and_hms(2026, 3, 15, 12, 0, 0).unwrap();
 
         market_catalog
             .send(
@@ -1217,23 +1193,11 @@ mod tests {
                         CatalogMarket::new(Symbol::from_raw("BTC"), 50),
                         CatalogMarket::new(Symbol::from_raw("ETH"), 25),
                     ],
-                    observed_at: Utc::now(),
+                    observed_at,
                 },
             )
             .await
             .unwrap();
-
-        let router = build_router(Arc::new(AppState {
-            config,
-            database_pool: pool,
-            portfolio_store,
-            portfolio_projection,
-            ingestion_store,
-            ingestion_projection,
-            market_enablement,
-            market_enablement_projection,
-            market_catalog_projection,
-        }));
 
         let listed = router
             .clone()
@@ -1244,6 +1208,7 @@ mod tests {
         let body: market_metadata::LeverageLimits =
             serde_json::from_str(&body_text(listed).await).unwrap();
         assert_eq!(body.limits.len(), 2);
+        assert_eq!(body.fetched_at, observed_at);
         assert!(logs_contain_at(
             tracing::Level::DEBUG,
             &["leverage limits read", "markets=2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,9 @@ async fn post_screener(
 }
 
 async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
-    match ingestion::enqueue_run(&state.ingestion_store, &state.ingestion_projection).await {
+    // `create_run` enqueues the ingestion job atomically with the `Started`
+    // event so a concurrent loser cannot wedge the slot.
+    match ingestion::create_run(&state.ingestion_store, &state.ingestion_projection).await {
         Ok(_) => StatusCode::ACCEPTED,
         Err(IngestionError::AlreadyRunning) => StatusCode::CONFLICT,
         Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1183,6 +1183,14 @@ mod tests {
             router,
             market_catalog,
         } = test_harness(data_dir.path()).await;
+
+        let unobserved = router
+            .clone()
+            .oneshot(get_request("/markets/hyperliquid/leverage"))
+            .await
+            .unwrap();
+        assert_eq!(unobserved.status(), StatusCode::NOT_FOUND);
+
         let observed_at = Utc.with_ymd_and_hms(2026, 3, 15, 12, 0, 0).unwrap();
 
         market_catalog
@@ -1205,10 +1213,29 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(listed.status(), StatusCode::OK);
-        let body: market_metadata::LeverageLimits =
-            serde_json::from_str(&body_text(listed).await).unwrap();
+        let raw = body_text(listed).await;
+        let body: market_metadata::LeverageLimits = serde_json::from_str(&raw).unwrap();
         assert_eq!(body.limits.len(), 2);
         assert_eq!(body.fetched_at, observed_at);
+
+        let mut by_symbol: Vec<(&str, u32)> = body
+            .limits
+            .iter()
+            .map(|limit| (limit.symbol.as_str(), limit.max_leverage))
+            .collect();
+        by_symbol.sort_unstable();
+        assert_eq!(by_symbol, vec![("BTC", 50), ("ETH", 25)]);
+
+        let wire: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let btc = wire["limits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|limit| limit["symbol"] == "BTC")
+            .unwrap();
+        assert_eq!(btc["maxLeverage"], 50);
+        assert_eq!(wire["fetchedAt"], "2026-03-15T12:00:00Z");
+
         assert!(logs_contain_at(
             tracing::Level::DEBUG,
             &["leverage limits read", "markets=2"]
@@ -1219,6 +1246,68 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn markets_leverage_includes_disabled_markets() {
+        let data_dir = TempDir::new().unwrap();
+        let TestHarness {
+            router,
+            market_catalog,
+        } = test_harness(data_dir.path()).await;
+        let observed_at = Utc.with_ymd_and_hms(2026, 3, 15, 12, 0, 0).unwrap();
+
+        market_catalog
+            .send(
+                &VenueRef::Hyperliquid,
+                MarketCatalogCommand::RecordUniverse {
+                    markets: vec![
+                        CatalogMarket::new(Symbol::from_raw("BTC"), 50),
+                        CatalogMarket::new(Symbol::from_raw("ETH"), 25),
+                    ],
+                    observed_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        let disabled = router
+            .clone()
+            .oneshot(post_json(
+                "/markets/hyperliquid/BTC/disable",
+                &serde_json::json!({ "reason": "maintenance" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(disabled.status(), StatusCode::ACCEPTED);
+
+        let tradable = router
+            .clone()
+            .oneshot(get_request("/markets/hyperliquid"))
+            .await
+            .unwrap();
+        assert_eq!(tradable.status(), StatusCode::OK);
+        let tradable_symbols: Vec<String> = serde_json::from_str(&body_text(tradable).await).unwrap();
+        assert_eq!(tradable_symbols, vec!["ETH".to_string()]);
+
+        let leverage = router
+            .clone()
+            .oneshot(get_request("/markets/hyperliquid/leverage"))
+            .await
+            .unwrap();
+        assert_eq!(leverage.status(), StatusCode::OK);
+        let body: market_metadata::LeverageLimits =
+            serde_json::from_str(&body_text(leverage).await).unwrap();
+
+        let mut symbols: Vec<&str> = body
+            .limits
+            .iter()
+            .map(|limit| limit.symbol.as_str())
+            .collect();
+        symbols.sort_unstable();
+        assert_eq!(symbols, vec!["BTC", "ETH"]);
+        assert_eq!(body.fetched_at, observed_at);
     }
 
     #[traced_test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1288,7 +1288,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(tradable.status(), StatusCode::OK);
-        let tradable_symbols: Vec<String> = serde_json::from_str(&body_text(tradable).await).unwrap();
+        let tradable_symbols: Vec<String> =
+            serde_json::from_str(&body_text(tradable).await).unwrap();
         assert_eq!(tradable_symbols, vec!["ETH".to_string()]);
 
         let leverage = router

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,6 +666,23 @@ async fn get_markets(
     ))
 }
 
+/// Serves a venue's per-market max-leverage limits from the cached catalog so
+/// clients size leverage controls without each running a heavy all-market fetch.
+async fn get_markets_leverage(
+    State(state): State<Arc<AppState>>,
+    AxumPath(venue): AxumPath<String>,
+) -> Result<Json<market_metadata::LeverageLimits>, StatusCode> {
+    let venue = VenueRef::from_str(&venue).map_err(|_| StatusCode::NOT_FOUND)?;
+    match market_metadata::leverage_limits(venue, &state.market_catalog_projection).await {
+        Ok(Some(limits)) => Ok(Json(limits)),
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(err) => {
+            error!(error = %err, "failed to read leverage limits");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
 fn parse_market_id(venue: &str, symbol: &str) -> Result<MarketId, ApiError> {
     let venue = VenueRef::from_str(venue).map_err(|_| bad_request("unknown venue"))?;
     Ok(MarketId::new(venue, Symbol::from_raw(symbol)))
@@ -907,6 +924,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/portfolio/{id}/rename", post(post_portfolio_rename))
         .route("/portfolio/{id}/archive", post(post_portfolio_archive))
         .route("/markets/{venue}", get(get_markets))
+        .route("/markets/{venue}/leverage", get(get_markets_leverage))
         .route(
             "/markets/{venue}/{symbol}/disable",
             post(post_market_disable),
@@ -960,13 +978,18 @@ pub(crate) fn logs_contain_at(level: tracing::Level, snippets: &[&str]) -> bool 
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
+    use chrono::Utc;
     use proptest::prelude::*;
     use tempfile::TempDir;
     use tower::ServiceExt;
     use tracing_test::traced_test;
+
+    use market_catalog::{CatalogMarket, MarketCatalogCommand};
 
     /// Builds the full production router backed by a temp-dir SQLite database, so
     /// tests exercise the real route wiring and shared state, not a hand-rolled
@@ -1133,6 +1156,102 @@ mod tests {
         assert_eq!(bad_disable.status(), StatusCode::BAD_REQUEST);
         let bad_list = router.oneshot(get_request("/markets/bogus")).await.unwrap();
         assert_eq!(bad_list.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn markets_leverage_serves_catalog_limits_and_rejects_unknown_venue() {
+        let data_dir = TempDir::new().unwrap();
+        let config = Config {
+            port: 0,
+            data_dir: data_dir.path().to_path_buf(),
+            database_url: format!(
+                "sqlite://{}?mode=rwc",
+                data_dir.path().join("leverage-test.db").display()
+            ),
+            hyperliquid_base_url: None,
+            log_level: LogLevel::Info,
+            max_concurrent_requests: 3,
+            max_retries: 5,
+            ingestion_schedule: "0 0 * * * *".to_string(),
+            derive: None,
+        };
+        let database_options = SqliteConnectOptions::from_str(&config.database_url)
+            .unwrap()
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_secs(5));
+        let pool = SqlitePool::connect_with(database_options).await.unwrap();
+        sqlx::migrate!("./migrations")
+            .set_ignore_missing(true)
+            .run(&pool)
+            .await
+            .unwrap();
+
+        let (portfolio_store, portfolio_projection) = StoreBuilder::<Portfolio>::new(pool.clone())
+            .build()
+            .await
+            .unwrap();
+        let (ingestion_store, ingestion_projection) =
+            StoreBuilder::<IngestionRun>::new(pool.clone())
+                .build()
+                .await
+                .unwrap();
+        let (market_catalog, market_catalog_projection) =
+            StoreBuilder::<MarketCatalog>::new(pool.clone())
+                .build()
+                .await
+                .unwrap();
+        let (market_enablement, market_enablement_projection) =
+            StoreBuilder::<MarketEnablement>::new(pool.clone())
+                .build()
+                .await
+                .unwrap();
+
+        market_catalog
+            .send(
+                &VenueRef::Hyperliquid,
+                MarketCatalogCommand::RecordUniverse {
+                    markets: vec![
+                        CatalogMarket::new(Symbol::from_raw("BTC"), 50),
+                        CatalogMarket::new(Symbol::from_raw("ETH"), 25),
+                    ],
+                    observed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let router = build_router(Arc::new(AppState {
+            config,
+            database_pool: pool,
+            portfolio_store,
+            portfolio_projection,
+            ingestion_store,
+            ingestion_projection,
+            market_enablement,
+            market_enablement_projection,
+            market_catalog_projection,
+        }));
+
+        let listed = router
+            .clone()
+            .oneshot(get_request("/markets/hyperliquid/leverage"))
+            .await
+            .unwrap();
+        assert_eq!(listed.status(), StatusCode::OK);
+        let body: market_metadata::LeverageLimits =
+            serde_json::from_str(&body_text(listed).await).unwrap();
+        assert_eq!(body.limits.len(), 2);
+        assert!(logs_contain_at(
+            tracing::Level::DEBUG,
+            &["leverage limits read", "markets=2"]
+        ));
+
+        let unknown = router
+            .oneshot(get_request("/markets/bogus/leverage"))
+            .await
+            .unwrap();
+        assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
     }
 
     #[traced_test]

--- a/src/market_catalog.rs
+++ b/src/market_catalog.rs
@@ -35,17 +35,27 @@ impl CatalogMarket {
     pub(crate) fn symbol(&self) -> &Symbol {
         &self.symbol
     }
+
+    pub(crate) fn max_leverage(&self) -> u32 {
+        self.max_leverage
+    }
 }
 
 /// The exchange-listed universe of one venue, keyed by [`VenueRef`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MarketCatalog {
     markets: Vec<CatalogMarket>,
+    observed_at: DateTime<Utc>,
 }
 
 impl MarketCatalog {
     pub(crate) fn markets(&self) -> &[CatalogMarket] {
         &self.markets
+    }
+
+    /// When the venue universe behind this snapshot was last observed.
+    pub(crate) fn observed_at(&self) -> DateTime<Utc> {
+        self.observed_at
     }
 }
 
@@ -116,13 +126,17 @@ impl EventSourced for MarketCatalog {
 
     const AGGREGATE_TYPE: &'static str = "MarketCatalog";
     const PROJECTION: Table = Table("market_catalog_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
     const SNAPSHOT_SIZE: usize = 1;
 
     fn originate(event: &MarketCatalogEvent) -> Option<Self> {
-        let MarketCatalogEvent::VenueUniverseObserved { markets, .. } = event;
+        let MarketCatalogEvent::VenueUniverseObserved {
+            markets,
+            observed_at,
+        } = event;
         Some(Self {
             markets: markets.clone(),
+            observed_at: *observed_at,
         })
     }
 
@@ -130,9 +144,13 @@ impl EventSourced for MarketCatalog {
         _entity: &Self,
         event: &MarketCatalogEvent,
     ) -> Result<Option<Self>, MarketCatalogError> {
-        let MarketCatalogEvent::VenueUniverseObserved { markets, .. } = event;
+        let MarketCatalogEvent::VenueUniverseObserved {
+            markets,
+            observed_at,
+        } = event;
         Ok(Some(Self {
             markets: markets.clone(),
+            observed_at: *observed_at,
         }))
     }
 
@@ -218,6 +236,24 @@ mod tests {
             catalog.markets(),
             &[CatalogMarket::new(Symbol::from_raw("SOL"), 20)]
         );
+    }
+
+    #[test]
+    fn replay_exposes_the_latest_observation_time() {
+        let catalog = replay::<MarketCatalog>(vec![
+            MarketCatalogEvent::VenueUniverseObserved {
+                markets: vec![CatalogMarket::new(Symbol::from_raw("BTC"), 50)],
+                observed_at: observed_at(1),
+            },
+            MarketCatalogEvent::VenueUniverseObserved {
+                markets: vec![CatalogMarket::new(Symbol::from_raw("ETH"), 25)],
+                observed_at: observed_at(2),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(catalog.observed_at(), observed_at(2));
     }
 
     #[tokio::test]

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 
 use chrono::{DateTime, Utc};
 use event_sorcery::{Projection, ProjectionError, SendError, Store};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 use crate::finance::{Market, Symbol};
@@ -30,7 +30,7 @@ pub(crate) struct MarketMetadata {
 }
 
 /// One market's max leverage, as served to clients.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LeverageLimit {
     pub(crate) symbol: String,
@@ -39,7 +39,7 @@ pub(crate) struct LeverageLimit {
 
 /// A venue's per-market leverage limits plus the time the universe behind them
 /// was last observed, so clients can reason about freshness.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LeverageLimits {
     pub(crate) limits: Vec<LeverageLimit>,

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -165,9 +165,9 @@ mod tests {
     use event_sorcery::StoreBuilder;
 
     use super::*;
-    use crate::market_catalog::{CatalogMarket, MarketCatalogCommand};
     use crate::candle::Candle;
     use crate::funding::FundingRate;
+    use crate::market_catalog::{CatalogMarket, MarketCatalogCommand};
     use crate::market_enablement::MarketEnablementCommand;
     use crate::timeframe::Timeframe;
 

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -10,9 +10,10 @@
 
 use std::collections::BTreeSet;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use event_sorcery::{Projection, ProjectionError, SendError, Store};
-use tracing::info;
+use serde::Serialize;
+use tracing::{debug, info};
 
 use crate::finance::{Market, Symbol};
 use crate::hyperliquid::{Hyperliquid, HyperliquidError};
@@ -26,6 +27,23 @@ pub(crate) struct MarketMetadata {
     pub(crate) symbol: Market,
     pub(crate) max_leverage: u32,
     pub(crate) asset_index: u32,
+}
+
+/// One market's max leverage, as served to clients.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LeverageLimit {
+    pub(crate) symbol: String,
+    pub(crate) max_leverage: u32,
+}
+
+/// A venue's per-market leverage limits plus the time the universe behind them
+/// was last observed, so clients can reason about freshness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LeverageLimits {
+    pub(crate) limits: Vec<LeverageLimit>,
+    pub(crate) fetched_at: DateTime<Utc>,
 }
 
 /// Why refreshing the market universe fails.
@@ -105,6 +123,33 @@ pub(crate) async fn tradable_markets(
         .map(|market| Market::new(market.symbol().as_str().to_string()))
         .collect();
     Ok(tradable)
+}
+
+/// A venue's per-market max-leverage limits, read straight from the catalog
+/// snapshot. Unlike [`tradable_markets`], operator disable flags do not apply:
+/// leverage is venue metadata a client may need for any position it holds.
+/// `None` when the venue has never been observed.
+pub(crate) async fn leverage_limits(
+    venue: VenueRef,
+    catalog_projection: &Projection<MarketCatalog>,
+) -> Result<Option<LeverageLimits>, ProjectionError<MarketCatalog>> {
+    let Some(catalog) = catalog_projection.load(&venue).await? else {
+        return Ok(None);
+    };
+
+    let limits: Vec<LeverageLimit> = catalog
+        .markets()
+        .iter()
+        .map(|market| LeverageLimit {
+            symbol: market.symbol().as_str().to_string(),
+            max_leverage: market.max_leverage(),
+        })
+        .collect();
+    debug!(venue = %venue, markets = limits.len(), "leverage limits read");
+    Ok(Some(LeverageLimits {
+        limits,
+        fetched_at: catalog.observed_at(),
+    }))
 }
 
 #[cfg(test)]
@@ -265,5 +310,62 @@ mod tests {
             Level::INFO,
             &["markets metadata refreshed"]
         ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn leverage_limits_reports_every_listed_market_ignoring_disables() {
+        let (catalog, catalog_projection, enablement, enablement_projection) =
+            market_stores().await;
+        let client = StubClient {
+            metadata: vec![metadata("BTC", 50, 0), metadata("ETH", 25, 1)],
+        };
+        refresh_markets(
+            &client,
+            &catalog,
+            &catalog_projection,
+            &enablement_projection,
+        )
+        .await
+        .unwrap();
+
+        // Disabling a market removes it from the tradable set but not from the
+        // leverage limits -- leverage is venue metadata, not a trading decision.
+        enablement
+            .send(
+                &MarketId::new(VenueRef::Hyperliquid, Symbol::from_raw("BTC")),
+                MarketEnablementCommand::Disable { reason: None },
+            )
+            .await
+            .unwrap();
+
+        let limits = leverage_limits(VenueRef::Hyperliquid, &catalog_projection)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut by_symbol: Vec<(&str, u32)> = limits
+            .limits
+            .iter()
+            .map(|limit| (limit.symbol.as_str(), limit.max_leverage))
+            .collect();
+        by_symbol.sort_unstable();
+        assert_eq!(by_symbol, vec![("BTC", 50), ("ETH", 25)]);
+        assert!(crate::logs_contain_at(
+            Level::DEBUG,
+            &["leverage limits read", "markets=2"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn leverage_limits_returns_none_for_an_unobserved_venue() {
+        let (_catalog, catalog_projection, _enablement, _enablement_projection) =
+            market_stores().await;
+
+        let limits = leverage_limits(VenueRef::Hyperliquid, &catalog_projection)
+            .await
+            .unwrap();
+
+        assert!(limits.is_none());
     }
 }

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -33,7 +33,7 @@ pub(crate) struct MarketMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LeverageLimit {
-    pub(crate) symbol: String,
+    pub(crate) symbol: Symbol,
     pub(crate) max_leverage: u32,
 }
 
@@ -141,7 +141,7 @@ pub(crate) async fn leverage_limits(
         .markets()
         .iter()
         .map(|market| LeverageLimit {
-            symbol: market.symbol().as_str().to_string(),
+            symbol: market.symbol().clone(),
             max_leverage: market.max_leverage(),
         })
         .collect();
@@ -344,6 +344,12 @@ mod tests {
             .unwrap()
             .unwrap();
 
+        let catalog = catalog_projection
+            .load(&VenueRef::Hyperliquid)
+            .await
+            .unwrap()
+            .unwrap();
+
         let mut by_symbol: Vec<(&str, u32)> = limits
             .limits
             .iter()
@@ -351,6 +357,7 @@ mod tests {
             .collect();
         by_symbol.sort_unstable();
         assert_eq!(by_symbol, vec![("BTC", 50), ("ETH", 25)]);
+        assert_eq!(limits.fetched_at, catalog.observed_at());
         assert!(crate::logs_contain_at(
             Level::DEBUG,
             &["leverage limits read", "markets=2"]

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -157,7 +157,7 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
-    use chrono::{DateTime, Utc};
+    use chrono::{DateTime, TimeZone, Utc};
     use sqlx::sqlite::SqlitePoolOptions;
     use tracing::Level;
     use tracing_test::traced_test;
@@ -165,6 +165,7 @@ mod tests {
     use event_sorcery::StoreBuilder;
 
     use super::*;
+    use crate::market_catalog::{CatalogMarket, MarketCatalogCommand};
     use crate::candle::Candle;
     use crate::funding::FundingRate;
     use crate::market_enablement::MarketEnablementCommand;
@@ -362,6 +363,72 @@ mod tests {
             Level::DEBUG,
             &["leverage limits read", "markets=2"]
         ));
+    }
+
+    #[tokio::test]
+    async fn leverage_limits_reflects_latest_catalog_observation_time() {
+        let (catalog, catalog_projection, _enablement, _enablement_projection) =
+            market_stores().await;
+        let first_observed = Utc.with_ymd_and_hms(2026, 3, 15, 12, 0, 0).unwrap();
+        let second_observed = Utc.with_ymd_and_hms(2026, 3, 16, 8, 30, 0).unwrap();
+
+        catalog
+            .send(
+                &VenueRef::Hyperliquid,
+                MarketCatalogCommand::RecordUniverse {
+                    markets: vec![CatalogMarket::new(Symbol::from_raw("BTC"), 50)],
+                    observed_at: first_observed,
+                },
+            )
+            .await
+            .unwrap();
+
+        let first_limits = leverage_limits(VenueRef::Hyperliquid, &catalog_projection)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first_limits.fetched_at, first_observed);
+        assert_eq!(first_limits.limits.len(), 1);
+        assert_eq!(first_limits.limits[0].max_leverage, 50);
+
+        catalog
+            .send(
+                &VenueRef::Hyperliquid,
+                MarketCatalogCommand::RecordUniverse {
+                    markets: vec![CatalogMarket::new(Symbol::from_raw("ETH"), 40)],
+                    observed_at: second_observed,
+                },
+            )
+            .await
+            .unwrap();
+
+        let latest_limits = leverage_limits(VenueRef::Hyperliquid, &catalog_projection)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest_limits.fetched_at, second_observed);
+        assert_eq!(latest_limits.limits.len(), 1);
+        assert_eq!(latest_limits.limits[0].symbol.as_str(), "ETH");
+        assert_eq!(latest_limits.limits[0].max_leverage, 40);
+    }
+
+    #[test]
+    fn leverage_limits_serialize_with_camel_case_fields() {
+        let limits = LeverageLimits {
+            limits: vec![LeverageLimit {
+                symbol: Symbol::from_raw("BTC"),
+                max_leverage: 50,
+            }],
+            fetched_at: Utc.with_ymd_and_hms(2026, 3, 15, 12, 0, 0).unwrap(),
+        };
+
+        let json = serde_json::to_value(&limits).unwrap();
+        assert_eq!(json["limits"][0]["symbol"], "BTC");
+        assert_eq!(json["limits"][0]["maxLeverage"], 50);
+        assert_eq!(json["fetchedAt"], "2026-03-15T12:00:00Z");
+
+        let roundtrip: LeverageLimits = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip, limits);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Max leverage is already fetched and persisted in the `MarketCatalog`, but nothing
exposes it, so each client pulls the full all-market ticker payload on page load
just to read it (#234). Serving it from the cached catalog removes that
per-client fetch. Leverage rarely changes, so the catalog snapshot is fresh
enough, and `fetchedAt` lets clients reason about staleness.

Closes #379.

## Solution

Adds `GET /markets/{venue}/leverage`, serving each listed market's max leverage
plus the universe's last-observed time from the event-sourced catalog snapshot.
`CatalogMarket` exposes `max_leverage()`; `MarketCatalog` retains `observed_at`
(schema version bumped so stale snapshots rebuild from events). Unlike the
tradable set, operator disables do not filter leverage limits. Unknown or
never-observed venues return 404.

Stacked on #409. The frontend still fetches leverage via ccxt `fetchTickers`;
wiring it to this endpoint completes #234 and is the deferred follow-up.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #410
- <kbd>&nbsp;3&nbsp;</kbd> #380 👈
- <kbd>&nbsp;2&nbsp;</kbd> #409
- <kbd>&nbsp;1&nbsp;</kbd> #406
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a market leverage endpoint that returns per-venue, per-symbol max leverage limits from the latest catalog data.
  * Responses include a “fetched at” timestamp reflecting when the venue universe was last observed.
* **Bug Fixes**
  * Improved ingestion startup to enqueue ingestion runs more safely and reduce concurrency issues.
  * Returns a clear 404 when a venue has no leverage limits; leverage responses include disabled markets when they exist in the latest catalog.
* **Documentation**
  * Updated the roadmap with the new leverage limits task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->