### PR TITLE
test: decouple the factors endpoint test from fixture-specific values

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,6 +85,9 @@ of them.
 - [x] Tradable filter wired into ingestion --
       [#277](https://github.com/dataclique/moneymentum/issues/277) /
       [#278](https://github.com/dataclique/moneymentum/pull/278)
+- [x] Decouple the factors endpoint test from fixture-specific values --
+      [#354](https://github.com/dataclique/moneymentum/issues/354) /
+      [#381](https://github.com/dataclique/moneymentum/pull/381)
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,37 +654,32 @@ mod tests {
         assert!(
             rows.iter().all(|row| row
                 .get("annualized_return")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries annualized_return as a number (the fixture's closes are clean)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries annualized_return as a number or null"
         );
         assert!(
             rows.iter().all(|row| row
                 .get("sharpe")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries sharpe as a number (the fixture's closes all vary)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries sharpe as a number or null"
         );
         assert!(
             rows.iter().all(|row| row
                 .get("sortino")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries sortino as a number (every fixture ticker has downside)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries sortino as a number or null"
         );
         assert!(
             rows.iter().all(|row| row
                 .get("autocorrelation")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries autocorrelation as a number (the fixture's returns all vary)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries autocorrelation as a number or null"
         );
         assert!(
             rows.iter().all(|row| row
                 .get("information_discreteness")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries information_discreteness as a number (the fixture's returns all vary)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries information_discreteness as a number or null"
         );
         // The fixture ships no funding data, so carry is legitimately null --
         // but the key itself must stay in the schema for every row.
@@ -697,16 +692,14 @@ mod tests {
         assert!(
             rows.iter().all(|row| row
                 .get("beta")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries beta as a number (prices vary and BTC is the benchmark)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries beta as a number or null"
         );
         assert!(
             rows.iter().all(|row| row
                 .get("volume_24h")
-                .and_then(serde_json::Value::as_f64)
-                .is_some()),
-            "every row carries volume_24h as a number (every fixture ticker has current candles)"
+                .is_some_and(|value| value.is_null() || value.as_f64().is_some())),
+            "every row carries volume_24h as a number or null"
         );
         assert_btc_factor_values_are_real(&rows);
 


### PR DESCRIPTION
## Motivation

Closes #354. `annualized_return`, `sharpe`, `sortino`, `autocorrelation`,
`information_discreteness`, `beta`, and `volume_24h` are legitimately nullable
(sharpe is null without volatility, sortino is null without downside, etc., all
covered by the `per_ticker_*` unit tests in `factors/scores.rs`), but the
endpoint test `get_factors_returns_per_ticker_factor_scores_json` demanded
non-null values that only hold because `fixtures/ohlcv_1d_beta.csv` happens to
give every ticker volatility and downside. Coupled to fixture specifics, it
could fail on correct behavior if the fixture changed.

## Solution

- Those seven assertions now use the same "present, null-or-number" contract
  pattern already used for `sma` / `mean_return` / `price_zscore`.
- `assert_btc_factor_values_are_real` still pins BTC's real finite values, so a
  serialization regression still fails the test -- only the fixture coupling is
  removed.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 1 in a stack** made with GitButler:
- <kbd>&nbsp;1&nbsp;</kbd> #381 👈
<!-- GitButler Footer Boundary Bottom -->
