### PR TITLE
fix: address CodeRabbit review follow-ups from #377

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,6 +98,8 @@ the next user-facing priority; it runs in parallel to the Dev track above.
 - [ ] [Serve The App From A Domain](./stories/0x009.serve-app-from-domain.md)
 - [x] [Clear stale switch-to-configuration lock blocking deploys](https://github.com/dataclique/moneymentum/issues/394)
       ([#395](https://github.com/dataclique/moneymentum/pull/395))
+- [x] [Address #377 review follow-ups](https://github.com/dataclique/moneymentum/issues/392)
+      ([#393](https://github.com/dataclique/moneymentum/pull/393))
 
 ---
 

--- a/ai/skills/gitbutler/SKILL.md
+++ b/ai/skills/gitbutler/SKILL.md
@@ -212,10 +212,11 @@ GitButler snapshots everything, including uncommitted changes:
 ## This Repository
 
 - **Pre-commit hooks (prek):** `prek` is the repo's pre-commit hook runner;
-  `but commit` runs the hooks (nixfmt-classic, nil, eslint, prettier, taplo,
-  denofmt, rustfmt, clippy). If you must `but amend`/`but rub` (which skip
-  hooks), run `prek run --all-files` afterward and fold in any formatting fixes
-  before pushing. Markdown is formatted by `deno fmt`.
+  `but commit` runs the enabled hooks (nixfmt, nil, eslint, prettier, taplo,
+  denofmt, rustfmt; the local clippy hook is disabled). If you must
+  `but amend`/`but rub` (which skip hooks), run `prek run --all-files` afterward
+  and fold in any formatting fixes before pushing. Markdown is formatted by
+  `deno fmt`.
 - **Commit messages:** conventional, lowercase -- `feat:`, `fix:`, `docs:`,
   `chore:`, `refactor:`, `test:`. Explain _why_ in the body. Never add
   "Generated with ..." or co-author trailers.

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -230,6 +230,42 @@ describe("HyperliquidClient", () => {
     expect(positions[1].side).toBe("sell")
   })
 
+  it("rejects a malformed metaAndAssetCtxs payload shape", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async input => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url
+
+      if (url.includes("/info")) {
+        return { ok: true, json: async () => [null, []] } as Response
+      }
+
+      return {
+        ok: true,
+        headers: new Headers({ "cache-control": "public, max-age=86400" }),
+        json: async () => ({
+          tickers: ["BTC/USDC:USDC"],
+          leverageLimits: [
+            { symbol: "BTC/USDC:USDC", maxLeverage: 50, assetIndex: 0 },
+          ],
+          refreshedAt: new Date().toISOString(),
+        }),
+      } as Response
+    })
+
+    const actions: RebalanceAction[] = [
+      { kind: "close", symbol: "BTC/USDC:USDC", side: "buy" },
+    ]
+
+    const client = new HyperliquidClient(credentials, "mainnet")
+    await expect(client.rebalancePositions(actions)).rejects.toThrow(
+      "Unexpected metaAndAssetCtxs payload shape",
+    )
+  })
+
   it("sets leverage first then sends reduction batch and expansion batch", async () => {
     const actions: RebalanceAction[] = [
       {

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -266,6 +266,45 @@ describe("HyperliquidClient", () => {
     )
   })
 
+  it("rejects a metaAndAssetCtxs universe with a null entry", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async input => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url
+
+      if (url.includes("/info")) {
+        return {
+          ok: true,
+          json: async () => [{ universe: [null] }, []],
+        } as Response
+      }
+
+      return {
+        ok: true,
+        headers: new Headers({ "cache-control": "public, max-age=86400" }),
+        json: async () => ({
+          tickers: ["BTC/USDC:USDC"],
+          leverageLimits: [
+            { symbol: "BTC/USDC:USDC", maxLeverage: 50, assetIndex: 0 },
+          ],
+          refreshedAt: new Date().toISOString(),
+        }),
+      } as Response
+    })
+
+    const actions: RebalanceAction[] = [
+      { kind: "close", symbol: "BTC/USDC:USDC", side: "buy" },
+    ]
+
+    const client = new HyperliquidClient(credentials, "mainnet")
+    await expect(client.rebalancePositions(actions)).rejects.toThrow(
+      "Unexpected metaAndAssetCtxs payload shape",
+    )
+  })
+
   it("sets leverage first then sends reduction batch and expansion batch", async () => {
     const actions: RebalanceAction[] = [
       {

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -109,20 +109,22 @@ const fetchPerpMarketContexts = async (
     throw new Error("Unexpected metaAndAssetCtxs payload shape")
   }
 
-  const meta = json[0] as {
-    universe?: Array<{ name?: string; szDecimals?: number }>
-  } | null
+  const meta = json[0] as { universe?: unknown[] } | null
   const assetContexts = json[1] as Array<
     { markPx?: string | number } | null | undefined
   >
   if (
     meta === null ||
     !Array.isArray(meta.universe) ||
+    meta.universe.some(asset => asset === null || typeof asset !== "object") ||
     !Array.isArray(assetContexts)
   ) {
     throw new Error("Unexpected metaAndAssetCtxs payload shape")
   }
-  const universe = meta.universe
+  const universe = meta.universe as Array<{
+    name?: string
+    szDecimals?: number
+  }>
   const contexts = new Map<string, PerpMarketContext>()
 
   universe.forEach((asset, index) => {

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -115,7 +115,10 @@ const fetchPerpMarketContexts = async (
   const assetContexts = json[1] as Array<
     { markPx?: string | number } | null | undefined
   >
-  const universe = meta.universe ?? []
+  if (!Array.isArray(meta.universe) || !Array.isArray(assetContexts)) {
+    throw new Error("Unexpected metaAndAssetCtxs payload shape")
+  }
+  const universe = meta.universe
   const contexts = new Map<string, PerpMarketContext>()
 
   universe.forEach((asset, index) => {

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -111,11 +111,15 @@ const fetchPerpMarketContexts = async (
 
   const meta = json[0] as {
     universe?: Array<{ name?: string; szDecimals?: number }>
-  }
+  } | null
   const assetContexts = json[1] as Array<
     { markPx?: string | number } | null | undefined
   >
-  if (!Array.isArray(meta.universe) || !Array.isArray(assetContexts)) {
+  if (
+    meta === null ||
+    !Array.isArray(meta.universe) ||
+    !Array.isArray(assetContexts)
+  ) {
     throw new Error("Unexpected metaAndAssetCtxs payload shape")
   }
   const universe = meta.universe

--- a/os.nix
+++ b/os.nix
@@ -280,7 +280,7 @@ in
   systemd.timers.moneymentum-markets-refresh = {
     wantedBy = [ "timers.target" ];
     timerConfig = {
-      OnCalendar = "*-*-* 00:00:00";
+      OnCalendar = "*-*-* 00:00:00 UTC";
       Persistent = true;
     };
   };
@@ -288,7 +288,7 @@ in
   systemd.timers.staging-markets-refresh = {
     wantedBy = [ "timers.target" ];
     timerConfig = {
-      OnCalendar = "*-*-* 00:00:00";
+      OnCalendar = "*-*-* 00:00:00 UTC";
       Persistent = true;
     };
   };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,10 +97,11 @@ struct ConfigSource {
 impl ConfigSource {
     fn into_config(self, publish_path: Option<&Path>) -> Result<Config, ConfigError> {
         let markets_refresh_token = if let Some(token) = self.markets_refresh_token {
-            if token.trim().is_empty() {
+            let trimmed_token = token.trim();
+            if trimmed_token.is_empty() {
                 return Err(ConfigError::BlankMarketsRefreshToken);
             }
-            token
+            trimmed_token.to_owned()
         } else {
             let publish_path =
                 publish_path.ok_or(ConfigError::MissingMarketsRefreshTokenPublishPath)?;
@@ -871,6 +872,28 @@ mod tests {
             max_concurrent_requests = 3
             max_retries = 5
             markets_refresh_token = ""
+            "#,
+        )
+        .unwrap();
+
+        let result = Config::load(&config_path, None);
+        assert!(matches!(result, Err(ConfigError::BlankMarketsRefreshToken)));
+    }
+
+    #[test]
+    fn config_load_rejects_whitespace_only_inline_token() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+            port = 8000
+            data_dir = "data"
+            database_url = "sqlite::memory:"
+            log_level = "info"
+            max_concurrent_requests = 3
+            max_retries = 5
+            markets_refresh_token = "  \t  "
             "#,
         )
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ impl ConfigSource {
         let markets_refresh_token = if let Some(token) = self.markets_refresh_token {
             let trimmed_token = token.trim();
             if trimmed_token.is_empty() {
+                warn!("rejected blank markets_refresh_token");
                 return Err(ConfigError::BlankMarketsRefreshToken);
             }
             trimmed_token.to_owned()
@@ -858,6 +859,7 @@ mod tests {
         ));
     }
 
+    #[traced_test]
     #[test]
     fn config_load_rejects_blank_inline_token() {
         let temp_dir = TempDir::new().unwrap();
@@ -878,8 +880,13 @@ mod tests {
 
         let result = Config::load(&config_path, None);
         assert!(matches!(result, Err(ConfigError::BlankMarketsRefreshToken)));
+        assert!(logs_contain_at(
+            tracing::Level::WARN,
+            &["rejected", "markets_refresh_token"]
+        ));
     }
 
+    #[traced_test]
     #[test]
     fn config_load_rejects_whitespace_only_inline_token() {
         let temp_dir = TempDir::new().unwrap();
@@ -900,6 +907,10 @@ mod tests {
 
         let result = Config::load(&config_path, None);
         assert!(matches!(result, Err(ConfigError::BlankMarketsRefreshToken)));
+        assert!(logs_contain_at(
+            tracing::Level::WARN,
+            &["rejected", "markets_refresh_token"]
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,9 @@ struct ConfigSource {
 impl ConfigSource {
     fn into_config(self, publish_path: Option<&Path>) -> Result<Config, ConfigError> {
         let markets_refresh_token = if let Some(token) = self.markets_refresh_token {
+            if token.trim().is_empty() {
+                return Err(ConfigError::BlankMarketsRefreshToken);
+            }
             token
         } else {
             let publish_path =
@@ -188,6 +191,10 @@ pub enum ConfigError {
         "--markets-refresh-token-publish-path is required when markets_refresh_token is omitted"
     )]
     MissingMarketsRefreshTokenPublishPath,
+    #[error(
+        "markets_refresh_token must not be blank; omit it to auto-generate or set a non-empty value"
+    )]
+    BlankMarketsRefreshToken,
 }
 
 type IngestionJobQueue = SqliteStorage<IngestionJob>;
@@ -848,6 +855,28 @@ mod tests {
             result,
             Err(ConfigError::MissingMarketsRefreshTokenPublishPath)
         ));
+    }
+
+    #[test]
+    fn config_load_rejects_blank_inline_token() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+            port = 8000
+            data_dir = "data"
+            database_url = "sqlite::memory:"
+            log_level = "info"
+            max_concurrent_requests = 3
+            max_retries = 5
+            markets_refresh_token = ""
+            "#,
+        )
+        .unwrap();
+
+        let result = Config::load(&config_path, None);
+        assert!(matches!(result, Err(ConfigError::BlankMarketsRefreshToken)));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

CodeRabbit raised several issues while reviewing #377 that merged before they
were addressed. Closes #392.

## Solution

- **os.nix** -- the `markets-refresh` / `staging-markets-refresh` systemd timers
  now use `OnCalendar = "*-*-* 00:00:00 UTC"`, matching the `MarketsJson`
  UTC-midnight cache boundary so the daily refresh and cache expiry stay aligned
  on non-UTC hosts.
- **lib.rs** -- a blank or whitespace `markets_refresh_token` is now rejected
  (`ConfigError::BlankMarketsRefreshToken`) rather than silently used, which
  previously let an empty `X-Markets-Refresh-Token` header authorize refreshes.
  Fails loudly per the no-hidden-defaults rule; covered by a new test.
- **hyperliquid-client.ts** -- `metaAndAssetCtxs` is validated (both `universe`
  and the asset-contexts entry must be arrays) before iterating, so a malformed
  upstream response is rejected instead of throwing inside `forEach` during
  rebalance hydration.
- **ai/skills/gitbutler/SKILL.md** -- the pre-commit hook list is synced with
  `flake.nix` (`nixfmt`, not `nixfmt-classic`; notes the local clippy hook is
  disabled).

## Not addressed

CodeRabbit also flagged the checked-in `markets_refresh_token` in `config.toml`
(a credential-bearing config file). I deliberately left it untouched -- removing
it should be done by hand: leave it unset in `config.toml` / `example.toml` and
supply a unique value via secret management. The `lib.rs` blank-token rejection
here is the code-side guard for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected blank or whitespace-only `markets_refresh_token` values during configuration parsing, with a clearer error message.
  * Stricter handling of market context API payloads: invalid shapes now fail fast with a descriptive error.
  * Updated scheduled refresh timers to run explicitly in UTC to reduce timing drift.
* **Documentation**
  * Refreshed pre-commit hook instructions to match the current formatter setup and note the disabled local lint hook.
* **Tests**
  * Added coverage for invalid market context payloads to ensure the new failure behavior is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->