### PR TITLE
fix: enqueue the ingestion job atomically with the started event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,6 +3405,7 @@ dependencies = [
  "futures",
  "getrandom 0.4.3",
  "hyperliquid_rust_sdk",
+ "moneymentum",
  "polars",
  "proptest",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,10 +88,18 @@ uuid = { version = "1.23.3", features = ["v4", "serde"] }
 [lints]
 workspace = true
 
+[features]
+# Forwards event-sorcery's test-support (TestHarness, FailureInjector, and the
+# 4-argument `work` job handler). The ingestion worker registers a
+# FailureInjector only when event-sorcery's test-support is active, so this
+# feature must track it exactly. Enabling it through the self dev-dependency
+# below turns it on for the whole `cargo test` graph (unit and integration
+# tests alike), so `cfg(feature = "test-support")` lines up with when the
+# 4-argument handler is compiled.
+test-support = ["event-sorcery/test-support"]
+
 [dev-dependencies]
-event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery", tag = "0.2.0-rc2", features = [
-  "test-support",
-] }
+moneymentum = { path = ".", features = ["test-support"] }
 proptest.workspace = true
 reqwest = { version = "0.13.2", features = ["blocking"] }
 rust_decimal_macros = "1.40.0"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Design: [adrs/0001](./adrs/0001-event-sorcery-persistence-foundation.md).
 - [ ] Event-source portfolios, ingestion runs, and the market universe --
       [#364](https://github.com/data-cartel/moneymentum/issues/364) /
       [#362](https://github.com/data-cartel/moneymentum/pull/362)
-- [ ] Enqueue the ingestion job atomically with the Started event --
+- [x] Enqueue the ingestion job atomically with the Started event --
       [#404](https://github.com/dataclique/moneymentum/issues/404) /
       [#406](https://github.com/dataclique/moneymentum/pull/406)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,9 @@ Design: [adrs/0001](./adrs/0001-event-sorcery-persistence-foundation.md).
 - [ ] Event-source portfolios, ingestion runs, and the market universe --
       [#364](https://github.com/data-cartel/moneymentum/issues/364) /
       [#362](https://github.com/data-cartel/moneymentum/pull/362)
+- [ ] Enqueue the ingestion job atomically with the Started event --
+      [#404](https://github.com/dataclique/moneymentum/issues/404) /
+      [#406](https://github.com/dataclique/moneymentum/pull/406)
 
 ---
 

--- a/adrs/0001-event-sorcery-persistence-foundation.md
+++ b/adrs/0001-event-sorcery-persistence-foundation.md
@@ -337,3 +337,38 @@ GitHub issue and a ROADMAP.md checkbox.
 5. **One house portfolio vs multi-account now.** `PortfolioId(Uuid)` supports
    many portfolios; the beachhead ships a single "house" portfolio. Confirm that
    is the right initial surface (vs binding identity to a Solana pubkey now).
+
+## Amendment (2026-07-01): ingestion job enqueue is atomic with the Started event
+
+- Issue: [#404](https://github.com/dataclique/moneymentum/issues/404) (ingestion
+  run creation and job enqueue are not atomic, orphaning Running runs)
+
+The ingestion re-event-sourcing (epic 3) shipped `IngestionRun` with
+`type Jobs =
+Nil` and enqueued the ingestion job from the `/ingest` handler with
+a separate `SqliteStorage::push`, run _after_ `create_run` committed the
+`Started` event. That is not atomic: a crash or a push failure in the window
+between the committed `Started` event and the enqueue leaves a run stuck
+`Running` with no job behind it. Because the recovery reconciler only sweeps at
+startup, the "one running" slot then stays wedged until the next restart --
+exactly the class of failure the #339 history warned against. It also
+contradicted this ADR's own principle that "side effects go through durable
+apalis `Job`s enqueued in the same transaction as the events."
+
+The correction aligns the implementation with that principle: `IngestionRun`
+declares `type Jobs = jobs![IngestionJob]` and enqueues the job from
+`initialize` through the `JobQueue` handle. event-sorcery flushes that buffer on
+the event store's own connection _inside_ the event-commit transaction, so the
+job is queued if and only if the `Started` event commits -- there is no orphan
+window, and the handler no longer has a push to compensate for. The `Start`
+command carries the `IngestionRunId` (the handler does not receive the aggregate
+id) so `initialize` can address the job. The worker moves off the raw
+`SqliteStorage`/`WorkerBuilder` wiring onto event-sorcery's `JobBackend` +
+`build_supervised_worker!`, which polls the `IngestionJob::KIND` queue the
+enqueue side writes and applies the shared retry/backoff/circuit-breaker policy.
+
+Consequence for tests: event-sorcery's `test-support` gates a 4-argument `work`
+handler that pulls a `FailureInjector` from worker data, so the crate gains a
+forwarded `test-support` feature (enabled for the whole `cargo test` graph via a
+self dev-dependency) and the worker registers an idle `FailureInjector` under
+that feature. Production builds omit it entirely.

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -74,22 +74,6 @@ pub(crate) trait Hyperliquid: Send + Sync {
     ) -> Result<Vec<FundingRate>, HyperliquidError>;
 }
 
-/// Hyperliquid info client for ingestion.
-pub(crate) struct HyperliquidClients {
-    pub(crate) mainnet: Arc<dyn Hyperliquid>,
-}
-
-impl HyperliquidClients {
-    pub(crate) async fn from_config(
-        mainnet_base_url: Option<&Url>,
-        max_retries: usize,
-    ) -> Result<Self, HyperliquidError> {
-        let mainnet = Arc::new(HyperliquidClient::new(mainnet_base_url, max_retries).await?)
-            as Arc<dyn Hyperliquid>;
-        Ok(Self { mainnet })
-    }
-}
-
 pub(crate) struct HyperliquidClient {
     info: InfoClient,
     max_retries: usize,

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -12,11 +12,10 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use apalis::prelude::Data;
 use chrono::{DateTime, Utc};
 use event_sorcery::{
-    Column, DomainEvent, EventSourced, JobQueue, Nil, Projection, ProjectionError, SendError,
-    Store, Table,
+    Column, DomainEvent, EventSourced, Job, JobQueue, Label, Projection, ProjectionError,
+    SendError, Store, Table,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -184,6 +183,7 @@ impl DomainEvent for IngestionRunEvent {
 #[derive(Debug, Clone)]
 pub(crate) enum IngestionRunCommand {
     Start {
+        run_id: IngestionRunId,
         started_at: DateTime<Utc>,
     },
     Complete {
@@ -216,7 +216,7 @@ impl EventSourced for IngestionRun {
     type Event = IngestionRunEvent;
     type Command = IngestionRunCommand;
     type Error = IngestionRunError;
-    type Jobs = Nil;
+    type Jobs = event_sorcery::jobs![IngestionJob];
     type Materialized = Table;
 
     const AGGREGATE_TYPE: &'static str = "IngestionRun";
@@ -257,10 +257,15 @@ impl EventSourced for IngestionRun {
 
     fn initialize(
         command: IngestionRunCommand,
-        _jobs: &mut JobQueue<Self::Jobs>,
+        jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<IngestionRunEvent>, IngestionRunError> {
         match command {
-            IngestionRunCommand::Start { started_at } => {
+            IngestionRunCommand::Start { run_id, started_at } => {
+                // Enqueue the ingestion job on the same handle the framework
+                // flushes inside the event-commit transaction, so the job is
+                // queued iff the `Started` event commits -- there is no window
+                // where a run is Running with no job behind it (issue #404).
+                jobs.push(IngestionJob::new(run_id));
                 Ok(vec![IngestionRunEvent::Started { started_at }])
             }
             IngestionRunCommand::Complete { .. }
@@ -317,12 +322,33 @@ impl IngestionJob {
     pub(crate) fn new(run_id: IngestionRunId) -> Self {
         Self { run_id }
     }
+}
 
-    pub(crate) async fn run(
-        self,
-        store: Data<Arc<Store<IngestionRun>>>,
-        services: Data<Arc<IngestionServices>>,
-    ) -> Result<(), SendError<IngestionRun>> {
+/// Everything the ingestion worker needs to drive a run to a terminal state:
+/// the run's own event store (to load state and record completion or failure)
+/// and the fetch/catalog services that do the ingestion work. Built once at
+/// startup and shared as the worker's [`Job::Input`].
+pub(crate) struct IngestionJobContext {
+    pub(crate) run_store: Arc<Store<IngestionRun>>,
+    pub(crate) services: IngestionServices,
+}
+
+impl Job for IngestionJob {
+    type Input = IngestionJobContext;
+    type Output = ();
+    type Error = SendError<IngestionRun>;
+
+    const WORKER_NAME: &'static str = "ingestion";
+    const KIND: &'static str = "ingestion";
+
+    fn label(&self) -> Label {
+        Label::new(format!("ingestion:{}", self.run_id))
+    }
+
+    async fn perform(&self, context: &IngestionJobContext) -> Result<(), SendError<IngestionRun>> {
+        let store = &context.run_store;
+        let services = &context.services;
+
         // A run abandoned by startup recovery must not resurrect: skip the work
         // and leave its terminal state untouched.
         match store.load(&self.run_id).await {
@@ -363,7 +389,7 @@ impl IngestionJob {
                 // The run stays Running until this commits; surface a
                 // terminalization failure so the worker retries instead of
                 // leaving the slot wedged until the next startup reconcile.
-                if let Err(err) = complete_run(&store, &self.run_id, last_record).await {
+                if let Err(err) = complete_run(store, &self.run_id, last_record).await {
                     error!(error = %err, run_id = %self.run_id, "failed to record ingestion completion");
                     return Err(err);
                 }
@@ -373,7 +399,7 @@ impl IngestionJob {
                 error!(error = %err, run_id = %self.run_id, "ingestion failed");
                 // If we cannot even record the failure the run stays Running;
                 // surface it so the worker retries rather than wedging the slot.
-                if let Err(record_err) = fail_run(&store, &self.run_id, &err.to_string()).await {
+                if let Err(record_err) = fail_run(store, &self.run_id, &err.to_string()).await {
                     error!(
                         error = %record_err,
                         run_id = %self.run_id,
@@ -456,7 +482,13 @@ pub(crate) async fn create_run(
     let started_at = Utc::now();
     let run_id = IngestionRunId::new(started_at);
     store
-        .send(&run_id, IngestionRunCommand::Start { started_at })
+        .send(
+            &run_id,
+            IngestionRunCommand::Start {
+                run_id: run_id.clone(),
+                started_at,
+            },
+        )
         .await?;
 
     // The pre-send projection read is not atomic with the Start, so two callers
@@ -602,7 +634,7 @@ mod tests {
     use tracing::Level;
     use tracing_test::traced_test;
 
-    use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
+    use event_sorcery::{Job, LifecycleError, StoreBuilder, TestHarness, replay};
 
     use super::*;
     use crate::candle::Candle;
@@ -825,6 +857,7 @@ mod tests {
             .send(
                 &first_id,
                 IngestionRunCommand::Start {
+                    run_id: first_id.clone(),
                     started_at: shared_start,
                 },
             )
@@ -844,6 +877,7 @@ mod tests {
             .send(
                 &second_id,
                 IngestionRunCommand::Start {
+                    run_id: second_id.clone(),
                     started_at: shared_start,
                 },
             )
@@ -893,13 +927,12 @@ mod tests {
         let run_id = create_run(&store, &projection).await.unwrap();
         recover_abandoned_runs(&store, &projection).await.unwrap();
         let job = IngestionJob::new(run_id.clone());
+        let context = IngestionJobContext {
+            run_store: Arc::clone(&store),
+            services: test_services().await,
+        };
 
-        job.run(
-            Data::new(Arc::clone(&store)),
-            Data::new(Arc::new(test_services().await)),
-        )
-        .await
-        .unwrap();
+        job.perform(&context).await.unwrap();
 
         let status = latest_status(&projection).await.unwrap();
 
@@ -917,13 +950,12 @@ mod tests {
         let (store, projection) = ingestion_store().await;
         let run_id = create_run(&store, &projection).await.unwrap();
         let job = IngestionJob::new(run_id.clone());
+        let context = IngestionJobContext {
+            run_store: Arc::clone(&store),
+            services: test_services().await,
+        };
 
-        job.run(
-            Data::new(Arc::clone(&store)),
-            Data::new(Arc::new(test_services().await)),
-        )
-        .await
-        .unwrap();
+        job.perform(&context).await.unwrap();
 
         let status = latest_status(&projection).await.unwrap();
 

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -19,6 +19,7 @@ use event_sorcery::{
 };
 use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
+use sqlx::{AssertSqlSafe, SqlitePool};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -577,15 +578,49 @@ pub(crate) async fn recover_abandoned_runs(
     Ok(recovered)
 }
 
+/// Materialized-view payload shape for a live [`IngestionRun`].
+#[derive(Deserialize)]
+struct LiveIngestionRunView {
+    #[serde(rename = "Live")]
+    live: IngestionRun,
+}
+
 /// The status of the most recently started run, or `None` if none exist.
+///
+/// Reads a single view row ordered by [`IngestionRunId`] (microsecond start,
+/// then nonce), matching the old `ORDER BY started_at DESC LIMIT 1` ledger
+/// query without loading every run into memory.
 pub(crate) async fn latest_status(
-    projection: &Projection<IngestionRun>,
+    pool: &SqlitePool,
 ) -> Result<Option<IngestionRunStatus>, IngestionError> {
-    let runs = projection.load_all().await?;
-    Ok(runs
-        .into_iter()
-        .max_by(|(left_id, _), (right_id, _)| left_id.cmp(right_id))
-        .map(|(_, run)| run.status))
+    let Table(table) = IngestionRun::PROJECTION;
+    let micros_substr_start = INGESTION_RUN_ID_PREFIX.len() + 1;
+    let query = format!(
+        "SELECT view_id, payload FROM {table}
+         ORDER BY
+           CAST(substr(view_id, {micros_substr_start},
+             instr(substr(view_id, {micros_substr_start}), '-') - 1) AS INTEGER) DESC,
+           view_id DESC
+         LIMIT 1"
+    );
+
+    let row: Option<(String, String)> = sqlx::query_as(AssertSqlSafe(query))
+        .fetch_optional(pool)
+        .await
+        .map_err(|err| IngestionError::Projection(ProjectionError::from(err)))?;
+
+    let Some((view_id, payload)) = row else {
+        return Ok(None);
+    };
+
+    let view: LiveIngestionRunView = serde_json::from_str(&payload).map_err(|source| {
+        IngestionError::Projection(ProjectionError::Serde {
+            aggregate_id: view_id.clone(),
+            source,
+        })
+    })?;
+
+    Ok(Some(view.live.status))
 }
 
 async fn running_runs(
@@ -721,13 +756,14 @@ mod tests {
         }
     }
 
-    async fn ingestion_store() -> (Arc<Store<IngestionRun>>, Arc<Projection<IngestionRun>>) {
+    async fn ingestion_store() -> (Arc<Store<IngestionRun>>, Arc<Projection<IngestionRun>>, SqlitePool) {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
-        StoreBuilder::<IngestionRun>::new(pool)
+        let (store, projection) = StoreBuilder::<IngestionRun>::new(pool.clone())
             .build()
             .await
-            .unwrap()
+            .unwrap();
+        (store, projection, pool)
     }
 
     fn instant() -> DateTime<Utc> {
@@ -806,10 +842,10 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn create_run_starts_a_running_run_and_logs() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
 
         let run_id = create_run(&store, &projection).await.unwrap();
-        let status = latest_status(&projection).await.unwrap();
+        let status = latest_status(&pool).await.unwrap();
 
         assert_eq!(status, Some(IngestionRunStatus::Running));
         let run_id = run_id.to_string();
@@ -850,7 +886,7 @@ mod tests {
 
     #[tokio::test]
     async fn latest_status_prefers_the_latest_run_id_when_microseconds_match() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
         let shared_start = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
         let shared_micros = shared_start.timestamp_micros();
         let first_id: IngestionRunId =
@@ -893,7 +929,7 @@ mod tests {
             .await
             .unwrap();
 
-        let status = latest_status(&projection).await.unwrap();
+        let status = latest_status(&pool).await.unwrap();
 
         assert_eq!(status, Some(IngestionRunStatus::Running));
     }
@@ -904,7 +940,7 @@ mod tests {
         // The sequential case: the projection already reflects the first run, so
         // the pre-send guard rejects. The concurrent race is covered by
         // `concurrent_create_run_admits_exactly_one`.
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
 
         create_run(&store, &projection).await.unwrap();
         let duplicate = create_run(&store, &projection).await;
@@ -915,11 +951,11 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn recover_abandons_running_runs_and_logs() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
 
         create_run(&store, &projection).await.unwrap();
         let recovered = recover_abandoned_runs(&store, &projection).await.unwrap();
-        let status = latest_status(&projection).await.unwrap();
+        let status = latest_status(&pool).await.unwrap();
 
         assert_eq!(recovered, 1);
         assert_eq!(status, Some(IngestionRunStatus::Abandoned));
@@ -932,7 +968,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn stale_job_for_recovered_run_does_not_execute() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
         let run_id = create_run(&store, &projection).await.unwrap();
         recover_abandoned_runs(&store, &projection).await.unwrap();
         let job = IngestionJob::new(run_id.clone());
@@ -943,7 +979,7 @@ mod tests {
 
         job.perform(&context).await.unwrap();
 
-        let status = latest_status(&projection).await.unwrap();
+        let status = latest_status(&pool).await.unwrap();
 
         assert_eq!(status, Some(IngestionRunStatus::Abandoned));
         let run_id = run_id.to_string();
@@ -956,7 +992,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn job_completes_a_running_run_and_logs() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
         let run_id = create_run(&store, &projection).await.unwrap();
         let job = IngestionJob::new(run_id.clone());
         let context = IngestionJobContext {
@@ -966,7 +1002,7 @@ mod tests {
 
         job.perform(&context).await.unwrap();
 
-        let status = latest_status(&projection).await.unwrap();
+        let status = latest_status(&pool).await.unwrap();
 
         assert_eq!(status, Some(IngestionRunStatus::Completed));
         let run_id = run_id.to_string();
@@ -1047,7 +1083,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn recover_with_no_running_runs_is_a_noop() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
 
         let recovered = recover_abandoned_runs(&store, &projection).await.unwrap();
 
@@ -1061,7 +1097,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn concurrent_create_run_admits_exactly_one() {
-        let (store, projection) = ingestion_store().await;
+        let (store, projection, pool) = ingestion_store().await;
 
         // Two callers race create_run on the same store. The one-running
         // invariant must admit exactly one and reject the loser with

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -332,6 +332,7 @@ impl IngestionJob {
 /// startup and shared as the worker's [`Job::Input`].
 pub(crate) struct IngestionJobContext {
     pub(crate) run_store: Arc<Store<IngestionRun>>,
+    pub(crate) run_projection: Arc<Projection<IngestionRun>>,
     pub(crate) services: IngestionServices,
 }
 
@@ -365,6 +366,51 @@ impl Job for IngestionJob {
                 error!(error = %err, run_id = %self.run_id, "failed to load ingestion run");
                 return Err(err);
             }
+        }
+
+        // Both concurrent `create_run` losers and winners enqueue a job atomically
+        // with `Start`. The aggregate can still read Running for a loser until its
+        // `Abandon` commits, so verify this run_id is the projection's sole winner
+        // before any ingestion I/O.
+        let holds_slot = match holds_one_running_slot(&context.run_projection, &self.run_id).await {
+            Ok(holds_slot) => holds_slot,
+            Err(err) => {
+                error!(
+                    error = %err,
+                    run_id = %self.run_id,
+                    "failed to verify the one-running slot"
+                );
+                return retry_ingestion_job(store, &self.run_id).await;
+            }
+        };
+        if !holds_slot {
+            match store.load(&self.run_id).await {
+                Ok(Some(run)) if run.status == IngestionRunStatus::Running => {
+                    store
+                        .send(
+                            &self.run_id,
+                            IngestionRunCommand::Abandon {
+                                reason: LOST_RACE_REASON.to_string(),
+                                reconciled_at: Utc::now(),
+                            },
+                        )
+                        .await?;
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    error!(
+                        error = %err,
+                        run_id = %self.run_id,
+                        "failed to load ingestion run before abandoning race loser"
+                    );
+                    return Err(err);
+                }
+            }
+            warn!(
+                run_id = %self.run_id,
+                "skipping ingestion for a run that lost the one-running race"
+            );
+            return Ok(());
         }
 
         let candle_ingester = CandleIngester::new(
@@ -634,6 +680,37 @@ async fn running_runs(
         .await
 }
 
+async fn holds_one_running_slot(
+    projection: &Projection<IngestionRun>,
+    run_id: &IngestionRunId,
+) -> Result<bool, ProjectionError<IngestionRun>> {
+    Ok(matches!(
+        running_runs(projection).await?.as_slice(),
+        [(winner, _)] if winner == run_id
+    ))
+}
+
+async fn retry_ingestion_job(
+    store: &Store<IngestionRun>,
+    run_id: &IngestionRunId,
+) -> Result<(), SendError<IngestionRun>> {
+    let Some(run) = store.load(run_id).await? else {
+        return Ok(());
+    };
+    if run.status != IngestionRunStatus::Running {
+        return Ok(());
+    }
+    store
+        .send(
+            run_id,
+            IngestionRunCommand::Start {
+                run_id: run_id.clone(),
+                started_at: run.started_at,
+            },
+        )
+        .await
+}
+
 async fn complete_run(
     store: &Store<IngestionRun>,
     run_id: &IngestionRunId,
@@ -678,6 +755,7 @@ mod tests {
     use chrono::{DateTime, TimeZone, Utc};
     use rust_decimal_macros::dec;
     use sqlx::SqlitePool;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use tracing::Level;
     use tracing_test::traced_test;
 
@@ -692,11 +770,30 @@ mod tests {
     use crate::market_metadata::MarketMetadata;
     use crate::timeframe::Timeframe;
 
-    struct MockHyperliquid;
+    struct MockHyperliquid {
+        fetch_market_metadata_calls: Option<Arc<AtomicU32>>,
+    }
+
+    impl MockHyperliquid {
+        fn without_call_counter() -> Self {
+            Self {
+                fetch_market_metadata_calls: None,
+            }
+        }
+
+        fn with_call_counter(fetch_market_metadata_calls: Arc<AtomicU32>) -> Self {
+            Self {
+                fetch_market_metadata_calls: Some(fetch_market_metadata_calls),
+            }
+        }
+    }
 
     #[async_trait]
     impl Hyperliquid for MockHyperliquid {
         async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            if let Some(fetch_market_metadata_calls) = &self.fetch_market_metadata_calls {
+                fetch_market_metadata_calls.fetch_add(1, Ordering::SeqCst);
+            }
             Ok(vec![MarketMetadata {
                 symbol: Market::new("BTC".into()),
                 max_leverage: 50,
@@ -736,6 +833,12 @@ mod tests {
     }
 
     async fn test_services() -> IngestionServices {
+        test_services_with_hyperliquid(Arc::new(MockHyperliquid::without_call_counter())).await
+    }
+
+    async fn test_services_with_hyperliquid(
+        hyperliquid: Arc<dyn Hyperliquid>,
+    ) -> IngestionServices {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
         let (market_catalog, market_catalog_projection) =
@@ -750,12 +853,24 @@ mod tests {
                 .unwrap();
 
         IngestionServices {
-            hyperliquid: Arc::new(MockHyperliquid),
+            hyperliquid,
             data_dir: std::env::temp_dir(),
             max_concurrent_requests: 10,
             market_catalog,
             market_catalog_projection,
             market_enablement_projection,
+        }
+    }
+
+    fn job_context(
+        store: &Arc<Store<IngestionRun>>,
+        projection: &Arc<Projection<IngestionRun>>,
+        services: IngestionServices,
+    ) -> IngestionJobContext {
+        IngestionJobContext {
+            run_store: Arc::clone(store),
+            run_projection: Arc::clone(projection),
+            services,
         }
     }
 
@@ -979,10 +1094,7 @@ mod tests {
         let run_id = create_run(&store, &projection).await.unwrap();
         recover_abandoned_runs(&store, &projection).await.unwrap();
         let job = IngestionJob::new(run_id.clone());
-        let context = IngestionJobContext {
-            run_store: Arc::clone(&store),
-            services: test_services().await,
-        };
+        let context = job_context(&store, &projection, test_services().await);
 
         job.perform(&context).await.unwrap();
 
@@ -1002,10 +1114,7 @@ mod tests {
         let (store, projection, pool) = ingestion_store().await;
         let run_id = create_run(&store, &projection).await.unwrap();
         let job = IngestionJob::new(run_id.clone());
-        let context = IngestionJobContext {
-            run_store: Arc::clone(&store),
-            services: test_services().await,
-        };
+        let context = job_context(&store, &projection, test_services().await);
 
         job.perform(&context).await.unwrap();
 
@@ -1131,5 +1240,96 @@ mod tests {
             1,
             "exactly one run remains in the Running slot"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn race_loser_job_skips_ingestion_before_winner_runs() {
+        let fetch_market_metadata_calls = Arc::new(AtomicU32::new(0));
+        let (store, projection, _pool) = ingestion_store().await;
+        let services = test_services_with_hyperliquid(Arc::new(
+            MockHyperliquid::with_call_counter(Arc::clone(&fetch_market_metadata_calls)),
+        ))
+        .await;
+        let context = job_context(&store, &projection, services);
+
+        // Simulate the post-Start race window: both streams committed `Start`
+        // (and enqueued jobs) but the partial unique index left only one winner
+        // in the projection.
+        let shared_start = instant();
+        let shared_micros = shared_start.timestamp_micros();
+        let first_id: IngestionRunId =
+            format!("ingestion-{shared_micros}-00000000000000000000000000000001")
+                .parse()
+                .unwrap();
+        let second_id: IngestionRunId =
+            format!("ingestion-{shared_micros}-00000000000000000000000000000002")
+                .parse()
+                .unwrap();
+
+        store
+            .send(
+                &first_id,
+                IngestionRunCommand::Start {
+                    run_id: first_id.clone(),
+                    started_at: shared_start,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &second_id,
+                IngestionRunCommand::Start {
+                    run_id: second_id.clone(),
+                    started_at: shared_start,
+                },
+            )
+            .await
+            .unwrap();
+
+        let running = running_runs(&projection).await.unwrap();
+        assert_eq!(running.len(), 1, "projection must admit exactly one winner");
+        let winner_id = running[0].0.clone();
+        let loser_id = if winner_id == first_id {
+            second_id
+        } else {
+            first_id
+        };
+
+        // Run the loser's job first -- the ordering that previously duplicated work.
+        IngestionJob::new(loser_id.clone())
+            .perform(&context)
+            .await
+            .unwrap();
+        IngestionJob::new(winner_id.clone())
+            .perform(&context)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fetch_market_metadata_calls.load(Ordering::SeqCst),
+            1,
+            "only the projection winner may execute ingestion"
+        );
+
+        let loser = store.load(&loser_id).await.unwrap().unwrap();
+        let winner = store.load(&winner_id).await.unwrap().unwrap();
+        assert_eq!(loser.status, IngestionRunStatus::Abandoned);
+        assert_eq!(winner.status, IngestionRunStatus::Completed);
+
+        let loser_id = loser_id.to_string();
+        assert!(logs_contain_at(
+            Level::WARN,
+            &[
+                "skipping ingestion for a run that lost the one-running race",
+                loser_id.as_str()
+            ]
+        ));
+        let winner_id = winner_id.to_string();
+        assert!(logs_contain_at(
+            Level::INFO,
+            &["ingestion complete", winner_id.as_str()]
+        ));
     }
 }

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -538,31 +538,34 @@ pub(crate) async fn recover_abandoned_runs(
     // Abandon each run independently: one failed write must not block recovery
     // of the rest, since this completes before /ingest is served.
     let (recovered, first_error) = stream::iter(running.iter())
-        .fold((0u64, None::<SendError<IngestionRun>>), |(recovered, first_error), (run_id, _)| {
-            let run_id = run_id.clone();
-            async move {
-                match store
-                    .send(
-                        &run_id,
-                        IngestionRunCommand::Abandon {
-                            reason: ABANDONED_RUN_REASON.to_string(),
-                            reconciled_at,
-                        },
-                    )
-                    .await
-                {
-                    Ok(()) => (recovered + 1, first_error),
-                    Err(err) => {
-                        error!(
-                            error = %err,
-                            run_id = %run_id,
-                            "failed to abandon a running ingestion run"
-                        );
-                        (recovered, first_error.or(Some(err)))
+        .fold(
+            (0u64, None::<SendError<IngestionRun>>),
+            |(recovered, first_error), (run_id, _)| {
+                let run_id = run_id.clone();
+                async move {
+                    match store
+                        .send(
+                            &run_id,
+                            IngestionRunCommand::Abandon {
+                                reason: ABANDONED_RUN_REASON.to_string(),
+                                reconciled_at,
+                            },
+                        )
+                        .await
+                    {
+                        Ok(()) => (recovered + 1, first_error),
+                        Err(err) => {
+                            error!(
+                                error = %err,
+                                run_id = %run_id,
+                                "failed to abandon a running ingestion run"
+                            );
+                            (recovered, first_error.or(Some(err)))
+                        }
                     }
                 }
-            }
-        })
+            },
+        )
         .await;
 
     if let Some(err) = first_error {
@@ -756,7 +759,11 @@ mod tests {
         }
     }
 
-    async fn ingestion_store() -> (Arc<Store<IngestionRun>>, Arc<Projection<IngestionRun>>, SqlitePool) {
+    async fn ingestion_store() -> (
+        Arc<Store<IngestionRun>>,
+        Arc<Projection<IngestionRun>>,
+        SqlitePool,
+    ) {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
         let (store, projection) = StoreBuilder::<IngestionRun>::new(pool.clone())
@@ -886,7 +893,7 @@ mod tests {
 
     #[tokio::test]
     async fn latest_status_prefers_the_latest_run_id_when_microseconds_match() {
-        let (store, projection, pool) = ingestion_store().await;
+        let (store, _projection, pool) = ingestion_store().await;
         let shared_start = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
         let shared_micros = shared_start.timestamp_micros();
         let first_id: IngestionRunId =
@@ -940,7 +947,7 @@ mod tests {
         // The sequential case: the projection already reflects the first run, so
         // the pre-send guard rejects. The concurrent race is covered by
         // `concurrent_create_run_admits_exactly_one`.
-        let (store, projection, pool) = ingestion_store().await;
+        let (store, projection, _pool) = ingestion_store().await;
 
         create_run(&store, &projection).await.unwrap();
         let duplicate = create_run(&store, &projection).await;
@@ -1083,7 +1090,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn recover_with_no_running_runs_is_a_noop() {
-        let (store, projection, pool) = ingestion_store().await;
+        let (store, projection, _pool) = ingestion_store().await;
 
         let recovered = recover_abandoned_runs(&store, &projection).await.unwrap();
 
@@ -1097,7 +1104,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn concurrent_create_run_admits_exactly_one() {
-        let (store, projection, pool) = ingestion_store().await;
+        let (store, projection, _pool) = ingestion_store().await;
 
         // Two callers race create_run on the same store. The one-running
         // invariant must admit exactly one and reject the loser with

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -17,6 +17,7 @@ use event_sorcery::{
     Column, DomainEvent, EventSourced, Job, JobQueue, Label, Projection, ProjectionError,
     SendError, Store, Table,
 };
+use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
@@ -533,27 +534,35 @@ pub(crate) async fn recover_abandoned_runs(
     let running = running_runs(projection).await?;
     let reconciled_at = Utc::now();
 
-    let mut recovered = 0u64;
-    let mut first_error = None;
-    for (run_id, _) in &running {
-        // Abandon each run independently: one failed write must not block
-        // recovery of the rest, since this completes before /ingest is served.
-        if let Err(err) = store
-            .send(
-                run_id,
-                IngestionRunCommand::Abandon {
-                    reason: ABANDONED_RUN_REASON.to_string(),
-                    reconciled_at,
-                },
-            )
-            .await
-        {
-            error!(error = %err, run_id = %run_id, "failed to abandon a running ingestion run");
-            first_error.get_or_insert(err);
-            continue;
-        }
-        recovered += 1;
-    }
+    // Abandon each run independently: one failed write must not block recovery
+    // of the rest, since this completes before /ingest is served.
+    let (recovered, first_error) = stream::iter(running.iter())
+        .fold((0u64, None::<SendError<IngestionRun>>), |(recovered, first_error), (run_id, _)| {
+            let run_id = run_id.clone();
+            async move {
+                match store
+                    .send(
+                        &run_id,
+                        IngestionRunCommand::Abandon {
+                            reason: ABANDONED_RUN_REASON.to_string(),
+                            reconciled_at,
+                        },
+                    )
+                    .await
+                {
+                    Ok(()) => (recovered + 1, first_error),
+                    Err(err) => {
+                        error!(
+                            error = %err,
+                            run_id = %run_id,
+                            "failed to abandon a running ingestion run"
+                        );
+                        (recovered, first_error.or(Some(err)))
+                    }
+                }
+            }
+        })
+        .await;
 
     if let Some(err) = first_error {
         return Err(IngestionError::Send(err));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub enum ConfigError {
 
 pub(crate) struct AppState {
     config: Config,
+    database_pool: SqlitePool,
     portfolio_store: Arc<Store<Portfolio>>,
     portfolio_projection: Arc<Projection<Portfolio>>,
     ingestion_store: Arc<Store<IngestionRun>>,
@@ -219,7 +220,7 @@ async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
 async fn get_ingestion_status(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Option<IngestionRunStatus>>, StatusCode> {
-    let status = ingestion::latest_status(&state.ingestion_projection)
+    let status = ingestion::latest_status(&state.database_pool)
         .await
         .map_err(|err| {
             error!(error = %err, "failed to load ingestion status");
@@ -820,6 +821,7 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
 
     let state = Arc::new(AppState {
         config,
+        database_pool: pool,
         portfolio_store,
         portfolio_projection,
         ingestion_store,
@@ -961,6 +963,7 @@ mod tests {
 
         build_router(Arc::new(AppState {
             config,
+            database_pool: pool,
             portfolio_store,
             portfolio_projection,
             ingestion_store,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,6 +813,7 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
     };
     let ingestion_context = Arc::new(IngestionJobContext {
         run_store: Arc::clone(&ingestion_store),
+        run_projection: Arc::clone(&ingestion_projection),
         services,
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,15 +20,17 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use apalis::prelude::{Monitor, TaskSink, WorkerBuilder};
-use apalis_sqlite::SqliteStorage;
 use axum::Json;
 use axum::Router;
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
-use event_sorcery::{AggregateError, LifecycleError, Projection, SendError, Store, StoreBuilder};
+use event_sorcery::{
+    AggregateError, CircuitBreakerConfig, FAIL_STOP_RECOVERY_TIMEOUT, JobBackend, LifecycleError,
+    Monitor as EventSorceryMonitor, Projection, SendError, Store, StoreBuilder,
+    build_supervised_worker,
+};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::FromPrimitive;
 use serde::Deserialize;
@@ -38,10 +40,11 @@ use thiserror::Error;
 use tracing::{debug, error};
 use tracing_subscriber::EnvFilter;
 
-use crate::hyperliquid::HyperliquidClients;
+use crate::hyperliquid::{Hyperliquid, HyperliquidClient};
 use finance::Symbol;
 use ingestion::{
-    IngestionError, IngestionJob, IngestionRun, IngestionRunStatus, IngestionServices,
+    IngestionError, IngestionJob, IngestionJobContext, IngestionRun, IngestionRunStatus,
+    IngestionServices,
 };
 use market_catalog::MarketCatalog;
 use market_enablement::{
@@ -125,7 +128,6 @@ pub(crate) struct AppState {
     market_enablement: Arc<Store<MarketEnablement>>,
     market_enablement_projection: Arc<Projection<MarketEnablement>>,
     market_catalog_projection: Arc<Projection<MarketCatalog>>,
-    apalis_pool: apalis_sqlite::SqlitePool,
 }
 
 /// Renders pre-serialized JSON bytes with the `application/json` content type.
@@ -201,32 +203,17 @@ async fn post_screener(
 }
 
 async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
-    let run_id =
-        match ingestion::create_run(&state.ingestion_store, &state.ingestion_projection).await {
-            Ok(run_id) => run_id,
-            Err(IngestionError::AlreadyRunning) => return StatusCode::CONFLICT,
-            Err(err) => {
-                error!(error = %err, "failed to create ingestion run");
-                return StatusCode::INTERNAL_SERVER_ERROR;
-            }
-        };
-
-    let mut job_queue = SqliteStorage::<IngestionJob, (), ()>::new(&state.apalis_pool);
-    if let Err(err) = job_queue.push(IngestionJob::new(run_id.clone())).await {
-        error!(error = %err, "failed to queue ingestion job");
-        if let Err(record_err) = ingestion::fail_run(
-            &state.ingestion_store,
-            &run_id,
-            "failed to queue ingestion job",
-        )
-        .await
-        {
-            error!(error = %record_err, "failed to record ingestion queue failure");
+    // `create_run` enqueues the ingestion job atomically with the `Started`
+    // event through the aggregate's `Jobs` handle, so there is no separate push
+    // to fail here and no window where a Running run has no job (issue #404).
+    match ingestion::create_run(&state.ingestion_store, &state.ingestion_projection).await {
+        Ok(_run_id) => StatusCode::ACCEPTED,
+        Err(IngestionError::AlreadyRunning) => StatusCode::CONFLICT,
+        Err(err) => {
+            error!(error = %err, "failed to create ingestion run");
+            StatusCode::INTERNAL_SERVER_ERROR
         }
-        return StatusCode::INTERNAL_SERVER_ERROR;
     }
-
-    StatusCode::ACCEPTED
 }
 
 async fn get_ingestion_status(
@@ -703,20 +690,48 @@ fn classify_enablement_error(error: &SendError<MarketEnablement>, operation: &st
 
 /// Spawns the supervised apalis worker that drains queued ingestion jobs.
 ///
-/// The worker reads the `Jobs` table through its own sqlx-0.8 `apalis_pool` and
-/// drives each run's lifecycle through the sqlx-0.9 `ingestion_store`.
+/// The worker reads the `Jobs` table through its own sqlx-0.8 `apalis_pool`
+/// (matched to the queue by [`JobBackend`], which polls the `IngestionJob::KIND`
+/// queue the enqueue side writes) and drives each run's lifecycle through the
+/// sqlx-0.9 event store bundled in the [`IngestionJobContext`]. It carries the
+/// library's shared retry/backoff/circuit-breaker policy: retries are exhausted
+/// before a terminal failure trips the breaker and stops the worker for a human
+/// to inspect.
 fn spawn_ingestion_worker(
     apalis_pool: apalis_sqlite::SqlitePool,
-    ingestion_store: Arc<Store<IngestionRun>>,
-    services: Arc<IngestionServices>,
+    context: Arc<IngestionJobContext>,
 ) {
     tokio::spawn(async move {
-        let monitor = Monitor::new().register(move |_worker_index| {
-            WorkerBuilder::new("ingestion")
-                .backend(SqliteStorage::<IngestionJob, (), ()>::new(&apalis_pool))
-                .data(Arc::clone(&ingestion_store))
-                .data(services.clone())
-                .build(IngestionJob::run)
+        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let monitor = EventSorceryMonitor::new().register(move |worker_index| {
+            let backend = JobBackend::<IngestionJob>::new(&apalis_pool);
+            let fail_stop =
+                CircuitBreakerConfig::default().with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+
+            // Under `test-support`, event-sorcery's `work` handler routes
+            // through a `FailureInjector` pulled from worker data, so it must be
+            // registered for jobs to run; production builds omit it entirely.
+            #[cfg(not(feature = "test-support"))]
+            let worker = build_supervised_worker!(
+                ::<IngestionJob>,
+                worker_index,
+                backend,
+                Arc::clone(&context),
+                fail_stop,
+                Arc::clone(&failure_notify),
+            );
+            #[cfg(feature = "test-support")]
+            let worker = build_supervised_worker!(
+                ::<IngestionJob>,
+                worker_index,
+                backend,
+                Arc::clone(&context),
+                fail_stop,
+                Arc::clone(&failure_notify),
+                event_sorcery::FailureInjector::new(),
+            );
+
+            worker
         });
         if let Err(err) = monitor.run().await {
             error!(error = %err, "ingestion monitor crashed");
@@ -784,23 +799,23 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
     let apalis_pool = apalis_sqlite::SqlitePool::connect_with(apalis_options).await?;
     debug!("apalis storage pool connected");
 
-    let hyperliquid_clients =
-        HyperliquidClients::from_config(config.hyperliquid_base_url.as_ref(), config.max_retries)
-            .await?;
-    let services = Arc::new(IngestionServices {
-        hyperliquid: Arc::clone(&hyperliquid_clients.mainnet),
+    let hyperliquid: Arc<dyn Hyperliquid> = Arc::new(
+        HyperliquidClient::new(config.hyperliquid_base_url.as_ref(), config.max_retries).await?,
+    );
+    let services = IngestionServices {
+        hyperliquid,
         data_dir: config.data_dir.clone(),
         max_concurrent_requests: config.max_concurrent_requests,
         market_catalog: Arc::clone(&market_catalog),
         market_catalog_projection: Arc::clone(&market_catalog_projection),
         market_enablement_projection: Arc::clone(&market_enablement_projection),
+    };
+    let ingestion_context = Arc::new(IngestionJobContext {
+        run_store: Arc::clone(&ingestion_store),
+        services,
     });
 
-    spawn_ingestion_worker(
-        apalis_pool.clone(),
-        Arc::clone(&ingestion_store),
-        Arc::clone(&services),
-    );
+    spawn_ingestion_worker(apalis_pool.clone(), ingestion_context);
     debug!("ingestion worker started");
 
     let state = Arc::new(AppState {
@@ -812,7 +827,6 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
         market_enablement,
         market_enablement_projection,
         market_catalog_projection,
-        apalis_pool,
     });
 
     Ok(build_router(state))
@@ -945,13 +959,6 @@ mod tests {
                 .await
                 .unwrap();
 
-        let apalis_options = apalis_sqlite::SqliteConnectOptions::from_str(&config.database_url)
-            .unwrap()
-            .busy_timeout(std::time::Duration::from_secs(5));
-        let apalis_pool = apalis_sqlite::SqlitePool::connect_with(apalis_options)
-            .await
-            .unwrap();
-
         build_router(Arc::new(AppState {
             config,
             portfolio_store,
@@ -961,7 +968,6 @@ mod tests {
             market_enablement,
             market_enablement_projection,
             market_catalog_projection,
-            apalis_pool,
         }))
     }
 


### PR DESCRIPTION
## Motivation

`create_run` committed the `Started` event, then the `/ingest` handler enqueued
the ingestion job in a separate push -- a crash or push failure in between left a
run stuck `Running` with no job behind it, wedging the one-running slot until the
next startup sweep. It also broke ADR 0001's rule that side effects ride jobs
enqueued in the same transaction as their events.

Concurrent `create_run` races made the gap worse: both winner and loser enqueue
jobs atomically with `Start`, but the loser's aggregate can still read `Running`
until its `Abandon` commits, so a loser job could duplicate ingestion if
`perform` only checked aggregate state.

Closes #404.

## Solution

`IngestionRun` now declares `type Jobs = jobs![IngestionJob]` and enqueues from
`initialize` through the `JobQueue`, which event-sorcery flushes inside the
event-commit transaction, so the job is queued iff the `Started` event commits
and the handler has no push to compensate for. The `Start` command carries the
run id so the pure handler can address the job. The worker moves onto
`JobBackend` + `build_supervised_worker!`, with a forwarded `test-support`
feature registering an idle `FailureInjector` so the worker resolves under
`cargo test`.

`perform` reads `run_projection` and skips I/O unless this run is the sole
`Running` winner, abandoning race losers without duplicating work. A regression
test runs both enqueued jobs (loser first) and asserts only one ingestion
executes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #410
- <kbd>&nbsp;3&nbsp;</kbd> #380
- <kbd>&nbsp;2&nbsp;</kbd> #409
- <kbd>&nbsp;1&nbsp;</kbd> #406 👈
<!-- GitButler Footer Boundary Bottom -->