### PR TITLE
refactor: route beta and candle paths through Symbol and Market

### DIFF
--- a/src/candle.rs
+++ b/src/candle.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tracing::{debug, instrument};
 
 use crate::dataframe::{self, DataFrameError};
-use crate::finance::Symbol;
+use crate::finance::{Market, Symbol};
 use crate::timeframe::Timeframe;
 
 #[derive(Debug, Error)]
@@ -34,7 +34,7 @@ pub(crate) struct Candle {
     pub(crate) close: f64,
     pub(crate) volume: f64,
     /// Full market identifier in CCXT format (e.g., "BTC/USDC:USDC")
-    pub(crate) symbol: String,
+    pub(crate) symbol: Market,
     /// Normalized base symbol (e.g., "BTC")
     pub(crate) ticker: Symbol,
 }
@@ -116,7 +116,7 @@ mod tests {
                 low: 95.0,
                 close: 105.0,
                 volume: 1000.0,
-                symbol: "BTC/USDC:USDC".to_string(),
+                symbol: Market::new("BTC/USDC:USDC".to_string()),
                 ticker: Symbol::from_raw("BTC"),
             },
             Candle {
@@ -126,7 +126,7 @@ mod tests {
                 low: 100.0,
                 close: 110.0,
                 volume: 1500.0,
-                symbol: "BTC/USDC:USDC".to_string(),
+                symbol: Market::new("BTC/USDC:USDC".to_string()),
                 ticker: Symbol::from_raw("BTC"),
             },
         ]
@@ -147,7 +147,7 @@ mod tests {
                             low: 90.0,
                             close: 105.0,
                             volume: 1000.0,
-                            symbol: "BTC/USDC:USDC".to_string(),
+                            symbol: Market::new("BTC/USDC:USDC".to_string()),
                             ticker: Symbol::from_raw("BTC"),
                         }
                     })

--- a/src/factors/beta.rs
+++ b/src/factors/beta.rs
@@ -14,22 +14,30 @@ use tracing::{info, instrument};
 
 use super::ReturnsError;
 use super::returns::{LOG_RETURNS_LOOKBACK_CANDLES, compute_log_returns};
+use crate::finance::Symbol;
 use crate::timeframe::Timeframe;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PortfolioBetaReport {
     pub(crate) beta: Option<f64>,
-    pub(crate) excluded_tickers: Vec<String>,
-    pub(crate) effective_weights: BTreeMap<String, f64>,
+    pub(crate) excluded_tickers: Vec<Symbol>,
+    pub(crate) effective_weights: BTreeMap<Symbol, f64>,
     pub(crate) data_age_hours: i64,
 }
 
 #[instrument(skip_all, fields(data_dir = %data_dir.display()))]
 pub(crate) async fn compute_portfolio_beta_report(
     data_dir: &Path,
-    weights: &[(String, f64)],
-    benchmark_ticker: &str,
+    weights: &[(Symbol, f64)],
+    benchmark_ticker: &Symbol,
 ) -> Result<PortfolioBetaReport, ReturnsError> {
+    // Symbol is the domain boundary; the Polars machinery below keys on the raw
+    // ticker string, so convert to strings once here at the edge.
+    let weights: Vec<(String, f64)> = weights
+        .iter()
+        .map(|(symbol, weight)| (symbol.as_str().to_owned(), *weight))
+        .collect();
+    let benchmark_ticker = benchmark_ticker.as_str();
     let path = daily_candles_path(data_dir);
     let df = crate::dataframe::read_csv(path.clone()).await?;
 
@@ -38,15 +46,19 @@ pub(crate) async fn compute_portfolio_beta_report(
     };
 
     let data_age_hours = data_age_hours_at(&df, Utc::now())?;
-    let weights_clone = weights.to_vec();
+    let weights_clone = weights.clone();
     let benchmark_ticker_clone = benchmark_ticker.to_string();
     let lookback = LOG_RETURNS_LOOKBACK_CANDLES;
     let log_returns_df = tokio::task::spawn_blocking(move || {
         load_log_returns_last_n_candles(&df, &weights_clone, &benchmark_ticker_clone, lookback)
     })
     .await??;
-
-    compute_beta_report_from_log_returns(&log_returns_df, weights, benchmark_ticker, data_age_hours)
+    compute_beta_report_from_log_returns(
+        &log_returns_df,
+        &weights,
+        benchmark_ticker,
+        data_age_hours,
+    )
 }
 
 /// Portfolio beta from precomputed log returns `DataFrame` (e.g. from `load_log_returns_last_n_candles`).
@@ -283,7 +295,7 @@ fn compute_beta_report_from_log_returns(
                 beta: None,
                 excluded_tickers: excluded_tickers
                     .into_iter()
-                    .map(|(ticker, _weight)| ticker)
+                    .map(|(ticker, _weight)| Symbol::from_raw(&ticker))
                     .collect(),
                 effective_weights: BTreeMap::new(),
                 data_age_hours,
@@ -303,9 +315,12 @@ fn compute_beta_report_from_log_returns(
         beta,
         excluded_tickers: excluded_tickers
             .into_iter()
-            .map(|(ticker, _weight)| ticker)
+            .map(|(ticker, _weight)| Symbol::from_raw(&ticker))
             .collect(),
-        effective_weights,
+        effective_weights: effective_weights
+            .into_iter()
+            .map(|(ticker, weight)| (Symbol::from_raw(&ticker), weight))
+            .collect(),
         data_age_hours,
     })
 }
@@ -469,7 +484,7 @@ mod tests {
     #[tokio::test]
     async fn compute_portfolio_beta_errors_when_daily_candles_file_missing() {
         let dir = TempDir::new().unwrap();
-        let result = compute_portfolio_beta_report(dir.path(), &[], "BTC").await;
+        let result = compute_portfolio_beta_report(dir.path(), &[], &Symbol::from_raw("BTC")).await;
         assert!(matches!(result, Err(ReturnsError::NoData { .. })));
     }
 
@@ -623,8 +638,11 @@ mod tests {
         let report = compute_beta_report_from_log_returns(&log_returns_df, &weights, "BTC", 12)
             .expect("beta report");
 
-        assert_eq!(report.excluded_tickers, vec!["DOGE"]);
-        assert_eq!(report.effective_weights.get("ETH"), Some(&1.0));
+        assert_eq!(report.excluded_tickers, vec![Symbol::from_raw("DOGE")]);
+        assert_eq!(
+            report.effective_weights.get(&Symbol::from_raw("ETH")),
+            Some(&1.0)
+        );
         assert_eq!(report.data_age_hours, 12);
         assert!((report.beta.expect("beta") - 1.0).abs() < 1e-10);
         assert!(logs_contain_at(
@@ -651,7 +669,7 @@ mod tests {
             .expect("beta report");
 
         assert_eq!(report.beta, None);
-        assert_eq!(report.excluded_tickers, vec!["DOGE"]);
+        assert_eq!(report.excluded_tickers, vec![Symbol::from_raw("DOGE")]);
         assert!(report.effective_weights.is_empty());
         assert_eq!(report.data_age_hours, 2);
 
@@ -686,8 +704,11 @@ mod tests {
         let report = compute_beta_report_from_log_returns(&log_returns_df, &weights, "BTC", 12)
             .expect("beta report");
 
-        assert_eq!(report.excluded_tickers, vec!["DOGE"]);
-        assert_eq!(report.effective_weights.get("ETH"), Some(&1.0));
+        assert_eq!(report.excluded_tickers, vec![Symbol::from_raw("DOGE")]);
+        assert_eq!(
+            report.effective_weights.get(&Symbol::from_raw("ETH")),
+            Some(&1.0)
+        );
         assert_eq!(report.data_age_hours, 12);
         assert!((report.beta.expect("beta") - 1.0).abs() < 1e-10);
         assert!(logs_contain_at(
@@ -705,12 +726,16 @@ mod tests {
         fs::copy(src, &dst).unwrap();
 
         // 60% long BTC, 40% short ETH, benchmark BTC
-        let weights = [("BTC".to_string(), 0.6_f64), ("ETH".to_string(), -0.4_f64)];
+        let weights = [
+            (Symbol::from_raw("BTC"), 0.6_f64),
+            (Symbol::from_raw("ETH"), -0.4_f64),
+        ];
 
-        let report = compute_portfolio_beta_report(tmp_dir.path(), &weights, "BTC")
-            .await
-            .unwrap()
-            .beta;
+        let report =
+            compute_portfolio_beta_report(tmp_dir.path(), &weights, &Symbol::from_raw("BTC"))
+                .await
+                .unwrap()
+                .beta;
         let beta = report.expect("beta defined");
 
         assert!(

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -7,16 +7,17 @@
 //! [`Symbol`] normalizes these representations for consistent storage and lookup.
 //! [`Market`] preserves the exchange's native identifier for API calls.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Normalized trading symbol (e.g., "BTC", "ETH").
 ///
 /// Normalizes input like "BTC/USDC:USDC" to just "BTC".
 ///
-/// Serialization is transparent (the inner ticker string). Persisted symbols
-/// are always written through [`Symbol::from_raw`], so a deserialized value is
-/// already normalized -- replay trusts the stored representation.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+/// Serialization is transparent (the inner ticker string). Deserialization
+/// normalizes through [`Symbol::from_raw`], so a `Symbol` decoded at any boundary
+/// -- a wire request or a persisted event -- is canonical. `from_raw` is
+/// idempotent, so re-normalizing an already-stored symbol is a no-op.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub(crate) struct Symbol(String);
 
 impl Symbol {
@@ -27,6 +28,16 @@ impl Symbol {
 
     pub(crate) fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Symbol {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Ok(Self::from_raw(&raw))
     }
 }
 
@@ -172,5 +183,17 @@ mod tests {
             hyperliquid_swap_ccxt_symbol_with_collateral("HYNA-BTC", "USDE").as_str(),
             "HYNA-BTC/USDE:USDE"
         );
+    }
+
+    #[test]
+    fn deserialize_normalizes_to_canonical_symbol() {
+        let from_ccxt: Symbol = serde_json::from_str(r#""btc/USDC:USDC""#).unwrap();
+        assert_eq!(from_ccxt.as_str(), "BTC");
+
+        let from_lowercase: Symbol = serde_json::from_str(r#""eth""#).unwrap();
+        assert_eq!(from_lowercase.as_str(), "ETH");
+
+        let already_canonical: Symbol = serde_json::from_str(r#""BTC""#).unwrap();
+        assert_eq!(already_canonical.as_str(), "BTC");
     }
 }

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -235,7 +235,9 @@ impl Hyperliquid for HyperliquidClient {
                     close,
                     volume,
                     // CCXT perpetual format: BASE/USDC:USDC
-                    symbol: finance::hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
+                    symbol: Market::new(
+                        finance::hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
+                    ),
                     ticker: Symbol::from_raw(market.as_str()),
                 })
             })
@@ -505,7 +507,7 @@ mod tests {
                     low: 41000.0,
                     close: 42500.0,
                     volume: 1000.0,
-                    symbol: "BTC/USDC:USDC".to_string(),
+                    symbol: Market::new("BTC/USDC:USDC".to_string()),
                     ticker: Symbol::from_raw("BTC"),
                 }],
                 funding_rates: vec![FundingRate {

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -678,7 +678,7 @@ mod tests {
                 low: 95.0,
                 close: 102.0,
                 volume: 1000.0,
-                symbol: hyperliquid_swap_ccxt_symbol(market.as_str()).into_string(),
+                symbol: Market::new(hyperliquid_swap_ccxt_symbol(market.as_str()).into_string()),
                 ticker: Symbol::from_raw(market.as_str()),
             }])
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,15 +230,15 @@ async fn get_ingestion_status(
 
 #[derive(Debug, Deserialize)]
 struct BetaRequest {
-    weights: std::collections::HashMap<String, f64>,
-    benchmark: String,
+    weights: std::collections::HashMap<Symbol, f64>,
+    benchmark: Symbol,
 }
 
 #[derive(Debug, serde::Serialize)]
 struct BetaResponse {
     beta: Option<f64>,
-    excluded_symbols: Vec<String>,
-    effective_weights: std::collections::BTreeMap<String, f64>,
+    excluded_symbols: Vec<Symbol>,
+    effective_weights: std::collections::BTreeMap<Symbol, f64>,
     data_age_hours: i64,
 }
 
@@ -355,7 +355,7 @@ async fn post_beta(
     config: &State<Config>,
     body: Json<BetaRequest>,
 ) -> Result<Json<BetaResponse>, Status> {
-    if body.benchmark.trim().is_empty() {
+    if body.benchmark.as_str().trim().is_empty() {
         return Err(Status::BadRequest);
     }
     if body.weights.is_empty() {
@@ -365,7 +365,7 @@ async fn post_beta(
         return Err(Status::BadRequest);
     }
 
-    let weights: Vec<(String, f64)> = {
+    let weights: Vec<(Symbol, f64)> = {
         let mut sorted_weights: Vec<_> = body
             .weights
             .iter()


### PR DESCRIPTION
## What

Route the beta and candle code paths through the `Symbol` and `Market` newtypes
instead of bare strings. Closes #383.

## Why

`Symbol` existed but was bypassed by `HashMap<String, f64>` weights, `String`
benchmarks, and `String` candle identifiers, so the type system no longer
guaranteed a symbol was normalized or distinct from any other string, and
un-normalized input could pass the API boundary.

## How

- `Symbol` now deserializes through `from_raw` (idempotent), so every boundary
  yields a canonical symbol; added `Hash` so it can key a map.
- `Candle.symbol` is now `Market` (the full CCXT identifier), distinct from the
  normalized `ticker: Symbol`.
- `BetaRequest`/`BetaResponse` and `factors::PortfolioBetaReport` key on `Symbol`;
  `String` survives only at the Polars column edge.

## Testing

- 169 lib tests + the e2e suite + `cargo clippy --all-targets -- -D warnings` green.
- Standalone check: `cargo check --tests` passes in a detached worktree at this
  commit on its event-sorcery base alone, so the diff compiles on its own base.

## Anything else

Stacked on the event-sorcery PRs. The readonly-portfolio and analytics-PR symbol
cleanups are tracked separately; the readonly piece is blocked until #378 and the
event-sorcery stack reach master (it needs the enhanced `Symbol` from one and the
Decimals from the other).

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #384 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #380
- <kbd>&nbsp;3&nbsp;</kbd> #382
- <kbd>&nbsp;2&nbsp;</kbd> #362
- <kbd>&nbsp;1&nbsp;</kbd> #361
<!-- GitButler Footer Boundary Bottom -->