### PR TITLE
fix: clear stale switch-to-configuration lock before deploy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,6 +96,8 @@ the next user-facing priority; it runs in parallel to the Dev track above.
 - [ ] [Keep The App Deployed And Reachable](./stories/0x008.keep-app-deployed-and-reachable.md)
 - [ ] [Verify Deployed Hyperliquid Long-Short Rebalancing](./stories/0x00a.verify-deployed-hyperliquid-long-short-rebalancing.md)
 - [ ] [Serve The App From A Domain](./stories/0x009.serve-app-from-domain.md)
+- [x] [Clear stale switch-to-configuration lock blocking deploys](https://github.com/dataclique/moneymentum/issues/394)
+      ([#395](https://github.com/dataclique/moneymentum/pull/395))
 
 ---
 

--- a/deploy.nix
+++ b/deploy.nix
@@ -94,6 +94,13 @@ in
         map (name: "systemctl reset-failed ${name} || true") enabledServices
       );
 
+      # nixpkgs#398370: an earlier `switch-to-configuration` activation can hang
+      # in the systemd settle loop while holding an exclusive flock on
+      # /run/nixos/switch-to-configuration.lock, after which every subsequent
+      # deploy fails fast with "Could not acquire lock" (exit 11). Drop the
+      # stale lock before activating so the new switch takes a fresh one.
+      staleLockCleanup = "rm -f /run/nixos/switch-to-configuration.lock";
+
     in
     {
       deployNixos = pkgs.writeShellApplication {
@@ -122,7 +129,7 @@ in
         text = ''
           ${deployPreamble}
 
-          ssh -i "$identity" "root@$host_ip" '${serviceCleanup}'
+          ssh -i "$identity" "root@$host_ip" '${staleLockCleanup}; ${serviceCleanup}'
 
           deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} "$@" .#moneymentum
         '';


### PR DESCRIPTION
## Motivation

Production deploys fail reproducibly at activation with `Could not acquire lock`
(exit 11) and roll back to the previous generation, so the app is stuck and
re-running does not help. Closes #394.

The message is emitted by nixpkgs' `switch-to-configuration-ng`: it takes a
non-blocking exclusive flock on `/run/nixos/switch-to-configuration.lock` and
exits 11 (EAGAIN) when the lock is already held. An earlier activation hung in
the systemd settle loop (nixpkgs#398370) and never released the lock, so the
lingering process blocks every subsequent deploy. The affected
`switch-to-configuration-ng` arrived with the nixpkgs bump bundled into #377's
flake update (the last green deploy predates it).

## Solution

`deployServer`'s pre-activation SSH now removes the stale
`/run/nixos/switch-to-configuration.lock` before running `deploy`. The hung
process keeps its flock on the now-unlinked inode, so the next switch creates a
fresh lock file and activates cleanly. This unblocks the current stuck state on
the first run and stops a stale lock from silently wedging deploys again.

## Notes

- The settle-loop hang itself (nixpkgs#398370) is upstream and intermittent;
  this clears the stale lock it leaves behind so it can no longer block deploys.
  The upstream timeout fix (nixpkgs#422798) is not reliably present in
  nixos-26.05 (the issue was reopened against 26.05), so clearing the stale lock
  is the dependable mitigation in our control.
- Immediate recovery before this merges: on the host, run
  `rm -f /run/nixos/switch-to-configuration.lock`, then re-run the deploy.
