### PR TITLE
feat: new login system

### DIFF
--- a/frontend/src/components/wallet-header.test.tsx
+++ b/frontend/src/components/wallet-header.test.tsx
@@ -1,15 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { render, screen, waitFor, fireEvent } from "@solidjs/testing-library"
+import { render, screen, waitFor } from "@solidjs/testing-library"
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
 import type { ParentProps } from "solid-js"
 import { WalletHeader } from "./wallet-header"
 import { WalletProvider } from "@/contexts/WalletProvider"
 import { NetworkProvider } from "@/contexts/NetworkContext"
+import { encryptWalletPrivateKey } from "@/services/walletCredentialCrypto"
 
 const mockSwitchNetworkMutate = vi.fn()
 const mockSwitchNetworkMutateAsync = vi.fn()
 const mockUseWalletSettings = vi.fn()
+
+const TEST_PIN = "123456"
 
 vi.mock("@/hooks/useTrading", () => ({
   useWalletSettings: () => mockUseWalletSettings(),
@@ -179,286 +182,63 @@ describe("WalletHeader", () => {
     })
   })
 
-  describe("wallet configuration dialog", () => {
-    it("opens dialog when clicking 'No wallet configured'", async () => {
+  describe("disconnected and locked states", () => {
+    it("does not open a dialog when clicking 'No wallet configured'", async () => {
       const user = userEvent.setup()
       render(() => <WalletHeader handleDisconnect={() => {}} />, {
         wrapper: createWrapper(),
       })
 
-      const walletButton = screen.getByText("No wallet configured")
-      await user.click(walletButton)
+      await user.click(screen.getByText("No wallet configured"))
 
-      expect(screen.getByText("Connect Wallet")).toBeInTheDocument()
-      expect(
-        screen.getByText(
-          "Enter your Hyperliquid API wallet credentials to connect.",
-        ),
-      ).toBeInTheDocument()
+      expect(screen.queryByText("Connect Wallet")).not.toBeInTheDocument()
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
 
-    it("shows all credential input fields when not connected", async () => {
-      const user = userEvent.setup()
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      expect(
-        screen.getByLabelText("Hyperliquid main wallet address"),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByLabelText("Hyperliquid public API wallet address"),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByLabelText("Hyperliquid private API wallet key"),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("button", { name: "Connect" }),
-      ).toBeInTheDocument()
-    })
-
-    it("shows optional vault address field", async () => {
-      const user = userEvent.setup()
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      expect(
-        screen.getByLabelText("Vault Address (Optional)"),
-      ).toBeInTheDocument()
-    })
-
-    it("shows error toast when trying to connect with empty required fields", async () => {
-      const user = userEvent.setup()
-      const { toast } = await import("solid-sonner")
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-      await user.click(screen.getByRole("button", { name: "Connect" }))
-
-      expect(toast.error).toHaveBeenCalledWith(
-        "Please enter account address, API wallet address, and private key",
+    it("shows formatted address when wallet is locked", async () => {
+      const encrypted = await encryptWalletPrivateKey(
+        "0xMyPrivateKey",
+        TEST_PIN,
       )
-    })
-
-    it("connects wallet when valid credentials are provided", async () => {
-      const user = userEvent.setup()
-      const { toast } = await import("solid-sonner")
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      const accountAddressInput = screen.getByLabelText(
-        "Hyperliquid main wallet address",
-      )
-      const apiWalletAddressInput = screen.getByLabelText(
-        "Hyperliquid public API wallet address",
-      )
-      const privateKeyInput = screen.getByLabelText(
-        "Hyperliquid private API wallet key",
-      )
-
-      await user.type(accountAddressInput, "0xMyAccountAddress")
-      await user.type(apiWalletAddressInput, "0xMyApiWalletAddress")
-      await user.type(privateKeyInput, "0xMyPrivateKey")
-      await user.click(screen.getByRole("button", { name: "Connect" }))
-
-      expect(toast.success).toHaveBeenCalledWith("Wallet connected")
-
-      const stored = localStorage.getItem("hyperliquid-wallet")
-      expect(stored).not.toBeNull()
-      const parsed = JSON.parse(stored ?? "{}")
-      expect(parsed).toEqual({
-        accountAddress: "0xMyAccountAddress",
-        apiWalletAddress: "0xMyApiWalletAddress",
-      })
-      expect(parsed.privateKey).toBeUndefined()
-    }, 15000)
-
-    it("stores vault address when provided", async () => {
-      const user = userEvent.setup()
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      const accountAddressInput = screen.getByLabelText(
-        "Hyperliquid main wallet address",
-      )
-      const apiWalletAddressInput = screen.getByLabelText(
-        "Hyperliquid public API wallet address",
-      )
-      const privateKeyInput = screen.getByLabelText(
-        "Hyperliquid private API wallet key",
-      )
-      const vaultAddressInput = screen.getByLabelText(
-        "Vault Address (Optional)",
-      )
-
-      await user.type(accountAddressInput, "0xMyAccountAddress")
-      await user.type(apiWalletAddressInput, "0xMyApiWalletAddress")
-      await user.type(privateKeyInput, "0xMyPrivateKey")
-      await user.type(vaultAddressInput, "0xMyVaultAddress")
-      await user.click(screen.getByRole("button", { name: "Connect" }))
-
-      const stored = localStorage.getItem("hyperliquid-wallet")
-      expect(stored).not.toBeNull()
-      const parsed = JSON.parse(stored ?? "{}")
-      expect(parsed).toEqual({
-        accountAddress: "0xMyAccountAddress",
-        apiWalletAddress: "0xMyApiWalletAddress",
-        vaultAddress: "0xMyVaultAddress",
-      })
-      expect(parsed.privateKey).toBeUndefined()
-    }, 15000)
-
-    it("connects without vault address when not provided", async () => {
-      const user = userEvent.setup()
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      const accountAddressInput = screen.getByLabelText(
-        "Hyperliquid main wallet address",
-      )
-      const apiWalletAddressInput = screen.getByLabelText(
-        "Hyperliquid public API wallet address",
-      )
-      const privateKeyInput = screen.getByLabelText(
-        "Hyperliquid private API wallet key",
-      )
-
-      await user.type(accountAddressInput, "0xMyAccountAddress")
-      await user.type(apiWalletAddressInput, "0xMyApiWalletAddress")
-      await user.type(privateKeyInput, "0xMyPrivateKey")
-      await user.click(screen.getByRole("button", { name: "Connect" }))
-
-      const stored = localStorage.getItem("hyperliquid-wallet")
-      expect(stored).not.toBeNull()
-      const parsed = JSON.parse(stored ?? "{}")
-      expect(parsed.vaultAddress).toBeUndefined()
-    }, 10000)
-
-    it("closes dialog after successful connection", async () => {
-      const user = userEvent.setup()
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      const accountAddressInput = screen.getByLabelText(
-        "Hyperliquid main wallet address",
-      )
-      const apiWalletAddressInput = screen.getByLabelText(
-        "Hyperliquid public API wallet address",
-      )
-      const privateKeyInput = screen.getByLabelText(
-        "Hyperliquid private API wallet key",
-      )
-
-      await user.type(accountAddressInput, "0xMyAccountAddress")
-      await user.type(apiWalletAddressInput, "0xMyApiWalletAddress")
-      await user.type(privateKeyInput, "0xMyPrivateKey")
-      await user.click(screen.getByRole("button", { name: "Connect" }))
-
-      // Kobalte keeps dialog content mounted during close animation;
-      // jsdom never fires animationend, so check data-closed instead of DOM absence.
-      await waitFor(() => {
-        const dialog = screen.queryByRole("dialog")
-        if (dialog) {
-          expect(dialog).toHaveAttribute("data-closed")
-        }
-      })
-    }, 20000)
-
-    it("clears input fields after successful connection", async () => {
-      const user = userEvent.setup()
-      render(() => <WalletHeader handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await user.click(screen.getByText("No wallet configured"))
-
-      const accountAddressInput = screen.getByLabelText(
-        "Hyperliquid main wallet address",
-      )
-      const apiWalletAddressInput = screen.getByLabelText(
-        "Hyperliquid public API wallet address",
-      )
-      const privateKeyInput = screen.getByLabelText(
-        "Hyperliquid private API wallet key",
-      )
-
-      await user.type(accountAddressInput, "0xMyAccountAddress")
-      await user.type(apiWalletAddressInput, "0xMyApiWalletAddress")
-      await user.type(privateKeyInput, "0xMyPrivateKey")
-      await user.click(screen.getByRole("button", { name: "Connect" }))
-
-      // Wait for dialog to enter closed state (jsdom: animationend never fires)
-      await waitFor(() => {
-        const dialog = screen.queryByRole("dialog")
-        if (dialog) {
-          expect(dialog).toHaveAttribute("data-closed")
-        }
-      })
-
-      // In jsdom, Kobalte's closed overlay blocks pointer events because CSS
-      // animations never complete. Use fireEvent to bypass this jsdom limitation.
-      fireEvent.click(screen.getByText("No wallet configured"))
-
-      const newAccountAddressInput = screen.getByLabelText(
-        "Hyperliquid main wallet address",
-      )
-      const newApiWalletAddressInput = screen.getByLabelText(
-        "Hyperliquid public API wallet address",
-      )
-      const newPrivateKeyInput = screen.getByLabelText(
-        "Hyperliquid private API wallet key",
-      )
-
-      expect(newAccountAddressInput).toHaveValue("")
-      expect(newApiWalletAddressInput).toHaveValue("")
-      expect(newPrivateKeyInput).toHaveValue("")
-    }, 20000)
-
-    it("auto-opens dialog when autoOpen prop is true and not connected", async () => {
-      render(() => <WalletHeader autoOpen handleDisconnect={() => {}} />, {
-        wrapper: createWrapper(),
-      })
-
-      await waitFor(() => {
-        expect(screen.getByText("Connect Wallet")).toBeInTheDocument()
-      })
-    })
-
-    it("does not auto-open dialog when connected even with autoOpen prop", async () => {
-      mockUseWalletSettings.mockReturnValue({
-        data: () => ({
-          accountAddress: "0xConnectedAccountAddress",
-          isTestnet: true,
+      localStorage.setItem(
+        "hyperliquid-wallet",
+        JSON.stringify({
+          accountAddress: "0xLockedAccountAddress",
+          apiWalletAddress: "0xLockedApiWalletAddress",
+          ...encrypted,
         }),
-        isConnected: () => true,
-      })
+      )
 
-      render(() => <WalletHeader autoOpen handleDisconnect={() => {}} />, {
+      render(() => <WalletHeader handleDisconnect={() => {}} />, {
         wrapper: createWrapper(),
       })
 
-      await waitFor(() => {
-        expect(screen.queryByText("Connect Wallet")).not.toBeInTheDocument()
+      expect(screen.getByText("0xLock...ress")).toBeInTheDocument()
+    })
+
+    it("does not open unlock dialog when clicking locked address", async () => {
+      const user = userEvent.setup()
+      const encrypted = await encryptWalletPrivateKey(
+        "0xMyPrivateKey",
+        TEST_PIN,
+      )
+      localStorage.setItem(
+        "hyperliquid-wallet",
+        JSON.stringify({
+          accountAddress: "0xLockedAccountAddress",
+          apiWalletAddress: "0xLockedApiWalletAddress",
+          ...encrypted,
+        }),
+      )
+
+      render(() => <WalletHeader handleDisconnect={() => {}} />, {
+        wrapper: createWrapper(),
       })
+
+      await user.click(screen.getByText("0xLock...ress"))
+
+      expect(screen.queryByText("Unlock Wallet")).not.toBeInTheDocument()
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
   })
 
@@ -592,14 +372,15 @@ describe("WalletHeader", () => {
     })
   })
 
-  describe("wallet button styling", () => {
-    it("has hover styling to indicate clickability", () => {
+  describe("wallet status styling", () => {
+    it("renders disconnected state as non-interactive text", () => {
       render(() => <WalletHeader handleDisconnect={() => {}} />, {
         wrapper: createWrapper(),
       })
 
-      const walletButton = screen.getByText("No wallet configured")
-      expect(walletButton).toHaveClass("cursor-pointer")
+      const walletStatus = screen.getByText("No wallet configured")
+      expect(walletStatus.tagName).toBe("SPAN")
+      expect(walletStatus).not.toHaveClass("cursor-pointer")
     })
   })
 })

--- a/frontend/src/components/wallet-header.tsx
+++ b/frontend/src/components/wallet-header.tsx
@@ -1,16 +1,6 @@
-import { createSignal, createEffect, Show } from "solid-js"
+import { Show, createSignal } from "solid-js"
 import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-  DialogTrigger,
-} from "@/components/ui/dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +9,7 @@ import {
 import { useWalletSettings, useSwitchNetwork } from "@/hooks/useTrading"
 import { useNetwork } from "@/hooks/useNetwork"
 import { useWallet } from "@/hooks/useWallet"
+import { getStoredEncryptedSession } from "@/contexts/wallet-context"
 import { toast } from "solid-sonner"
 
 const formatPublicKey = (key: string): string => {
@@ -29,8 +20,10 @@ const formatPublicKey = (key: string): string => {
   return `${key.slice(0, 4)}...${key.slice(-4)}`
 }
 
+const walletStatusClass =
+  "rounded-md border border-border px-3 py-1.5 font-mono text-[11px] text-muted-foreground"
+
 interface WalletHeaderProps {
-  autoOpen?: boolean
   handleDisconnect?: () => void
   handleNetworkSwitch?: () => void
 }
@@ -39,25 +32,8 @@ export const WalletHeader = (props: WalletHeaderProps) => {
   const { data: walletSettings, isConnected } = useWalletSettings()
   const switchNetworkMutation = useSwitchNetwork()
   const { isNetworkSwitching, setIsNetworkSwitching } = useNetwork()
-  const { connect, disconnect } = useWallet()
-
-  const [dialogOpen, setDialogOpen] = createSignal(false)
-  const [accountAddress, setAccountAddress] = createSignal("")
-  const [apiWalletAddress, setApiWalletAddress] = createSignal("")
-  const [privateKey, setPrivateKey] = createSignal("")
-  const [vaultAddress, setVaultAddress] = createSignal("")
-  const [hasAutoOpened, setHasAutoOpened] = createSignal(false)
+  const { disconnect, isLocked } = useWallet()
   const [menuOpen, setMenuOpen] = createSignal(false)
-
-  // Auto-open the dialog once on mount when autoOpen is true and no wallet is
-  // connected. The hasAutoOpened flag prevents re-triggering on later
-  // disconnects.
-  createEffect(() => {
-    if (props.autoOpen && !isConnected() && !hasAutoOpened()) {
-      setDialogOpen(true)
-      setHasAutoOpened(true)
-    }
-  })
 
   const handleTestnetToggle = async (checked: boolean) => {
     if (!isConnected()) {
@@ -82,46 +58,12 @@ export const WalletHeader = (props: WalletHeaderProps) => {
     }
   }
 
-  const handleConnect = () => {
-    if (
-      !accountAddress().trim() ||
-      !apiWalletAddress().trim() ||
-      !privateKey().trim()
-    ) {
-      toast.error(
-        "Please enter account address, API wallet address, and private key",
-      )
-      return
-    }
-
-    const credentials: {
-      accountAddress: string
-      apiWalletAddress: string
-      privateKey: string
-      vaultAddress?: string
-    } = {
-      accountAddress: accountAddress().trim(),
-      apiWalletAddress: apiWalletAddress().trim(),
-      privateKey: privateKey().trim(),
-    }
-
-    if (vaultAddress().trim()) {
-      credentials.vaultAddress = vaultAddress().trim()
-    }
-
-    connect(credentials)
-    setDialogOpen(false)
-    setAccountAddress("")
-    setApiWalletAddress("")
-    setPrivateKey("")
-    setVaultAddress("")
-    toast.success("Wallet connected")
-  }
+  const lockedAccountAddress = () =>
+    getStoredEncryptedSession()?.accountAddress ?? ""
 
   const onDisconnectClick = () => {
     props.handleDisconnect?.()
     disconnect()
-    setDialogOpen(false)
     setMenuOpen(false)
     toast.success("Wallet disconnected")
   }
@@ -155,89 +97,24 @@ export const WalletHeader = (props: WalletHeaderProps) => {
       <Show
         when={isConnected()}
         fallback={
-          <Dialog open={dialogOpen()} onOpenChange={setDialogOpen}>
-            <DialogTrigger
-              as="button"
-              class="cursor-pointer rounded-md border border-border px-3 py-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:border-foreground/50 hover:text-foreground"
-            >
-              {currentAccountAddress()
-                ? formatPublicKey(currentAccountAddress())
-                : "No wallet configured"}
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Connect Wallet</DialogTitle>
-                <DialogDescription>
-                  Enter your Hyperliquid API wallet credentials to connect.
-                </DialogDescription>
-              </DialogHeader>
-
-              <div class="space-y-4 text-[12px]">
-                <div class="space-y-2">
-                  <label for="accountAddress" class="font-medium">
-                    Hyperliquid main wallet address
-                  </label>
-                  <Input
-                    id="accountAddress"
-                    placeholder="0x..."
-                    value={accountAddress()}
-                    onInput={event => {
-                      setAccountAddress(event.currentTarget.value)
-                    }}
-                  />
-                </div>
-                <div class="space-y-2">
-                  <label for="apiWalletAddress" class="font-medium">
-                    Hyperliquid public API wallet address
-                  </label>
-                  <Input
-                    id="apiWalletAddress"
-                    placeholder="0x..."
-                    value={apiWalletAddress()}
-                    onInput={event => {
-                      setApiWalletAddress(event.currentTarget.value)
-                    }}
-                  />
-                </div>
-                <div class="space-y-2">
-                  <label for="privateKey" class="font-medium">
-                    Hyperliquid private API wallet key
-                  </label>
-                  <Input
-                    id="privateKey"
-                    type="password"
-                    placeholder="0x..."
-                    value={privateKey()}
-                    onInput={event => {
-                      setPrivateKey(event.currentTarget.value)
-                    }}
-                  />
-                </div>
-                <div class="space-y-2">
-                  <label for="vaultAddress" class="font-medium">
-                    Vault Address (Optional)
-                  </label>
-                  <Input
-                    id="vaultAddress"
-                    placeholder="0x... (leave empty for personal trading)"
-                    value={vaultAddress()}
-                    onInput={event => {
-                      setVaultAddress(event.currentTarget.value)
-                    }}
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button onClick={handleConnect}>Connect</Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <Show
+            when={isLocked()}
+            fallback={
+              <span class={walletStatusClass}>No wallet configured</span>
+            }
+          >
+            <span class={walletStatusClass}>
+              {lockedAccountAddress()
+                ? formatPublicKey(lockedAccountAddress())
+                : "Wallet locked"}
+            </span>
+          </Show>
         }
       >
         <DropdownMenu open={menuOpen()} onOpenChange={setMenuOpen}>
           <DropdownMenuTrigger
             as="button"
-            class="cursor-pointer rounded-md border border-border px-3 py-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:border-foreground/50 hover:text-foreground"
+            class={`${walletStatusClass} cursor-pointer transition-colors hover:border-foreground/50 hover:text-foreground`}
           >
             {currentAccountAddress()
               ? formatPublicKey(currentAccountAddress())

--- a/frontend/src/contexts/WalletProvider.tsx
+++ b/frontend/src/contexts/WalletProvider.tsx
@@ -15,10 +15,19 @@ import {
   type NetworkMode,
   type WalletCredentials,
 } from "./wallet-context"
+import * as Effect from "effect/Effect"
+import {
+  WalletConnectError,
+  WalletIncorrectPin,
+  WalletSessionMissing,
+  WalletUnlockError,
+  type WalletUnlockFailure,
+} from "@/services/wallet"
 import { HyperliquidClient } from "@/services/hyperliquid-client"
 import {
   decryptWalletPrivateKey,
   encryptWalletPrivateKey,
+  WalletCredentialDecryptError,
 } from "@/services/walletCredentialCrypto"
 
 const credentialsFromSession = (
@@ -73,32 +82,52 @@ export const WalletProvider = (props: ParentProps) => {
     return new HyperliquidClient(creds, networkMode())
   })
 
-  const connect = async (
+  const connect = (
     newCredentials: WalletCredentials,
     pin: string,
-  ): Promise<void> => {
-    const encrypted = await encryptWalletPrivateKey(
-      newCredentials.privateKey,
-      pin,
+  ): Effect.Effect<void, WalletConnectError> =>
+    Effect.tryPromise({
+      try: () => encryptWalletPrivateKey(newCredentials.privateKey, pin),
+      catch: cause => new WalletConnectError({ cause }),
+    }).pipe(
+      Effect.tap(encrypted =>
+        Effect.sync(() => {
+          persistEncryptedSession(newCredentials, encrypted)
+          setCredentials(newCredentials)
+          syncStoredSessionState()
+        }),
+      ),
+      Effect.asVoid,
     )
-    persistEncryptedSession(newCredentials, encrypted)
-    setCredentials(newCredentials)
-    syncStoredSessionState()
-  }
 
-  const unlock = async (pin: string): Promise<void> => {
+  const unlock = (pin: string): Effect.Effect<void, WalletUnlockFailure> => {
     const session = getStoredEncryptedSession()
     if (!session) {
-      throw new Error("no encrypted wallet session in storage")
+      return Effect.fail(new WalletSessionMissing())
     }
 
-    const privateKey = await decryptWalletPrivateKey(
-      session.encryptedPrivateKey,
-      pin,
-      session.salt,
-      session.iv,
+    return Effect.tryPromise({
+      try: () =>
+        decryptWalletPrivateKey(
+          session.encryptedPrivateKey,
+          pin,
+          session.salt,
+          session.iv,
+        ),
+      catch: cause => {
+        if (cause instanceof WalletCredentialDecryptError) {
+          return new WalletIncorrectPin()
+        }
+        return new WalletUnlockError({ cause })
+      },
+    }).pipe(
+      Effect.tap(privateKey =>
+        Effect.sync(() => {
+          setCredentials(credentialsFromSession(session, privateKey))
+        }),
+      ),
+      Effect.asVoid,
     )
-    setCredentials(credentialsFromSession(session, privateKey))
   }
 
   const disconnect = () => {

--- a/frontend/src/contexts/WalletProvider.tsx
+++ b/frontend/src/contexts/WalletProvider.tsx
@@ -9,11 +9,43 @@ import {
   WalletContext,
   WALLET_STORAGE_KEY,
   NETWORK_STORAGE_KEY,
+  getStoredEncryptedSession,
   getStoredNetworkMode,
+  type EncryptedWalletSession,
   type NetworkMode,
   type WalletCredentials,
 } from "./wallet-context"
 import { HyperliquidClient } from "@/services/hyperliquid-client"
+import {
+  decryptWalletPrivateKey,
+  encryptWalletPrivateKey,
+} from "@/services/walletCredentialCrypto"
+
+const credentialsFromSession = (
+  session: EncryptedWalletSession,
+  privateKey: string,
+): WalletCredentials => ({
+  accountAddress: session.accountAddress,
+  apiWalletAddress: session.apiWalletAddress,
+  privateKey,
+})
+
+const persistEncryptedSession = (
+  credentials: WalletCredentials,
+  encrypted: Pick<
+    EncryptedWalletSession,
+    "encryptedPrivateKey" | "salt" | "iv"
+  >,
+) => {
+  const session: EncryptedWalletSession = {
+    accountAddress: credentials.accountAddress,
+    apiWalletAddress: credentials.apiWalletAddress,
+    encryptedPrivateKey: encrypted.encryptedPrivateKey,
+    salt: encrypted.salt,
+    iv: encrypted.iv,
+  }
+  localStorage.setItem(WALLET_STORAGE_KEY, JSON.stringify(session))
+}
 
 export const WalletProvider = (props: ParentProps) => {
   const [credentials, setCredentials] = createSignal<WalletCredentials | null>(
@@ -22,8 +54,18 @@ export const WalletProvider = (props: ParentProps) => {
   const [networkMode, setNetworkModeState] = createSignal<NetworkMode>(
     getStoredNetworkMode(),
   )
+  const [hasStoredSession, setHasStoredSession] = createSignal(
+    getStoredEncryptedSession() !== null,
+  )
+
+  const syncStoredSessionState = () => {
+    setHasStoredSession(getStoredEncryptedSession() !== null)
+  }
 
   const isConnected = createMemo(() => credentials() !== null)
+  const isLocked = createMemo(
+    () => hasStoredSession() && credentials() === null,
+  )
 
   const client = createMemo(() => {
     const creds = credentials()
@@ -31,21 +73,38 @@ export const WalletProvider = (props: ParentProps) => {
     return new HyperliquidClient(creds, networkMode())
   })
 
-  const connect = (newCredentials: WalletCredentials) => {
-    setCredentials(newCredentials)
-    const { accountAddress, apiWalletAddress, vaultAddress } = newCredentials
-    // SECURITY: never persist the private key. Only public address metadata is
-    // stored, so the reconnect dialog can pre-fill it; the user re-enters the
-    // private key on reload. Credentials never leave the browser to disk.
-    localStorage.setItem(
-      WALLET_STORAGE_KEY,
-      JSON.stringify({ accountAddress, apiWalletAddress, vaultAddress }),
+  const connect = async (
+    newCredentials: WalletCredentials,
+    pin: string,
+  ): Promise<void> => {
+    const encrypted = await encryptWalletPrivateKey(
+      newCredentials.privateKey,
+      pin,
     )
+    persistEncryptedSession(newCredentials, encrypted)
+    setCredentials(newCredentials)
+    syncStoredSessionState()
+  }
+
+  const unlock = async (pin: string): Promise<void> => {
+    const session = getStoredEncryptedSession()
+    if (!session) {
+      throw new Error("no encrypted wallet session in storage")
+    }
+
+    const privateKey = await decryptWalletPrivateKey(
+      session.encryptedPrivateKey,
+      pin,
+      session.salt,
+      session.iv,
+    )
+    setCredentials(credentialsFromSession(session, privateKey))
   }
 
   const disconnect = () => {
     setCredentials(null)
     localStorage.removeItem(WALLET_STORAGE_KEY)
+    syncStoredSessionState()
   }
 
   const setNetworkMode = (mode: NetworkMode) => {
@@ -56,6 +115,7 @@ export const WalletProvider = (props: ParentProps) => {
   const handleStorageChange = (event: StorageEvent) => {
     if (event.key === WALLET_STORAGE_KEY) {
       setCredentials(null)
+      syncStoredSessionState()
     }
     if (event.key === NETWORK_STORAGE_KEY) {
       setNetworkModeState(getStoredNetworkMode())
@@ -63,9 +123,6 @@ export const WalletProvider = (props: ParentProps) => {
   }
 
   onMount(() => {
-    // The private key is never persisted, so a full session cannot be restored
-    // on mount; the reconnect dialog pre-fills the stored public metadata and
-    // the user re-enters the key. Only wire the cross-tab storage listener.
     window.addEventListener("storage", handleStorageChange)
   })
   onCleanup(() => {
@@ -78,8 +135,11 @@ export const WalletProvider = (props: ParentProps) => {
         credentials,
         networkMode,
         isConnected,
+        isLocked,
+        hasStoredSession,
         client,
         connect,
+        unlock,
         disconnect,
         setNetworkMode,
       }}

--- a/frontend/src/contexts/WalletProvider.tsx
+++ b/frontend/src/contexts/WalletProvider.tsx
@@ -18,16 +18,13 @@ import {
 import * as Effect from "effect/Effect"
 import {
   WalletConnectError,
-  WalletIncorrectPin,
   WalletSessionMissing,
-  WalletUnlockError,
   type WalletUnlockFailure,
 } from "@/services/wallet"
 import { HyperliquidClient } from "@/services/hyperliquid-client"
 import {
   decryptWalletPrivateKey,
   encryptWalletPrivateKey,
-  WalletCredentialDecryptError,
 } from "@/services/walletCredentialCrypto"
 
 const credentialsFromSession = (
@@ -106,21 +103,12 @@ export const WalletProvider = (props: ParentProps) => {
       return Effect.fail(new WalletSessionMissing())
     }
 
-    return Effect.tryPromise({
-      try: () =>
-        decryptWalletPrivateKey(
-          session.encryptedPrivateKey,
-          pin,
-          session.salt,
-          session.iv,
-        ),
-      catch: cause => {
-        if (cause instanceof WalletCredentialDecryptError) {
-          return new WalletIncorrectPin()
-        }
-        return new WalletUnlockError({ cause })
-      },
-    }).pipe(
+    return decryptWalletPrivateKey(
+      session.encryptedPrivateKey,
+      pin,
+      session.salt,
+      session.iv,
+    ).pipe(
       Effect.tap(privateKey =>
         Effect.sync(() => {
           setCredentials(credentialsFromSession(session, privateKey))

--- a/frontend/src/contexts/wallet-context.ts
+++ b/frontend/src/contexts/wallet-context.ts
@@ -42,6 +42,16 @@ export interface EncryptedWalletSession {
   iv: string
 }
 
+const HEX_ENCODING_PATTERN = /^[0-9a-fA-F]+$/
+const SALT_BYTE_LENGTH = 16
+const IV_BYTE_LENGTH = 12
+
+const isHexEncoding = (value: string): boolean =>
+  value.length > 0 && HEX_ENCODING_PATTERN.test(value)
+
+const isFixedLengthHex = (value: string, byteLength: number): boolean =>
+  value.length === byteLength * 2 && isHexEncoding(value)
+
 const isEncryptedSession = (
   value: unknown,
 ): value is EncryptedWalletSession => {
@@ -51,17 +61,25 @@ const isEncryptedSession = (
 
   const sessionCandidate = value as Record<string, unknown>
 
+  if (
+    typeof sessionCandidate.accountAddress !== "string" ||
+    sessionCandidate.accountAddress === "" ||
+    typeof sessionCandidate.apiWalletAddress !== "string" ||
+    sessionCandidate.apiWalletAddress === "" ||
+    typeof sessionCandidate.encryptedPrivateKey !== "string" ||
+    typeof sessionCandidate.salt !== "string" ||
+    typeof sessionCandidate.iv !== "string"
+  ) {
+    return false
+  }
+
+  const { encryptedPrivateKey, salt, iv } = sessionCandidate
+
   return (
-    typeof sessionCandidate.accountAddress === "string" &&
-    sessionCandidate.accountAddress !== "" &&
-    typeof sessionCandidate.apiWalletAddress === "string" &&
-    sessionCandidate.apiWalletAddress !== "" &&
-    typeof sessionCandidate.encryptedPrivateKey === "string" &&
-    sessionCandidate.encryptedPrivateKey !== "" &&
-    typeof sessionCandidate.salt === "string" &&
-    sessionCandidate.salt !== "" &&
-    typeof sessionCandidate.iv === "string" &&
-    sessionCandidate.iv !== ""
+    isHexEncoding(encryptedPrivateKey) &&
+    encryptedPrivateKey.length % 2 === 0 &&
+    isFixedLengthHex(salt, SALT_BYTE_LENGTH) &&
+    isFixedLengthHex(iv, IV_BYTE_LENGTH)
   )
 }
 

--- a/frontend/src/contexts/wallet-context.ts
+++ b/frontend/src/contexts/wallet-context.ts
@@ -1,5 +1,7 @@
 import { createContext, type Accessor } from "solid-js"
+import type * as Effect from "effect/Effect"
 import type { HyperliquidClient } from "@/services/hyperliquid-client"
+import type { WalletConnectError, WalletUnlockFailure } from "@/services/wallet"
 
 export type NetworkMode = "testnet" | "mainnet"
 
@@ -16,8 +18,11 @@ export interface WalletContextType {
   isLocked: Accessor<boolean>
   hasStoredSession: Accessor<boolean>
   client: Accessor<HyperliquidClient | null>
-  connect: (credentials: WalletCredentials, pin: string) => Promise<void>
-  unlock: (pin: string) => Promise<void>
+  connect: (
+    credentials: WalletCredentials,
+    pin: string,
+  ) => Effect.Effect<void, WalletConnectError>
+  unlock: (pin: string) => Effect.Effect<void, WalletUnlockFailure>
   disconnect: () => void
   setNetworkMode: (mode: NetworkMode) => void
 }

--- a/frontend/src/contexts/wallet-context.ts
+++ b/frontend/src/contexts/wallet-context.ts
@@ -7,15 +7,17 @@ export interface WalletCredentials {
   accountAddress: string // Main wallet where positions/funds are
   apiWalletAddress: string // API wallet authorized to trade
   privateKey: string // Private key of the API wallet
-  vaultAddress?: string // Optional vault to trade on behalf of
 }
 
 export interface WalletContextType {
   credentials: Accessor<WalletCredentials | null>
   networkMode: Accessor<NetworkMode>
   isConnected: Accessor<boolean>
+  isLocked: Accessor<boolean>
+  hasStoredSession: Accessor<boolean>
   client: Accessor<HyperliquidClient | null>
-  connect: (credentials: WalletCredentials) => void
+  connect: (credentials: WalletCredentials, pin: string) => Promise<void>
+  unlock: (pin: string) => Promise<void>
   disconnect: () => void
   setNetworkMode: (mode: NetworkMode) => void
 }
@@ -27,28 +29,61 @@ export const WalletContext = createContext<WalletContextType | undefined>(
 export const WALLET_STORAGE_KEY = "hyperliquid-wallet"
 export const NETWORK_STORAGE_KEY = "hyperliquid-network"
 
-export interface StoredWalletMetadata {
+export interface EncryptedWalletSession {
   accountAddress: string
   apiWalletAddress: string
-  privateKey?: string
-  vaultAddress?: string
+  encryptedPrivateKey: string
+  salt: string
+  iv: string
 }
 
-export const getStoredWalletMetadata = (): StoredWalletMetadata | null => {
-  const stored = localStorage.getItem(WALLET_STORAGE_KEY)
-  if (!stored) return null
+const isEncryptedSession = (
+  value: unknown,
+): value is EncryptedWalletSession => {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const sessionCandidate = value as Record<string, unknown>
+
+  return (
+    typeof sessionCandidate.accountAddress === "string" &&
+    sessionCandidate.accountAddress !== "" &&
+    typeof sessionCandidate.apiWalletAddress === "string" &&
+    sessionCandidate.apiWalletAddress !== "" &&
+    typeof sessionCandidate.encryptedPrivateKey === "string" &&
+    sessionCandidate.encryptedPrivateKey !== "" &&
+    typeof sessionCandidate.salt === "string" &&
+    sessionCandidate.salt !== "" &&
+    typeof sessionCandidate.iv === "string" &&
+    sessionCandidate.iv !== ""
+  )
+}
+
+export const getStoredEncryptedSession = (): EncryptedWalletSession | null => {
   try {
-    const parsed = JSON.parse(stored) as StoredWalletMetadata
-    if (parsed.accountAddress && parsed.apiWalletAddress) {
-      return parsed
-    }
-    return null
+    const stored = localStorage.getItem(WALLET_STORAGE_KEY)
+    if (!stored) return null
+
+    const parsed: unknown = JSON.parse(stored)
+    return isEncryptedSession(parsed) ? parsed : null
   } catch {
     return null
   }
 }
 
-export const getStoredWallet = getStoredWalletMetadata
+export const getStoredWalletAddresses = (): Pick<
+  EncryptedWalletSession,
+  "accountAddress" | "apiWalletAddress"
+> | null => {
+  const session = getStoredEncryptedSession()
+  if (!session) return null
+
+  return {
+    accountAddress: session.accountAddress,
+    apiWalletAddress: session.apiWalletAddress,
+  }
+}
 
 export const getStoredNetworkMode = (): NetworkMode => {
   const stored = localStorage.getItem(NETWORK_STORAGE_KEY)

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as Effect from "effect/Effect"
 import { renderHook, waitFor } from "@solidjs/testing-library"
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
 import type { ParentProps } from "solid-js"
@@ -90,7 +91,7 @@ const createConnectedWrapper = (walletCredentials: {
   const ConnectOnMount = (props: ParentProps) => {
     const { connect } = useWallet()
     onMount(() => {
-      void connect(walletCredentials, TEST_PIN)
+      void Effect.runPromise(connect(walletCredentials, TEST_PIN))
     })
     return <>{props.children}</>
   }

--- a/frontend/src/hooks/useTrading.test.tsx
+++ b/frontend/src/hooks/useTrading.test.tsx
@@ -71,11 +71,18 @@ const createWrapper = () => {
   )
 }
 
+const TEST_PIN = "123456"
+
+const waitUntilWalletConnected = async (isConnected: () => boolean) => {
+  await waitFor(() => {
+    expect(isConnected()).toBe(true)
+  })
+}
+
 const createConnectedWrapper = (walletCredentials: {
   accountAddress: string
   apiWalletAddress: string
   privateKey: string
-  vaultAddress?: string
 }) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -83,7 +90,7 @@ const createConnectedWrapper = (walletCredentials: {
   const ConnectOnMount = (props: ParentProps) => {
     const { connect } = useWallet()
     onMount(() => {
-      connect(walletCredentials)
+      void connect(walletCredentials, TEST_PIN)
     })
     return <>{props.children}</>
   }
@@ -159,7 +166,7 @@ describe("useTrading hooks", () => {
       expect(result.isConnected()).toBe(false)
     })
 
-    it("returns client when wallet is connected", () => {
+    it("returns client when wallet is connected", async () => {
       const { result } = renderHook(() => useHyperliquidClient(), {
         wrapper: createConnectedWrapper({
           accountAddress: "0xTestAccountAddress",
@@ -168,11 +175,12 @@ describe("useTrading hooks", () => {
         }),
       })
 
+      await waitUntilWalletConnected(() => result.isConnected())
+
       expect(result.client()).not.toBeNull()
-      expect(result.isConnected()).toBe(true)
     })
 
-    it("returns correct network mode", () => {
+    it("returns correct network mode", async () => {
       localStorage.setItem("hyperliquid-network", "mainnet")
 
       const { result } = renderHook(() => useHyperliquidClient(), {
@@ -182,6 +190,8 @@ describe("useTrading hooks", () => {
           privateKey: "0xTestSecret",
         }),
       })
+
+      await waitUntilWalletConnected(() => result.isConnected())
 
       expect(result.networkMode()).toBe("mainnet")
     })
@@ -200,19 +210,28 @@ describe("useTrading hooks", () => {
     it("fetches balance when wallet is connected", async () => {
       mockMethods.getBalance.mockResolvedValue(1500.5)
 
-      const { result } = renderHook(() => useHyperliquidBalance(), {
-        wrapper: createConnectedWrapper({
-          accountAddress: "0xTestAccountAddress",
-          apiWalletAddress: "0xTestApiWallet",
-          privateKey: "0xTestSecret",
-        }),
-      })
+      const { result } = renderHook(
+        () => {
+          const wallet = useHyperliquidClient()
+          const balance = useHyperliquidBalance()
+          return { wallet, balance }
+        },
+        {
+          wrapper: createConnectedWrapper({
+            accountAddress: "0xTestAccountAddress",
+            apiWalletAddress: "0xTestApiWallet",
+            privateKey: "0xTestSecret",
+          }),
+        },
+      )
+
+      await waitUntilWalletConnected(() => result.wallet.isConnected())
 
       await waitFor(() => {
-        expect(result.isSuccess).toBe(true)
+        expect(result.balance.isSuccess).toBe(true)
       })
 
-      expect(result.data).toBe(1500.5)
+      expect(result.balance.data).toBe(1500.5)
     })
   })
 
@@ -246,22 +265,31 @@ describe("useTrading hooks", () => {
         },
       ])
 
-      const { result } = renderHook(() => useHyperliquidPositions(), {
-        wrapper: createConnectedWrapper({
-          accountAddress: "0xTestAccountAddress",
-          apiWalletAddress: "0xTestApiWallet",
-          privateKey: "0xTestSecret",
-        }),
-      })
+      const { result } = renderHook(
+        () => {
+          const wallet = useHyperliquidClient()
+          const positions = useHyperliquidPositions()
+          return { wallet, positions }
+        },
+        {
+          wrapper: createConnectedWrapper({
+            accountAddress: "0xTestAccountAddress",
+            apiWalletAddress: "0xTestApiWallet",
+            privateKey: "0xTestSecret",
+          }),
+        },
+      )
+
+      await waitUntilWalletConnected(() => result.wallet.isConnected())
 
       await waitFor(() => {
-        expect(result.isSuccess).toBe(true)
+        expect(result.positions.isSuccess).toBe(true)
       })
 
-      expect(result.data?.positions).toHaveLength(2)
-      expect(result.data?.totalNotional).toBe(1000)
-      expect(result.data?.positions[0].percentage).toBe(50)
-      expect(result.data?.positions[1].percentage).toBe(50)
+      expect(result.positions.data?.positions).toHaveLength(2)
+      expect(result.positions.data?.totalNotional).toBe(1000)
+      expect(result.positions.data?.positions[0].percentage).toBe(50)
+      expect(result.positions.data?.positions[1].percentage).toBe(50)
     })
   })
 
@@ -334,15 +362,24 @@ describe("useTrading hooks", () => {
         },
       ])
 
-      const { result } = renderHook(() => useRebalanceHyperliquidPositions(), {
-        wrapper: createConnectedWrapper({
-          accountAddress: "0xTestAccountAddress",
-          apiWalletAddress: "0xTestApiWallet",
-          privateKey: "0xTestSecret",
-        }),
-      })
+      const { result } = renderHook(
+        () => {
+          const wallet = useHyperliquidClient()
+          const rebalance = useRebalanceHyperliquidPositions()
+          return { wallet, rebalance }
+        },
+        {
+          wrapper: createConnectedWrapper({
+            accountAddress: "0xTestAccountAddress",
+            apiWalletAddress: "0xTestApiWallet",
+            privateKey: "0xTestSecret",
+          }),
+        },
+      )
 
-      result.mutate({
+      await waitUntilWalletConnected(() => result.wallet.isConnected())
+
+      result.rebalance.mutate({
         actions: [
           {
             kind: "rebalance",
@@ -355,7 +392,7 @@ describe("useTrading hooks", () => {
       })
 
       await waitFor(() => {
-        expect(result.isSuccess).toBe(true)
+        expect(result.rebalance.isSuccess).toBe(true)
       })
 
       expect(mockMethods.rebalancePositions).toHaveBeenCalledWith([
@@ -368,8 +405,8 @@ describe("useTrading hooks", () => {
         },
       ])
 
-      expect(result.data?.orders).toHaveLength(1)
-      expect(result.data?.orders[0].status).toBe("filled")
+      expect(result.rebalance.data?.orders).toHaveLength(1)
+      expect(result.rebalance.data?.orders[0].status).toBe("filled")
     })
 
     it("calls rebalancePositions with only the actions array (no separate precise arg)", async () => {
@@ -377,15 +414,24 @@ describe("useTrading hooks", () => {
         { symbol: "ETH/USDC:USDC", side: "sell", status: "working" },
       ])
 
-      const { result } = renderHook(() => useRebalanceHyperliquidPositions(), {
-        wrapper: createConnectedWrapper({
-          accountAddress: "0xTestAccountAddress",
-          apiWalletAddress: "0xTestApiWallet",
-          privateKey: "0xTestSecret",
-        }),
-      })
+      const { result } = renderHook(
+        () => {
+          const wallet = useHyperliquidClient()
+          const rebalance = useRebalanceHyperliquidPositions()
+          return { wallet, rebalance }
+        },
+        {
+          wrapper: createConnectedWrapper({
+            accountAddress: "0xTestAccountAddress",
+            apiWalletAddress: "0xTestApiWallet",
+            privateKey: "0xTestSecret",
+          }),
+        },
+      )
 
-      result.mutate({
+      await waitUntilWalletConnected(() => result.wallet.isConnected())
+
+      result.rebalance.mutate({
         actions: [
           {
             kind: "close",
@@ -396,7 +442,7 @@ describe("useTrading hooks", () => {
       })
 
       await waitFor(() => {
-        expect(result.isSuccess).toBe(true)
+        expect(result.rebalance.isSuccess).toBe(true)
       })
 
       expect(mockMethods.rebalancePositions).toHaveBeenCalledWith([
@@ -420,7 +466,7 @@ describe("useTrading hooks", () => {
       expect(result.isConnected()).toBe(false)
     })
 
-    it("returns wallet settings when connected", () => {
+    it("returns wallet settings when connected", async () => {
       localStorage.setItem("hyperliquid-network", "testnet")
 
       const { result } = renderHook(() => useWalletSettings(), {
@@ -431,12 +477,13 @@ describe("useTrading hooks", () => {
         }),
       })
 
+      await waitUntilWalletConnected(() => result.isConnected())
+
       expect(result.data()?.accountAddress).toBe("0xMyAccountAddress")
       expect(result.data()?.isTestnet).toBe(true)
-      expect(result.isConnected()).toBe(true)
     })
 
-    it("returns mainnet when network is mainnet", () => {
+    it("returns mainnet when network is mainnet", async () => {
       localStorage.setItem("hyperliquid-network", "mainnet")
 
       const { result } = renderHook(() => useWalletSettings(), {
@@ -446,6 +493,8 @@ describe("useTrading hooks", () => {
           privateKey: "0xMySecret",
         }),
       })
+
+      await waitUntilWalletConnected(() => result.isConnected())
 
       expect(result.data()?.isTestnet).toBe(false)
     })

--- a/frontend/src/hooks/useWallet.test.tsx
+++ b/frontend/src/hooks/useWallet.test.tsx
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import * as Effect from "effect/Effect"
 import { renderHook } from "@solidjs/testing-library"
 import { useWallet } from "./useWallet"
 import { WalletProvider } from "@/contexts/WalletProvider"
 import type { ParentProps } from "solid-js"
-import { WalletCredentialDecryptError } from "@/services/walletCredentialCrypto"
+import { getErrorMessage } from "@/lib/error-message"
 
 vi.mock("@/services/hyperliquid-client", () => ({
   HyperliquidClient: class MockHyperliquidClient {
@@ -118,7 +119,7 @@ describe("useWallet", () => {
       privateKey: "TEST_PRIVATE_KEY_PLACEHOLDER",
     }
 
-    await result.connect(credentials, TEST_PIN)
+    await Effect.runPromise(result.connect(credentials, TEST_PIN))
 
     expect(result.isConnected()).toBe(true)
     expect(result.credentials()).toEqual(credentials)
@@ -148,13 +149,13 @@ describe("useWallet", () => {
     }
 
     const { result: initial } = renderHook(() => useWallet(), { wrapper })
-    await initial.connect(credentials, TEST_PIN)
+    await Effect.runPromise(initial.connect(credentials, TEST_PIN))
     expect(localStorage.getItem("hyperliquid-wallet")).not.toBeNull()
 
     const { result: reloaded } = renderHook(() => useWallet(), { wrapper })
     expect(reloaded.isLocked()).toBe(true)
 
-    await reloaded.unlock(TEST_PIN)
+    await Effect.runPromise(reloaded.unlock(TEST_PIN))
 
     expect(reloaded.isConnected()).toBe(true)
     expect(reloaded.credentials()?.privateKey).toBe(credentials.privateKey)
@@ -162,20 +163,28 @@ describe("useWallet", () => {
 
   it("rejects unlock with the wrong pin", async () => {
     const { result } = renderHook(() => useWallet(), { wrapper })
-    await result.connect(
-      {
-        accountAddress: "0xTestAccountAddress",
-        apiWalletAddress: "0xTestApiWalletAddress",
-        privateKey: "TEST_PRIVATE_KEY_PLACEHOLDER",
-      },
-      TEST_PIN,
+    await Effect.runPromise(
+      result.connect(
+        {
+          accountAddress: "0xTestAccountAddress",
+          apiWalletAddress: "0xTestApiWalletAddress",
+          privateKey: "TEST_PRIVATE_KEY_PLACEHOLDER",
+        },
+        TEST_PIN,
+      ),
     )
 
     const { result: reloaded } = renderHook(() => useWallet(), { wrapper })
 
-    await expect(reloaded.unlock("999999")).rejects.toBeInstanceOf(
-      WalletCredentialDecryptError,
-    )
+    let unlockFailure: unknown
+    try {
+      await Effect.runPromise(reloaded.unlock("999999"))
+    } catch (error) {
+      unlockFailure = error
+    }
+
+    expect(unlockFailure).toBeDefined()
+    expect(getErrorMessage(unlockFailure)).toBe("Incorrect PIN")
     expect(reloaded.isConnected()).toBe(false)
   })
 

--- a/frontend/src/hooks/useWallet.test.tsx
+++ b/frontend/src/hooks/useWallet.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from "@solidjs/testing-library"
 import { useWallet } from "./useWallet"
 import { WalletProvider } from "@/contexts/WalletProvider"
 import type { ParentProps } from "solid-js"
+import { WalletCredentialDecryptError } from "@/services/walletCredentialCrypto"
 
 vi.mock("@/services/hyperliquid-client", () => ({
   HyperliquidClient: class MockHyperliquidClient {
@@ -17,6 +18,8 @@ vi.mock("@/services/hyperliquid-client", () => ({
 const wrapper = (props: ParentProps) => (
   <WalletProvider>{props.children}</WalletProvider>
 )
+
+const TEST_PIN = "123456"
 
 describe("useWallet", () => {
   const ensureLocalStorage = () => {
@@ -60,12 +63,11 @@ describe("useWallet", () => {
 
     expect(result.credentials()).toBeNull()
     expect(result.isConnected()).toBe(false)
+    expect(result.isLocked()).toBe(false)
     expect(result.networkMode()).toBe("testnet")
   })
 
-  it("does not auto-restore credentials on mount (private key is never persisted)", () => {
-    // Even a legacy or tampered entry that contains a private key must not be
-    // trusted: credentials are never restored from localStorage on mount.
+  it("does not auto-restore plaintext private keys from legacy storage", () => {
     localStorage.setItem(
       "hyperliquid-wallet",
       JSON.stringify({
@@ -79,6 +81,26 @@ describe("useWallet", () => {
 
     expect(result.credentials()).toBeNull()
     expect(result.isConnected()).toBe(false)
+    expect(result.isLocked()).toBe(false)
+  })
+
+  it("reports a locked session when encrypted credentials exist on disk", () => {
+    localStorage.setItem(
+      "hyperliquid-wallet",
+      JSON.stringify({
+        accountAddress: "0xStoredAccountAddress",
+        apiWalletAddress: "0xStoredApiWalletAddress",
+        encryptedPrivateKey: "abc",
+        salt: "def",
+        iv: "ghi",
+      }),
+    )
+
+    const { result } = renderHook(() => useWallet(), { wrapper })
+
+    expect(result.isLocked()).toBe(true)
+    expect(result.hasStoredSession()).toBe(true)
+    expect(result.isConnected()).toBe(false)
   })
 
   it("reads network mode from localStorage", () => {
@@ -88,35 +110,73 @@ describe("useWallet", () => {
     expect(result.networkMode()).toBe("mainnet")
   })
 
-  it("keeps the private key in memory but never in localStorage; disconnect clears both", () => {
+  it("encrypts the private key in localStorage and keeps plaintext in memory only", async () => {
     const { result } = renderHook(() => useWallet(), { wrapper })
     const credentials = {
       accountAddress: "0xTestAccountAddress",
       apiWalletAddress: "0xTestApiWalletAddress",
       privateKey: "TEST_PRIVATE_KEY_PLACEHOLDER",
-      vaultAddress: "0xVault",
     }
 
-    result.connect(credentials)
+    await result.connect(credentials, TEST_PIN)
 
     expect(result.isConnected()).toBe(true)
-    // Full credentials (including the private key) live in memory only.
     expect(result.credentials()).toEqual(credentials)
-    // localStorage holds public address metadata only -- never the private key.
     const stored = JSON.parse(
       localStorage.getItem("hyperliquid-wallet") ?? "{}",
     )
-    expect(stored).toEqual({
-      accountAddress: "0xTestAccountAddress",
-      apiWalletAddress: "0xTestApiWalletAddress",
-      vaultAddress: "0xVault",
-    })
+    expect(stored.accountAddress).toBe("0xTestAccountAddress")
+    expect(stored.apiWalletAddress).toBe("0xTestApiWalletAddress")
+    expect(stored.encryptedPrivateKey).toBeTypeOf("string")
+    expect(stored.salt).toBeTypeOf("string")
+    expect(stored.iv).toBeTypeOf("string")
     expect(stored.privateKey).toBeUndefined()
+    expect(stored.encryptedPrivateKey).not.toBe(credentials.privateKey)
 
     result.disconnect()
     expect(result.isConnected()).toBe(false)
-    expect(result.credentials()).toBeNull()
+    expect(result.isLocked()).toBe(false)
+    expect(result.hasStoredSession()).toBe(false)
     expect(localStorage.getItem("hyperliquid-wallet")).toBeNull()
+  })
+
+  it("unlocks an encrypted session with the correct pin", async () => {
+    const credentials = {
+      accountAddress: "0xTestAccountAddress",
+      apiWalletAddress: "0xTestApiWalletAddress",
+      privateKey: "TEST_PRIVATE_KEY_PLACEHOLDER",
+    }
+
+    const { result: initial } = renderHook(() => useWallet(), { wrapper })
+    await initial.connect(credentials, TEST_PIN)
+    expect(localStorage.getItem("hyperliquid-wallet")).not.toBeNull()
+
+    const { result: reloaded } = renderHook(() => useWallet(), { wrapper })
+    expect(reloaded.isLocked()).toBe(true)
+
+    await reloaded.unlock(TEST_PIN)
+
+    expect(reloaded.isConnected()).toBe(true)
+    expect(reloaded.credentials()?.privateKey).toBe(credentials.privateKey)
+  })
+
+  it("rejects unlock with the wrong pin", async () => {
+    const { result } = renderHook(() => useWallet(), { wrapper })
+    await result.connect(
+      {
+        accountAddress: "0xTestAccountAddress",
+        apiWalletAddress: "0xTestApiWalletAddress",
+        privateKey: "TEST_PRIVATE_KEY_PLACEHOLDER",
+      },
+      TEST_PIN,
+    )
+
+    const { result: reloaded } = renderHook(() => useWallet(), { wrapper })
+
+    await expect(reloaded.unlock("999999")).rejects.toBeInstanceOf(
+      WalletCredentialDecryptError,
+    )
+    expect(reloaded.isConnected()).toBe(false)
   })
 
   it("setNetworkMode updates signal and localStorage", () => {

--- a/frontend/src/hooks/useWallet.test.tsx
+++ b/frontend/src/hooks/useWallet.test.tsx
@@ -22,6 +22,14 @@ const wrapper = (props: ParentProps) => (
 
 const TEST_PIN = "123456"
 
+const validEncryptedSessionFixture = {
+  accountAddress: "0xStoredAccountAddress",
+  apiWalletAddress: "0xStoredApiWalletAddress",
+  encryptedPrivateKey: "deadbeef".repeat(4),
+  salt: "0123456789abcdef0123456789abcdef",
+  iv: "0123456789abcdef01234567",
+}
+
 describe("useWallet", () => {
   const ensureLocalStorage = () => {
     const globalAny = globalThis as { localStorage?: Storage }
@@ -88,6 +96,19 @@ describe("useWallet", () => {
   it("reports a locked session when encrypted credentials exist on disk", () => {
     localStorage.setItem(
       "hyperliquid-wallet",
+      JSON.stringify(validEncryptedSessionFixture),
+    )
+
+    const { result } = renderHook(() => useWallet(), { wrapper })
+
+    expect(result.isLocked()).toBe(true)
+    expect(result.hasStoredSession()).toBe(true)
+    expect(result.isConnected()).toBe(false)
+  })
+
+  it("ignores malformed encrypted session payloads on disk", () => {
+    localStorage.setItem(
+      "hyperliquid-wallet",
       JSON.stringify({
         accountAddress: "0xStoredAccountAddress",
         apiWalletAddress: "0xStoredApiWalletAddress",
@@ -99,9 +120,8 @@ describe("useWallet", () => {
 
     const { result } = renderHook(() => useWallet(), { wrapper })
 
-    expect(result.isLocked()).toBe(true)
-    expect(result.hasStoredSession()).toBe(true)
-    expect(result.isConnected()).toBe(false)
+    expect(result.isLocked()).toBe(false)
+    expect(result.hasStoredSession()).toBe(false)
   })
 
   it("reads network mode from localStorage", () => {

--- a/frontend/src/hooks/useWallet.test.tsx
+++ b/frontend/src/hooks/useWallet.test.tsx
@@ -206,6 +206,8 @@ describe("useWallet", () => {
     expect(unlockFailure).toBeDefined()
     expect(getErrorMessage(unlockFailure)).toBe("Incorrect PIN")
     expect(reloaded.isConnected()).toBe(false)
+    expect(reloaded.isLocked()).toBe(true)
+    expect(reloaded.hasStoredSession()).toBe(true)
   })
 
   it("setNetworkMode updates signal and localStorage", () => {

--- a/frontend/src/lib/error-message.ts
+++ b/frontend/src/lib/error-message.ts
@@ -77,6 +77,8 @@ const messageForTag = (error: TaggedError): string | null => {
       return "Failed to unlock wallet. Please try again."
     case "WalletIncorrectPin":
       return "Incorrect PIN"
+    case "WalletCredentialCryptoFailure":
+      return "Failed to unlock wallet. Please try again."
     case "WalletSessionMissing":
       return "No saved wallet session found."
     default:

--- a/frontend/src/lib/error-message.ts
+++ b/frontend/src/lib/error-message.ts
@@ -71,6 +71,14 @@ const messageForTag = (error: TaggedError): string | null => {
       return "Connect a wallet to continue."
     case "ExchangeRequestError":
       return "The exchange rejected the request. Please try again."
+    case "WalletConnectError":
+      return "Failed to save wallet credentials. Please try again."
+    case "WalletUnlockError":
+      return "Failed to unlock wallet. Please try again."
+    case "WalletIncorrectPin":
+      return "Incorrect PIN"
+    case "WalletSessionMissing":
+      return "No saved wallet session found."
     default:
       return null
   }

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanel.tsx
@@ -19,7 +19,8 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import type { OrderSide } from "@/hooks/useTrading"
 import { useWallet } from "@/hooks/useWallet"
-import { WalletHeader } from "@/components/wallet-header"
+import { WalletInlineConnect } from "./WalletInlineConnect"
+import { WalletInlinePinUnlock } from "./WalletInlinePinUnlock"
 import { cn } from "@/lib/cn"
 
 import { useFactorScores } from "../../hooks/useFactorScores"
@@ -97,7 +98,7 @@ interface PositionsPanelProps {
 }
 
 export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
-  const { isConnected } = useWallet()
+  const { isConnected, isLocked } = useWallet()
   const factorScoresQuery = useFactorScores()
   const [panelView, setPanelView] =
     createSignal<PositionsPanelView>("portfolio")
@@ -366,12 +367,9 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
               <Show
                 when={isConnected()}
                 fallback={
-                  <div class="h-full flex flex-col items-center justify-center gap-3 p-4 text-center text-muted-foreground text-[11px]">
-                    <p class="max-w-[260px]">
-                      Connect your wallet to view and rebalance positions.
-                    </p>
-                    <WalletHeader />
-                  </div>
+                  <Show when={isLocked()} fallback={<WalletInlineConnect />}>
+                    <WalletInlinePinUnlock />
+                  </Show>
                 }
               >
                 <div class="flex-1 min-h-0 overflow-auto scrollbar-hide">

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlineConnect.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlineConnect.tsx
@@ -4,10 +4,7 @@ import { toast } from "solid-sonner"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import {
-  getStoredEncryptedSession,
-  getStoredWalletAddresses,
-} from "@/contexts/wallet-context"
+import { getStoredWalletAddresses } from "@/contexts/wallet-context"
 import { useWallet } from "@/hooks/useWallet"
 import { getErrorMessage } from "@/lib/error-message"
 import {
@@ -25,7 +22,7 @@ export const WalletInlineConnect = (): JSX.Element => {
 
   onMount(() => {
     const stored = getStoredWalletAddresses()
-    if (!stored || getStoredEncryptedSession()) {
+    if (!stored) {
       return
     }
 

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlineConnect.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlineConnect.tsx
@@ -1,0 +1,156 @@
+import { createMemo, createSignal, onMount, type JSX } from "solid-js"
+import { toast } from "solid-sonner"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  getStoredEncryptedSession,
+  getStoredWalletAddresses,
+} from "@/contexts/wallet-context"
+import { useWallet } from "@/hooks/useWallet"
+import {
+  normalizeWalletPinInput,
+  WALLET_PIN_LENGTH,
+} from "@/services/walletCredentialCrypto"
+
+export const WalletInlineConnect = (): JSX.Element => {
+  const { connect } = useWallet()
+  const [accountAddress, setAccountAddress] = createSignal("")
+  const [apiWalletAddress, setApiWalletAddress] = createSignal("")
+  const [privateKey, setPrivateKey] = createSignal("")
+  const [pin, setPin] = createSignal("")
+  const [isConnecting, setIsConnecting] = createSignal(false)
+
+  onMount(() => {
+    const stored = getStoredWalletAddresses()
+    if (!stored || getStoredEncryptedSession()) {
+      return
+    }
+
+    setAccountAddress(stored.accountAddress)
+    setApiWalletAddress(stored.apiWalletAddress)
+  })
+
+  const canConnect = createMemo(
+    () =>
+      accountAddress().trim() !== "" &&
+      apiWalletAddress().trim() !== "" &&
+      privateKey().trim() !== "" &&
+      pin().length === WALLET_PIN_LENGTH,
+  )
+
+  const handleConnect = async () => {
+    if (!canConnect()) {
+      return
+    }
+    const credentials = {
+      accountAddress: accountAddress().trim(),
+      apiWalletAddress: apiWalletAddress().trim(),
+      privateKey: privateKey().trim(),
+    }
+
+    setIsConnecting(true)
+    try {
+      await connect(credentials, pin())
+      setPrivateKey("")
+      setPin("")
+      toast.success("Wallet connected")
+    } catch (error) {
+      console.error("Failed to encrypt and store wallet credentials:", error)
+      toast.error("Failed to save wallet credentials. Please try again.")
+    } finally {
+      setIsConnecting(false)
+    }
+  }
+
+  return (
+    <div class="flex h-full flex-col items-center justify-center gap-4 overflow-auto p-4 text-[16px] text-muted-foreground">
+      <p class="max-w-[45ch] text-center font-medium text-foreground">
+        Connect Hyperliquid wallet to rebalance your portfolio
+      </p>
+      <div class="flex w-full max-w-[45ch] flex-col gap-3 text-left">
+        <div class="space-y-1.5">
+          <label for="portfolioAccountAddress" class="font-medium">
+            Hyperliquid main wallet address
+          </label>
+          <Input
+            id="portfolioAccountAddress"
+            placeholder="0x..."
+            value={accountAddress()}
+            disabled={isConnecting()}
+            class="h-8 text-[12px]"
+            onInput={event => {
+              setAccountAddress(event.currentTarget.value)
+            }}
+          />
+        </div>
+        <div class="space-y-1.5">
+          <label for="portfolioApiWalletAddress" class="font-medium">
+            Hyperliquid public API wallet address
+          </label>
+          <Input
+            id="portfolioApiWalletAddress"
+            placeholder="0x..."
+            value={apiWalletAddress()}
+            disabled={isConnecting()}
+            class="h-8 text-[12px]"
+            onInput={event => {
+              setApiWalletAddress(event.currentTarget.value)
+            }}
+          />
+        </div>
+        <div class="space-y-1.5">
+          <label for="portfolioPrivateKey" class="font-medium">
+            Hyperliquid private API wallet key
+          </label>
+          <Input
+            id="portfolioPrivateKey"
+            type="password"
+            placeholder="0x..."
+            value={privateKey()}
+            disabled={isConnecting()}
+            class="h-8 text-[12px]"
+            onInput={event => {
+              setPrivateKey(event.currentTarget.value)
+            }}
+          />
+        </div>
+        <div class="space-y-1.5">
+          <label for="portfolioConnectPin" class="font-medium">
+            Local PIN ({String(WALLET_PIN_LENGTH)} characters)
+          </label>
+          <Input
+            id="portfolioConnectPin"
+            type="password"
+            inputmode="numeric"
+            autocomplete="new-password"
+            placeholder="6-digit PIN"
+            maxlength={WALLET_PIN_LENGTH}
+            value={pin()}
+            disabled={isConnecting()}
+            class="h-8 text-[12px] font-mono tracking-[0.3em]"
+            onInput={event => {
+              setPin(normalizeWalletPinInput(event.currentTarget.value))
+            }}
+            onKeyDown={event => {
+              if (event.key === "Enter" && canConnect()) {
+                event.preventDefault()
+                void handleConnect()
+              }
+            }}
+          />
+        </div>
+        <Button
+          type="button"
+          class="h-8 text-[12px]"
+          disabled={isConnecting() || !canConnect()}
+          onClick={() => {
+            void handleConnect()
+          }}
+        >
+          Connect
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlineConnect.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlineConnect.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, onMount, type JSX } from "solid-js"
+import * as Effect from "effect/Effect"
 import { toast } from "solid-sonner"
 
 import { Button } from "@/components/ui/button"
@@ -8,6 +9,7 @@ import {
   getStoredWalletAddresses,
 } from "@/contexts/wallet-context"
 import { useWallet } from "@/hooks/useWallet"
+import { getErrorMessage } from "@/lib/error-message"
 import {
   normalizeWalletPinInput,
   WALLET_PIN_LENGTH,
@@ -51,13 +53,13 @@ export const WalletInlineConnect = (): JSX.Element => {
 
     setIsConnecting(true)
     try {
-      await connect(credentials, pin())
+      await Effect.runPromise(connect(credentials, pin()))
       setPrivateKey("")
       setPin("")
       toast.success("Wallet connected")
     } catch (error) {
       console.error("Failed to encrypt and store wallet credentials:", error)
-      toast.error("Failed to save wallet credentials. Please try again.")
+      toast.error(getErrorMessage(error))
     } finally {
       setIsConnecting(false)
     }

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlinePinUnlock.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlinePinUnlock.tsx
@@ -1,0 +1,103 @@
+import { createSignal, onMount, Show, type JSX } from "solid-js"
+
+import { Input } from "@/components/ui/input"
+import { getStoredEncryptedSession } from "@/contexts/wallet-context"
+import { useWallet } from "@/hooks/useWallet"
+import {
+  normalizeWalletPinInput,
+  WALLET_PIN_LENGTH,
+  WalletCredentialDecryptError,
+} from "@/services/walletCredentialCrypto"
+
+const formatWalletAddress = (address: string): string => {
+  if (!address || address.length < 10) {
+    return address
+  }
+  if (address.startsWith("0x")) {
+    return `${address.slice(0, 6)}...${address.slice(-4)}`
+  }
+  return `${address.slice(0, 4)}...${address.slice(-4)}`
+}
+
+export const WalletInlinePinUnlock = (): JSX.Element => {
+  const { unlock } = useWallet()
+  const [pin, setPin] = createSignal("")
+  const [unlockError, setUnlockError] = createSignal<string | null>(null)
+  const [isUnlocking, setIsUnlocking] = createSignal(false)
+  let pinInputRef: HTMLInputElement | undefined
+
+  const focusPinInput = () => {
+    pinInputRef?.focus()
+  }
+
+  onMount(() => {
+    focusPinInput()
+  })
+
+  const walletAddress = () =>
+    formatWalletAddress(getStoredEncryptedSession()?.accountAddress ?? "wallet")
+
+  const attemptUnlock = async (enteredPin: string) => {
+    if (enteredPin.length !== WALLET_PIN_LENGTH || isUnlocking()) {
+      return
+    }
+
+    setIsUnlocking(true)
+    setUnlockError(null)
+    try {
+      await unlock(enteredPin)
+      setPin("")
+    } catch (error) {
+      setPin("")
+      if (error instanceof WalletCredentialDecryptError) {
+        setUnlockError("Incorrect PIN")
+      } else {
+        console.error("Failed to unlock wallet:", error)
+        setUnlockError("Failed to unlock wallet. Please try again.")
+      }
+    } finally {
+      setIsUnlocking(false)
+      focusPinInput()
+    }
+  }
+
+  return (
+    <div class="flex h-full flex-col items-center justify-center gap-3 p-4 text-center text-muted-foreground text-[11px]">
+      <p class="max-w-[320px]">
+        To continue using your wallet{" "}
+        <span class="font-mono text-foreground">{walletAddress()}</span> enter
+        PIN
+      </p>
+      <div class="flex w-full max-w-[240px] flex-col gap-2 text-left">
+        <label for="portfolioWalletPin" class="sr-only">
+          Local PIN
+        </label>
+        <Input
+          ref={pinInputRef}
+          id="portfolioWalletPin"
+          type="password"
+          inputmode="numeric"
+          autocomplete="current-password"
+          placeholder="6-digit PIN"
+          maxlength={WALLET_PIN_LENGTH}
+          value={pin()}
+          disabled={isUnlocking()}
+          class="h-8 text-center font-mono text-[12px] tracking-[0.3em]"
+          onInput={event => {
+            const nextPin = normalizeWalletPinInput(event.currentTarget.value)
+            setPin(nextPin)
+            setUnlockError(null)
+            if (nextPin.length === WALLET_PIN_LENGTH) {
+              void attemptUnlock(nextPin)
+            }
+          }}
+        />
+        <Show when={unlockError()}>
+          <p class="text-center text-destructive text-[11px]">
+            {unlockError()}
+          </p>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlinePinUnlock.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlinePinUnlock.tsx
@@ -1,5 +1,6 @@
 import { createSignal, onMount, Show, type JSX } from "solid-js"
 import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
 
 import { Input } from "@/components/ui/input"
 import { getStoredEncryptedSession } from "@/contexts/wallet-context"
@@ -45,17 +46,21 @@ export const WalletInlinePinUnlock = (): JSX.Element => {
 
     setIsUnlocking(true)
     setUnlockError(null)
-    try {
-      await Effect.runPromise(unlock(enteredPin))
+
+    const unlockResult = await Effect.runPromise(
+      Effect.either(unlock(enteredPin)),
+    )
+
+    if (Either.isRight(unlockResult)) {
       setPin("")
-    } catch (error) {
+    } else {
       setPin("")
-      console.error("Failed to unlock wallet:", error)
-      setUnlockError(getErrorMessage(error))
-    } finally {
-      setIsUnlocking(false)
-      focusPinInput()
+      console.error("Failed to unlock wallet:", unlockResult.left)
+      setUnlockError(getErrorMessage(unlockResult.left))
     }
+
+    setIsUnlocking(false)
+    focusPinInput()
   }
 
   return (

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlinePinUnlock.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/WalletInlinePinUnlock.tsx
@@ -1,12 +1,13 @@
 import { createSignal, onMount, Show, type JSX } from "solid-js"
+import * as Effect from "effect/Effect"
 
 import { Input } from "@/components/ui/input"
 import { getStoredEncryptedSession } from "@/contexts/wallet-context"
 import { useWallet } from "@/hooks/useWallet"
+import { getErrorMessage } from "@/lib/error-message"
 import {
   normalizeWalletPinInput,
   WALLET_PIN_LENGTH,
-  WalletCredentialDecryptError,
 } from "@/services/walletCredentialCrypto"
 
 const formatWalletAddress = (address: string): string => {
@@ -45,16 +46,12 @@ export const WalletInlinePinUnlock = (): JSX.Element => {
     setIsUnlocking(true)
     setUnlockError(null)
     try {
-      await unlock(enteredPin)
+      await Effect.runPromise(unlock(enteredPin))
       setPin("")
     } catch (error) {
       setPin("")
-      if (error instanceof WalletCredentialDecryptError) {
-        setUnlockError("Incorrect PIN")
-      } else {
-        console.error("Failed to unlock wallet:", error)
-        setUnlockError("Failed to unlock wallet. Please try again.")
-      }
+      console.error("Failed to unlock wallet:", error)
+      setUnlockError(getErrorMessage(error))
     } finally {
       setIsUnlocking(false)
       focusPinInput()

--- a/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
+++ b/frontend/src/pages/Portfolio/hooks/usePortfolioState.ts
@@ -441,6 +441,7 @@ export const usePortfolioState = () => {
     symbolsDeltaBelowMinimum().length > 0
 
   const handleAddToken = (symbol: string) => {
+    if (!isConnected()) return
     if (symbol in targetPortfolio) return
     if (deletedArchive[symbol] !== undefined) return
 

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -335,11 +335,7 @@ describe("HyperliquidClient", () => {
     const client = new HyperliquidClient(credentials, "mainnet")
     const result = await client.rebalancePositions(actions)
 
-    expect(mockExchange.setLeverage).toHaveBeenCalledWith(
-      5,
-      "BTC/USDC:USDC",
-      undefined,
-    )
+    expect(mockExchange.setLeverage).toHaveBeenCalledWith(5, "BTC/USDC:USDC")
 
     expect(mockExchange.createOrdersWs).toHaveBeenCalledTimes(2)
     expect(mockExchange.fetchPositions).toHaveBeenCalledTimes(1)
@@ -671,47 +667,6 @@ describe("HyperliquidClient", () => {
     })
 
     expect(mockExchange.fetchPositions).toHaveBeenCalledWith()
-  })
-
-  it("includes vaultAddress in leverage and order params", async () => {
-    const vaultCreds: WalletCredentials = {
-      ...credentials,
-      vaultAddress: "0xVault",
-    }
-
-    const actions: RebalanceAction[] = [
-      {
-        kind: "rebalance",
-        symbol: "BTC/USDC:USDC",
-        signedNotionalDelta: 50,
-        leverage: 3,
-        leverageChanged: true,
-      },
-    ]
-
-    mockExchange.fetchTickers.mockResolvedValue({
-      "BTC/USDC:USDC": { last: 50_000 },
-    })
-
-    mockExchange.fetchPositions.mockResolvedValue([])
-    mockExchange.createOrdersWs.mockResolvedValue([
-      { status: "closed", info: {} },
-    ])
-
-    const client = new HyperliquidClient(vaultCreds, "mainnet")
-    await client.rebalancePositions(actions)
-
-    expect(mockExchange.setLeverage).toHaveBeenCalledWith(3, "BTC/USDC:USDC", {
-      vaultAddress: "0xVault",
-    })
-
-    expect(mockExchange.createOrdersWs).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: expect.objectContaining({ vaultAddress: "0xVault" }),
-        }),
-      ]),
-    )
   })
 
   it("batches preciseRebalance close with other reductions then opens in phase two", async () => {

--- a/frontend/src/services/hyperliquid-client.test.ts
+++ b/frontend/src/services/hyperliquid-client.test.ts
@@ -706,17 +706,23 @@ describe("HyperliquidClient", () => {
     expect(result).toHaveLength(2)
 
     const firstCall = mockExchange.createOrdersWs.mock.calls[0][0]
-    expect(firstCall[0]).toMatchObject({
+    expect(firstCall[0]).toEqual({
+      symbol: "BTC/USDC:USDC",
+      type: "market",
       side: "sell",
       amount: 11 / 50_000,
-      params: expect.objectContaining({ reduceOnly: true }),
+      price: 50_000,
+      params: { reduceOnly: true },
     })
 
     const secondCall = mockExchange.createOrdersWs.mock.calls[1][0]
-    expect(secondCall[0]).toMatchObject({
+    expect(secondCall[0]).toEqual({
+      symbol: "BTC/USDC:USDC",
+      type: "market",
       side: "buy",
       amount: 13 / 50_000,
-      params: expect.not.objectContaining({ reduceOnly: true }),
+      price: 50_000,
+      params: {},
     })
   })
 

--- a/frontend/src/services/hyperliquid-client.ts
+++ b/frontend/src/services/hyperliquid-client.ts
@@ -317,23 +317,16 @@ interface HyperliquidExchange {
 export class HyperliquidClient {
   private exchange: HyperliquidExchange
   private networkMode: NetworkMode
-  private vaultAddress: string | undefined
 
   constructor(credentials: WalletCredentials, networkMode: NetworkMode) {
     this.networkMode = networkMode
-    this.vaultAddress = credentials.vaultAddress
 
     const HyperliquidClass = pro.hyperliquid as unknown as new (
       config: Record<string, unknown>,
     ) => HyperliquidExchange
 
-    // walletAddress is used for info requests (fetching positions/balance)
-    // When trading on behalf of a vault, use vault address; otherwise use account address
-    const effectiveWalletAddress =
-      credentials.vaultAddress ?? credentials.accountAddress
-
     this.exchange = new HyperliquidClass({
-      walletAddress: effectiveWalletAddress,
+      walletAddress: credentials.accountAddress,
       privateKey: credentials.privateKey,
       enableRateLimit: true,
     })
@@ -508,11 +501,7 @@ export class HyperliquidClient {
   }
 
   private async setLeverage(symbol: string, leverage: number): Promise<void> {
-    await this.exchange.setLeverage(leverage, symbol, this.vaultParams)
-  }
-
-  private get vaultParams(): Record<string, unknown> | undefined {
-    return this.vaultAddress ? { vaultAddress: this.vaultAddress } : undefined
+    await this.exchange.setLeverage(leverage, symbol)
   }
 
   private parseCcxtPerpSymbolParts(symbol: string): {
@@ -698,9 +687,7 @@ export class HyperliquidClient {
       side,
       amount,
       price,
-      params: reduceOnly
-        ? { reduceOnly: true, ...this.vaultParams }
-        : { ...this.vaultParams },
+      params: reduceOnly ? { reduceOnly: true } : {},
     }
   }
 

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -1,0 +1,22 @@
+import * as Data from "effect/Data"
+
+export class WalletConnectError extends Data.TaggedError("WalletConnectError")<{
+  readonly cause: unknown
+}> {}
+
+export class WalletUnlockError extends Data.TaggedError("WalletUnlockError")<{
+  readonly cause: unknown
+}> {}
+
+export class WalletIncorrectPin extends Data.TaggedError("WalletIncorrectPin")<
+  Record<string, never>
+> {}
+
+export class WalletSessionMissing extends Data.TaggedError(
+  "WalletSessionMissing",
+)<Record<string, never>> {}
+
+export type WalletUnlockFailure =
+  | WalletSessionMissing
+  | WalletIncorrectPin
+  | WalletUnlockError

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -8,6 +8,12 @@ export class WalletUnlockError extends Data.TaggedError("WalletUnlockError")<{
   readonly cause: unknown
 }> {}
 
+export class WalletCredentialCryptoFailure extends Data.TaggedError(
+  "WalletCredentialCryptoFailure",
+)<{
+  readonly cause: unknown
+}> {}
+
 export class WalletIncorrectPin extends Data.TaggedError("WalletIncorrectPin")<
   Record<string, never>
 > {}
@@ -20,3 +26,8 @@ export type WalletUnlockFailure =
   | WalletSessionMissing
   | WalletIncorrectPin
   | WalletUnlockError
+  | WalletCredentialCryptoFailure
+
+export type WalletDecryptFailure =
+  | WalletIncorrectPin
+  | WalletCredentialCryptoFailure

--- a/frontend/src/services/walletCredentialCrypto.test.ts
+++ b/frontend/src/services/walletCredentialCrypto.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  decryptWalletPrivateKey,
+  encryptWalletPrivateKey,
+  WALLET_PIN_LENGTH,
+  WalletCredentialDecryptError,
+} from "./walletCredentialCrypto"
+
+describe("walletCredentialCrypto", () => {
+  it("round-trips a private key with the same pin", async () => {
+    const privateKey = "0xabc123privatekey"
+    const pin = "654321"
+
+    const encrypted = await encryptWalletPrivateKey(privateKey, pin)
+    const decrypted = await decryptWalletPrivateKey(
+      encrypted.encryptedPrivateKey,
+      pin,
+      encrypted.salt,
+      encrypted.iv,
+    )
+
+    expect(decrypted).toBe(privateKey)
+    expect(encrypted.encryptedPrivateKey).not.toContain(privateKey)
+  })
+
+  it("rejects pins that are not exactly six characters", async () => {
+    const shortPin = "1".repeat(WALLET_PIN_LENGTH - 1)
+    const longPin = "1".repeat(WALLET_PIN_LENGTH + 1)
+
+    await expect(
+      encryptWalletPrivateKey("0xsecret", shortPin),
+    ).rejects.toMatchObject({
+      name: "WalletCredentialCryptoError",
+    })
+    await expect(
+      encryptWalletPrivateKey("0xsecret", longPin),
+    ).rejects.toMatchObject({
+      name: "WalletCredentialCryptoError",
+    })
+  })
+
+  it("rejects decryption with the wrong pin", async () => {
+    const encrypted = await encryptWalletPrivateKey("0xsecret", "123456")
+
+    await expect(
+      decryptWalletPrivateKey(
+        encrypted.encryptedPrivateKey,
+        "999999",
+        encrypted.salt,
+        encrypted.iv,
+      ),
+    ).rejects.toBeInstanceOf(WalletCredentialDecryptError)
+  })
+
+  it("produces different ciphertext for the same key on each encryption", async () => {
+    const first = await encryptWalletPrivateKey("0xsecret", "123456")
+    const second = await encryptWalletPrivateKey("0xsecret", "123456")
+
+    expect(first.encryptedPrivateKey).not.toBe(second.encryptedPrivateKey)
+    expect(first.salt).not.toBe(second.salt)
+    expect(first.iv).not.toBe(second.iv)
+  })
+})

--- a/frontend/src/services/walletCredentialCrypto.test.ts
+++ b/frontend/src/services/walletCredentialCrypto.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest"
+import * as Effect from "effect/Effect"
 
+import { WalletIncorrectPin } from "./wallet"
 import {
   decryptWalletPrivateKey,
   encryptWalletPrivateKey,
   WALLET_PIN_LENGTH,
-  WalletCredentialDecryptError,
 } from "./walletCredentialCrypto"
+
+const failureError = async <ErrorType>(
+  effect: Effect.Effect<unknown, ErrorType>,
+): Promise<ErrorType> => {
+  const exit = await Effect.runPromiseExit(effect)
+  if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+    return exit.cause.error
+  }
+  throw new Error(`expected a tagged failure, got: ${JSON.stringify(exit)}`)
+}
 
 describe("walletCredentialCrypto", () => {
   it("round-trips a private key with the same pin", async () => {
@@ -13,11 +24,13 @@ describe("walletCredentialCrypto", () => {
     const pin = "654321"
 
     const encrypted = await encryptWalletPrivateKey(privateKey, pin)
-    const decrypted = await decryptWalletPrivateKey(
-      encrypted.encryptedPrivateKey,
-      pin,
-      encrypted.salt,
-      encrypted.iv,
+    const decrypted = await Effect.runPromise(
+      decryptWalletPrivateKey(
+        encrypted.encryptedPrivateKey,
+        pin,
+        encrypted.salt,
+        encrypted.iv,
+      ),
     )
 
     expect(decrypted).toBe(privateKey)
@@ -43,14 +56,17 @@ describe("walletCredentialCrypto", () => {
   it("rejects decryption with the wrong pin", async () => {
     const encrypted = await encryptWalletPrivateKey("0xsecret", "123456")
 
-    await expect(
+    const error = await failureError(
       decryptWalletPrivateKey(
         encrypted.encryptedPrivateKey,
         "999999",
         encrypted.salt,
         encrypted.iv,
       ),
-    ).rejects.toBeInstanceOf(WalletCredentialDecryptError)
+    )
+
+    expect(error).toBeInstanceOf(WalletIncorrectPin)
+    expect(error._tag).toBe("WalletIncorrectPin")
   })
 
   it("produces different ciphertext for the same key on each encryption", async () => {

--- a/frontend/src/services/walletCredentialCrypto.test.ts
+++ b/frontend/src/services/walletCredentialCrypto.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import * as Effect from "effect/Effect"
 
-import { WalletIncorrectPin } from "./wallet"
+import { WalletCredentialCryptoFailure, WalletIncorrectPin } from "./wallet"
 import {
   decryptWalletPrivateKey,
   encryptWalletPrivateKey,
@@ -72,6 +72,22 @@ describe("walletCredentialCrypto", () => {
     ).rejects.toMatchObject({
       name: "WalletCredentialCryptoError",
     })
+  })
+
+  it("rejects decryption with malformed hex encodings", async () => {
+    const encrypted = await encryptWalletPrivateKey("0xsecret", "123456")
+
+    const error = await failureError(
+      decryptWalletPrivateKey(
+        encrypted.encryptedPrivateKey,
+        "123456",
+        `${encrypted.salt.slice(0, 30)}fg`,
+        encrypted.iv,
+      ),
+    )
+
+    expect(error).toBeInstanceOf(WalletCredentialCryptoFailure)
+    expect(error._tag).toBe("WalletCredentialCryptoFailure")
   })
 
   it("rejects decryption with the wrong pin", async () => {

--- a/frontend/src/services/walletCredentialCrypto.test.ts
+++ b/frontend/src/services/walletCredentialCrypto.test.ts
@@ -5,6 +5,8 @@ import { WalletIncorrectPin } from "./wallet"
 import {
   decryptWalletPrivateKey,
   encryptWalletPrivateKey,
+  normalizeWalletPinInput,
+  validateWalletPin,
   WALLET_PIN_LENGTH,
 } from "./walletCredentialCrypto"
 
@@ -37,7 +39,21 @@ describe("walletCredentialCrypto", () => {
     expect(encrypted.encryptedPrivateKey).not.toContain(privateKey)
   })
 
-  it("rejects pins that are not exactly six characters", async () => {
+  it("accepts only six numeric digits as a valid pin", () => {
+    expect(validateWalletPin("123456")).toBe(true)
+    expect(validateWalletPin("12ab34")).toBe(false)
+    expect(validateWalletPin("12 345")).toBe(false)
+    expect(validateWalletPin("12345")).toBe(false)
+    expect(validateWalletPin("1234567")).toBe(false)
+  })
+
+  it("strips non-digit characters before truncating pin input", () => {
+    expect(normalizeWalletPinInput("12ab34")).toBe("1234")
+    expect(normalizeWalletPinInput("12 345")).toBe("12345")
+    expect(normalizeWalletPinInput("1234567890")).toBe("123456")
+  })
+
+  it("rejects pins that are not exactly six digits", async () => {
     const shortPin = "1".repeat(WALLET_PIN_LENGTH - 1)
     const longPin = "1".repeat(WALLET_PIN_LENGTH + 1)
 
@@ -48,6 +64,11 @@ describe("walletCredentialCrypto", () => {
     })
     await expect(
       encryptWalletPrivateKey("0xsecret", longPin),
+    ).rejects.toMatchObject({
+      name: "WalletCredentialCryptoError",
+    })
+    await expect(
+      encryptWalletPrivateKey("0xsecret", "12ab34"),
     ).rejects.toMatchObject({
       name: "WalletCredentialCryptoError",
     })

--- a/frontend/src/services/walletCredentialCrypto.ts
+++ b/frontend/src/services/walletCredentialCrypto.ts
@@ -30,10 +30,10 @@ export class WalletCredentialDecryptError extends WalletCredentialCryptoError {
 }
 
 export const validateWalletPin = (pin: string): boolean =>
-  pin.length === WALLET_PIN_LENGTH
+  pin.length === WALLET_PIN_LENGTH && /^\d+$/.test(pin)
 
 export const normalizeWalletPinInput = (value: string): string =>
-  value.slice(0, WALLET_PIN_LENGTH)
+  value.replace(/\D/g, "").slice(0, WALLET_PIN_LENGTH)
 
 const assertWebCrypto = (): Crypto => {
   const cryptoApi = (globalThis as { crypto?: Crypto }).crypto

--- a/frontend/src/services/walletCredentialCrypto.ts
+++ b/frontend/src/services/walletCredentialCrypto.ts
@@ -1,3 +1,11 @@
+import * as Effect from "effect/Effect"
+
+import {
+  WalletCredentialCryptoFailure,
+  WalletIncorrectPin,
+  type WalletDecryptFailure,
+} from "./wallet"
+
 export const WALLET_PIN_LENGTH = 6
 export const PBKDF2_ITERATIONS = 100_000
 
@@ -111,33 +119,47 @@ export const encryptWalletPrivateKey = async (
   }
 }
 
-export const decryptWalletPrivateKey = async (
+export const decryptWalletPrivateKey = (
   encryptedHex: string,
   pin: string,
   saltHex: string,
   ivHex: string,
-): Promise<string> => {
+): Effect.Effect<string, WalletDecryptFailure> => {
   if (!validateWalletPin(pin)) {
-    throw new WalletCredentialCryptoError(
-      `pin must be exactly ${String(WALLET_PIN_LENGTH)} characters`,
+    return Effect.fail(
+      new WalletCredentialCryptoFailure({
+        cause: new WalletCredentialCryptoError(
+          `pin must be exactly ${String(WALLET_PIN_LENGTH)} characters`,
+        ),
+      }),
     )
   }
 
-  const cryptoApi = assertWebCrypto()
-  const decoder = new TextDecoder()
+  return Effect.tryPromise({
+    try: async () => {
+      const cryptoApi = assertWebCrypto()
+      const decoder = new TextDecoder()
 
-  try {
-    const cryptoKey = await deriveKey(pin, hexToBytes(saltHex))
-    const decrypted = await cryptoApi.subtle.decrypt(
-      { name: "AES-GCM", iv: hexToBytes(ivHex) },
-      cryptoKey,
-      hexToBytes(encryptedHex),
-    )
-    return decoder.decode(decrypted)
-  } catch (error) {
-    if (error instanceof WalletCredentialCryptoError) {
-      throw error
-    }
-    throw new WalletCredentialDecryptError()
-  }
+      try {
+        const cryptoKey = await deriveKey(pin, hexToBytes(saltHex))
+        const decrypted = await cryptoApi.subtle.decrypt(
+          { name: "AES-GCM", iv: hexToBytes(ivHex) },
+          cryptoKey,
+          hexToBytes(encryptedHex),
+        )
+        return decoder.decode(decrypted)
+      } catch (error) {
+        if (error instanceof WalletCredentialCryptoError) {
+          throw error
+        }
+        throw new WalletCredentialDecryptError()
+      }
+    },
+    catch: cause => {
+      if (cause instanceof WalletCredentialDecryptError) {
+        return new WalletIncorrectPin()
+      }
+      return new WalletCredentialCryptoFailure({ cause })
+    },
+  })
 }

--- a/frontend/src/services/walletCredentialCrypto.ts
+++ b/frontend/src/services/walletCredentialCrypto.ts
@@ -1,0 +1,143 @@
+export const WALLET_PIN_LENGTH = 6
+export const PBKDF2_ITERATIONS = 100_000
+
+export interface EncryptedWalletPrivateKey {
+  encryptedPrivateKey: string
+  salt: string
+  iv: string
+}
+
+export class WalletCredentialCryptoError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "WalletCredentialCryptoError"
+  }
+}
+
+export class WalletCredentialDecryptError extends WalletCredentialCryptoError {
+  constructor() {
+    super("incorrect pin")
+    this.name = "WalletCredentialDecryptError"
+  }
+}
+
+export const validateWalletPin = (pin: string): boolean =>
+  pin.length === WALLET_PIN_LENGTH
+
+export const normalizeWalletPinInput = (value: string): string =>
+  value.slice(0, WALLET_PIN_LENGTH)
+
+const assertWebCrypto = (): Crypto => {
+  const cryptoApi = (globalThis as { crypto?: Crypto }).crypto
+  if (cryptoApi?.subtle === undefined) {
+    throw new WalletCredentialCryptoError("web crypto is unavailable")
+  }
+  return cryptoApi
+}
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map(byte => byte.toString(16).padStart(2, "0"))
+    .join("")
+
+const hexToBytes = (hex: string): Uint8Array => {
+  if (hex.length % 2 !== 0) {
+    throw new WalletCredentialCryptoError("invalid hex encoding")
+  }
+
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let index = 0; index < bytes.length; index += 1) {
+    const byte = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16)
+    if (Number.isNaN(byte)) {
+      throw new WalletCredentialCryptoError("invalid hex encoding")
+    }
+    bytes[index] = byte
+  }
+
+  return bytes
+}
+
+const deriveKey = async (pin: string, salt: Uint8Array): Promise<CryptoKey> => {
+  const cryptoApi = assertWebCrypto()
+  const encoder = new TextEncoder()
+  const baseKey = await cryptoApi.subtle.importKey(
+    "raw",
+    encoder.encode(pin),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  )
+
+  return cryptoApi.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    baseKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  )
+}
+
+export const encryptWalletPrivateKey = async (
+  privateKeyText: string,
+  pin: string,
+): Promise<EncryptedWalletPrivateKey> => {
+  if (!validateWalletPin(pin)) {
+    throw new WalletCredentialCryptoError(
+      `pin must be exactly ${String(WALLET_PIN_LENGTH)} characters`,
+    )
+  }
+
+  const cryptoApi = assertWebCrypto()
+  const encoder = new TextEncoder()
+  const salt = cryptoApi.getRandomValues(new Uint8Array(16))
+  const iv = cryptoApi.getRandomValues(new Uint8Array(12))
+  const cryptoKey = await deriveKey(pin, salt)
+
+  const encrypted = await cryptoApi.subtle.encrypt(
+    { name: "AES-GCM", iv: iv }, // Без лишних оберток
+    cryptoKey,
+    encoder.encode(privateKeyText),
+  )
+
+  return {
+    encryptedPrivateKey: bytesToHex(new Uint8Array(encrypted)),
+    salt: bytesToHex(salt),
+    iv: bytesToHex(iv),
+  }
+}
+
+export const decryptWalletPrivateKey = async (
+  encryptedHex: string,
+  pin: string,
+  saltHex: string,
+  ivHex: string,
+): Promise<string> => {
+  if (!validateWalletPin(pin)) {
+    throw new WalletCredentialCryptoError(
+      `pin must be exactly ${String(WALLET_PIN_LENGTH)} characters`,
+    )
+  }
+
+  const cryptoApi = assertWebCrypto()
+  const decoder = new TextDecoder()
+
+  try {
+    const cryptoKey = await deriveKey(pin, hexToBytes(saltHex))
+    const decrypted = await cryptoApi.subtle.decrypt(
+      { name: "AES-GCM", iv: hexToBytes(ivHex) },
+      cryptoKey,
+      hexToBytes(encryptedHex),
+    )
+    return decoder.decode(decrypted)
+  } catch (error) {
+    if (error instanceof WalletCredentialCryptoError) {
+      throw error
+    }
+    throw new WalletCredentialDecryptError()
+  }
+}

--- a/frontend/src/services/walletCredentialCrypto.ts
+++ b/frontend/src/services/walletCredentialCrypto.ts
@@ -48,6 +48,8 @@ const bytesToHex = (bytes: Uint8Array): string =>
     .map(byte => byte.toString(16).padStart(2, "0"))
     .join("")
 
+const HEX_BYTE_PATTERN = /^[0-9a-fA-F]{2}$/
+
 const hexToBytes = (hex: string): Uint8Array => {
   if (hex.length % 2 !== 0) {
     throw new WalletCredentialCryptoError("invalid hex encoding")
@@ -55,11 +57,11 @@ const hexToBytes = (hex: string): Uint8Array => {
 
   const bytes = new Uint8Array(hex.length / 2)
   for (let index = 0; index < bytes.length; index += 1) {
-    const byte = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16)
-    if (Number.isNaN(byte)) {
+    const pair = hex.slice(index * 2, index * 2 + 2)
+    if (!HEX_BYTE_PATTERN.test(pair)) {
       throw new WalletCredentialCryptoError("invalid hex encoding")
     }
-    bytes[index] = byte
+    bytes[index] = Number.parseInt(pair, 16)
   }
 
   return bytes


### PR DESCRIPTION
Новая схема работы с приватным апи ключом гиперликвида.

[Пользователь] -> (Ввод ключей + ПИН) -> [SolidJS (Шифрование)] -> [LocalStorage]
                                                |
                                      (Торговля через CCXT)
                                                ↓
                                         [Hyperliquid]

Пользователь вводит ключи, приватный ключ шифруется при помощи локального пин-кода (6 знаков) и хранится в localStorage. Расшифрованный ключ хранится в памяти браузера на время работы вкладки. Любая перезагрузка вкладки ищет ключ в localStorage и просит пользователя ввети пин-код для расшифроки и дальнейшей работы.

Так же обновлен дизайн, убраны все поп-апы связанные с вводом кошелька, теперь все поля находятся внутри portolio панели в открытом виде.

Загрузка страницы с уже подключенным кошельком загружает поле ввода пин-кода внутри portfolio панели с фокусом в поле. Ввод 6 символов в поле автоматически триггерит попытку расшифровки.

Пофикшен баг, когда при отключенном кошельке можно было добавлять позиции в портфолио и даже попытаться вызвать ребаланс.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet sessions are now saved encrypted and restored in a locked state, with PIN-based unlock.
  * Portfolio positions now show inline connect vs inline unlock controls based on whether the wallet is disconnected or locked.
  * Wallet header status now reflects “No wallet configured” vs “Wallet locked”.
* **Bug Fixes**
  * Clicking wallet actions when no wallet is configured no longer opens connect/unlock dialogs.
  * Disconnect now fully clears the saved wallet session.
  * Portfolio “add token” actions no longer run while disconnected.
* **Tests**
  * Updated and added coverage for encrypted session restore, unlock success/failure, and locked/disconnected UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->