### PR TITLE
surface typed errors in the UI

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -113,14 +113,31 @@ Programs:
 ### Bridge to TanStack Query
 
 `Effect.runPromise(program)` inside `queryFn`. When the Effect fails,
-`runPromise` rejects with a typed error that has `_tag` -- components can
-pattern-match on `error._tag` instead of parsing strings.
+`runPromise` rejects with a `FiberFailure` that wraps the typed error in its
+`Cause` -- so `query.error` is the `FiberFailure`, not the tagged error itself.
 
 ```ts
 queryFn: (({ signal }) => Effect.runPromise(fetchJson<T>(url, { signal })));
 ```
 
 Always forward the `signal` from TanStack Query's context into the HTTP helpers.
+
+### Displaying errors in the UI
+
+Never render `error.message` directly -- the `FiberFailure` message is generic
+("An error has occurred"). Pass `query.error` through `getErrorMessage`
+(`src/lib/error-message.ts`), which unwraps the `FiberFailure` to the tagged
+error and maps each `_tag` to display text:
+
+```tsx
+<Show when={query.error}>
+  <p>{getErrorMessage(query.error)}</p>
+</Show>;
+```
+
+Add a `case` to `getErrorMessage` whenever you introduce a new tagged error so
+every failure surfaces a user-facing message instead of falling back to the raw
+string.
 
 ### Hyperliquid service (`src/services/hyperliquid.ts`)
 

--- a/frontend/src/lib/error-message.test.ts
+++ b/frontend/src/lib/error-message.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import * as Effect from "effect/Effect"
+
+import { getErrorMessage } from "./error-message"
+import { HttpStatusError, NetworkError } from "./http"
+import { ApiMessageError, MissingTickerError } from "@/hooks/useApi"
+
+const asFiberFailure = async (error: unknown): Promise<unknown> => {
+  try {
+    await Effect.runPromise(Effect.fail(error))
+  } catch (caught) {
+    return caught
+  }
+  throw new Error("expected the effect to fail")
+}
+
+describe("getErrorMessage", () => {
+  it("maps a FiberFailure-wrapped HttpStatusError to its detail", async () => {
+    const failure = await asFiberFailure(
+      new HttpStatusError({ status: 503, detail: "service unavailable" }),
+    )
+    expect(getErrorMessage(failure)).toBe("service unavailable")
+  })
+
+  it("maps an HttpStatusError without detail to its status", async () => {
+    const failure = await asFiberFailure(new HttpStatusError({ status: 500 }))
+    expect(getErrorMessage(failure)).toBe("Request failed with status 500.")
+  })
+
+  it("maps a NetworkError to a connection message", async () => {
+    const failure = await asFiberFailure(new NetworkError({ cause: "offline" }))
+    expect(getErrorMessage(failure)).toContain("Network request failed")
+  })
+
+  it("maps a MissingTickerError to a ticker prompt", async () => {
+    const failure = await asFiberFailure(new MissingTickerError())
+    expect(getErrorMessage(failure)).toBe("Select a ticker to continue.")
+  })
+
+  it("surfaces the ApiMessageError message verbatim", async () => {
+    const failure = await asFiberFailure(
+      new ApiMessageError({ message: "no data for ticker" }),
+    )
+    expect(getErrorMessage(failure)).toBe("no data for ticker")
+  })
+
+  it("falls back to a plain Error message", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom")
+  })
+
+  it("stringifies unknown non-error values", () => {
+    expect(getErrorMessage("weird")).toBe("weird")
+  })
+})

--- a/frontend/src/lib/error-message.ts
+++ b/frontend/src/lib/error-message.ts
@@ -1,0 +1,77 @@
+import * as Cause from "effect/Cause"
+import * as Option from "effect/Option"
+import * as Runtime from "effect/Runtime"
+
+/**
+ * Turns any error surfaced to the UI into human-readable display text.
+ *
+ * Effects bridged to TanStack Query via `Effect.runPromise` reject with a
+ * `FiberFailure` whose own `message` is generic, so the tagged error has to be
+ * unwrapped from its `Cause` before it can be matched on `_tag`. Components must
+ * render errors through this helper instead of reading `error.message`.
+ */
+export const getErrorMessage = (error: unknown): string => {
+  const unwrapped = unwrapTaggedError(error)
+
+  if (hasTag(unwrapped)) {
+    const message = messageForTag(unwrapped)
+    if (message !== null) return message
+  }
+
+  if (unwrapped instanceof Error) return unwrapped.message
+
+  return String(unwrapped)
+}
+
+const unwrapTaggedError = (error: unknown): unknown => {
+  if (Runtime.isFiberFailure(error)) {
+    const failure = Cause.failureOption(error[Runtime.FiberFailureCauseId])
+    if (Option.isSome(failure)) return failure.value
+  }
+  return error
+}
+
+interface TaggedError {
+  readonly _tag: string
+  readonly status?: number
+  readonly detail?: string
+  readonly message?: string
+}
+
+const hasTag = (value: unknown): value is TaggedError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  typeof (value as { _tag: unknown })._tag === "string"
+
+const messageForTag = (error: TaggedError): string | null => {
+  switch (error._tag) {
+    case "NetworkError":
+      return "Network request failed. Check your connection and try again."
+    case "HttpStatusError":
+      return (
+        error.detail ??
+        (error.status
+          ? `Request failed with status ${error.status}.`
+          : "Request failed.")
+      )
+    case "JsonParseError":
+      return "The server returned a response we could not read."
+    case "JsonSerializeError":
+      return "We could not encode the request."
+    case "MissingTickerError":
+      return "Select a ticker to continue."
+    case "EmptyStreamError":
+      return "The server returned an empty response."
+    case "StreamReadError":
+      return "We lost the connection while reading the server response."
+    case "ApiMessageError":
+      return error.message ?? "The server reported an error."
+    case "WalletNotConnected":
+      return "Connect a wallet to continue."
+    case "ExchangeRequestError":
+      return "The exchange rejected the request. Please try again."
+    default:
+      return null
+  }
+}

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -7,6 +7,7 @@ import {
   type Timeframe,
 } from "@/components/ui/timeframe-select"
 import { cn } from "@/lib/cn"
+import { getErrorMessage } from "@/lib/error-message"
 import { Button } from "@/components/ui/button"
 import {
   useDateRange,
@@ -108,8 +109,10 @@ const MainPage = () => {
     dateRangeQuery.isLoading ||
     analysisQuery.isLoading ||
     reloadMutation.isPending
-  const error = () =>
-    dateRangeQuery.error?.message ?? analysisQuery.error?.message ?? null
+  const error = () => {
+    const failure = dateRangeQuery.error ?? analysisQuery.error
+    return failure ? getErrorMessage(failure) : null
+  }
   const data = () => analysisQuery.data?.data ?? []
   const message = () => analysisQuery.data?.message ?? null
 

--- a/frontend/src/pages/TokenPage/index.tsx
+++ b/frontend/src/pages/TokenPage/index.tsx
@@ -17,6 +17,7 @@ import {
   type Timeframe,
 } from "@/components/ui/timeframe-select"
 import { buttonVariants } from "@/lib/button-variants"
+import { getErrorMessage } from "@/lib/error-message"
 import { AVAILABLE_METRICS } from "./constants"
 import ChartComponent, { type MetricSelection } from "./ChartComponent"
 import { useTokenData } from "@/hooks/useApi"
@@ -62,7 +63,7 @@ const TokenPage = (props: { timeframe: Timeframe }) => {
               <CardTitle class="text-destructive">Error</CardTitle>
             </CardHeader>
             <CardContent>
-              <p>{tokenQuery.error?.message}</p>
+              <p>{getErrorMessage(tokenQuery.error)}</p>
               <A
                 class={buttonVariants({
                   variant: "link",


### PR DESCRIPTION
## Motivation

Errors reach the UI through `Effect.runPromise`, which rejects with a `FiberFailure` whose own message is generic ("An error has occurred"). TokenPage and MainPage rendered that raw message, so users saw meaningless error text. This is the remaining review follow-up from #115: typed errors never reached the display layer.

## Solution

Add `getErrorMessage`, which unwraps the `FiberFailure` to its tagged error and maps each `_tag` to human-readable text (with fallbacks for plain errors and unknown values). Render `query.error` through it in TokenPage and MainPage, and document the UI-boundary rule in `frontend/AGENTS.md`.