### PR TITLE
feat: scheduled ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "apalis-cron"
+version = "1.0.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1536e0af43d92eda2b6df260879861e59e913ea60e0b0388ae48ac43138a5ad"
+dependencies = [
+ "apalis-core",
+ "chrono",
+ "cron",
+ "futures-util",
+ "serde",
+ "ulid",
+]
+
+[[package]]
 name = "apalis-sql"
 version = "1.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1216,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "phf 0.11.3",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3394,6 +3420,7 @@ name = "moneymentum"
 version = "0.1.0"
 dependencies = [
  "apalis",
+ "apalis-cron",
  "apalis-sqlite",
  "async-trait",
  "axum",
@@ -3401,6 +3428,7 @@ dependencies = [
  "bitcoin",
  "chrono",
  "clap",
+ "cron",
  "event-sorcery",
  "futures",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ authors = ["Data Clique Software Design FZCO"]
 
 [dependencies]
 apalis = "=1.0.0-rc.9"
+apalis-cron = "=1.0.0-rc.8"
 apalis-sqlite = "=1.0.0-rc.8"
 async-trait = "0.1.89"
 axum = "0.8.9"
@@ -51,6 +52,7 @@ backon = "1.6.0"
 bitcoin = "0.32.8"
 chrono = { version = "0.4.43", features = ["serde"] }
 clap = { version = "4.5.57", features = ["derive", "env"] }
+cron = "=0.16.0"
 event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery", tag = "0.2.0-rc2", version = "0.1.0" }
 futures = "0.3.31"
 getrandom = "0.4.3"

--- a/config.toml
+++ b/config.toml
@@ -19,4 +19,5 @@ log_level = "info"
 # Concurrency and retry settings for Hyperliquid requests.
 max_concurrent_requests = 1
 max_retries = 5                                       # so that Rust patiently retries on 429
+ingestion_schedule = "0 0 * * * *"
 markets_refresh_token = "local-markets-refresh-token"

--- a/config/moneymentum.toml
+++ b/config/moneymentum.toml
@@ -4,3 +4,4 @@ database_url = "sqlite:///mnt/data/prod/moneymentum.db?mode=rwc"
 log_level = "info"
 max_concurrent_requests = 3
 max_retries = 5
+ingestion_schedule = "0 0 * * * *"

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -4,3 +4,4 @@ database_url = "sqlite:///mnt/data/staging/moneymentum.db?mode=rwc"
 log_level = "debug"
 max_concurrent_requests = 3
 max_retries = 5
+ingestion_schedule = "0 0 * * * *"

--- a/example.toml
+++ b/example.toml
@@ -10,6 +10,11 @@ log_level = "debug"
 # Ingestion tuning - balance speed vs rate limiting
 max_concurrent_requests = 3
 max_retries = 5
+
+# Ingestion schedule as a 6-field cron expression
+# (sec min hour day-of-month month day-of-week). Hourly, on the hour:
+ingestion_schedule = "0 0 * * * *"
+
 markets_refresh_token = "local-markets-refresh-token"
 
 # Derive (Lyra) options integration.

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use chrono::{DateTime, Utc};
 use event_sorcery::{
@@ -523,6 +524,39 @@ pub(crate) async fn create_run(
 
     debug!(run_id = %run_id, "ingestion run created");
     Ok(run_id)
+}
+
+/// Opens an ingestion run and enqueues its job atomically with the `Started`
+/// event. Shared by the `/ingest` handler and the scheduler.
+pub(crate) async fn enqueue_run(
+    store: &Store<IngestionRun>,
+    projection: &Projection<IngestionRun>,
+) -> Result<IngestionRunId, IngestionError> {
+    create_run(store, projection).await
+}
+
+/// Runs one scheduled ingestion attempt. An already-running run is the normal
+/// skip-this-tick case, not a failure; genuine failures increment a consecutive
+/// counter and warn so an operator can spot a wedged scheduler.
+pub(crate) async fn trigger_scheduled_ingestion(
+    store: &Store<IngestionRun>,
+    projection: &Projection<IngestionRun>,
+    consecutive_failures: &AtomicU32,
+) {
+    match enqueue_run(store, projection).await {
+        Ok(run_id) => {
+            consecutive_failures.store(0, Ordering::Relaxed);
+            debug!(run_id = %run_id, "scheduled ingestion run enqueued");
+        }
+        Err(IngestionError::AlreadyRunning) => {
+            consecutive_failures.store(0, Ordering::Relaxed);
+            debug!("scheduled ingestion skipped; a run is already active");
+        }
+        Err(err) => {
+            let consecutive = consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
+            warn!(error = %err, consecutive, "scheduled ingestion run failed");
+        }
+    }
 }
 
 /// Abandons every still-running stream. Run unconditionally at startup, before
@@ -1131,5 +1165,42 @@ mod tests {
             1,
             "exactly one run remains in the Running slot"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn scheduled_ingestion_skips_when_a_run_is_already_active() {
+        let (store, projection, _pool) = ingestion_store().await;
+        let consecutive_failures = AtomicU32::new(3);
+
+        create_run(&store, &projection).await.unwrap();
+        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
+
+        assert_eq!(
+            consecutive_failures.load(Ordering::Relaxed),
+            0,
+            "an active run is a normal skip, not a failure"
+        );
+        assert!(logs_contain_at(
+            Level::DEBUG,
+            &["scheduled ingestion skipped"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn scheduled_ingestion_warns_and_counts_consecutive_failures() {
+        let (store, projection, pool) = ingestion_store().await;
+        pool.close().await;
+        let consecutive_failures = AtomicU32::new(0);
+
+        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
+        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
+
+        assert_eq!(consecutive_failures.load(Ordering::Relaxed), 2);
+        assert!(logs_contain_at(
+            Level::WARN,
+            &["scheduled ingestion run failed", "consecutive=2"]
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
 
+use apalis::prelude::{Data, Monitor, WorkerBuilder};
 use axum::Json;
 use axum::Router;
 use axum::extract::{Path as AxumPath, Query, State};
@@ -88,6 +90,7 @@ pub struct Config {
     log_level: LogLevel,
     max_concurrent_requests: usize,
     max_retries: usize,
+    ingestion_schedule: String,
     pub derive: Option<derive::DeriveConfig>,
 }
 
@@ -204,14 +207,11 @@ async fn post_screener(
 }
 
 async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
-    // `create_run` enqueues the ingestion job atomically with the `Started`
-    // event through the aggregate's `Jobs` handle, so there is no separate push
-    // to fail here and no window where a Running run has no job (issue #404).
-    match ingestion::create_run(&state.ingestion_store, &state.ingestion_projection).await {
-        Ok(_run_id) => StatusCode::ACCEPTED,
+    match ingestion::enqueue_run(&state.ingestion_store, &state.ingestion_projection).await {
+        Ok(_) => StatusCode::ACCEPTED,
         Err(IngestionError::AlreadyRunning) => StatusCode::CONFLICT,
         Err(err) => {
-            error!(error = %err, "failed to create ingestion run");
+            error!(error = %err, "failed to start ingestion run");
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }
@@ -740,6 +740,46 @@ fn spawn_ingestion_worker(
     });
 }
 
+/// apalis-cron handler: enqueues an ingestion run on each schedule tick.
+async fn run_scheduled_ingestion(
+    _tick: apalis_cron::Tick<chrono::Utc>,
+    ingestion_store: Data<Arc<Store<IngestionRun>>>,
+    ingestion_projection: Data<Arc<Projection<IngestionRun>>>,
+    consecutive_failures: Data<Arc<AtomicU32>>,
+) -> Result<(), std::convert::Infallible> {
+    ingestion::trigger_scheduled_ingestion(
+        &ingestion_store,
+        &ingestion_projection,
+        &consecutive_failures,
+    )
+    .await;
+    Ok(())
+}
+
+/// Spawns the supervised apalis-cron worker that enqueues an ingestion run on a
+/// fixed schedule, so deployed data stays current without an operator poking
+/// `/ingest`.
+fn spawn_ingestion_scheduler(
+    schedule: cron::Schedule,
+    ingestion_store: Arc<Store<IngestionRun>>,
+    ingestion_projection: Arc<Projection<IngestionRun>>,
+) {
+    let consecutive_failures = Arc::new(AtomicU32::new(0));
+    tokio::spawn(async move {
+        let monitor = Monitor::new().register(move |_worker_index| {
+            WorkerBuilder::new("ingestion-scheduler")
+                .backend(apalis_cron::CronStream::new(schedule.clone()))
+                .data(Arc::clone(&ingestion_store))
+                .data(Arc::clone(&ingestion_projection))
+                .data(Arc::clone(&consecutive_failures))
+                .build(run_scheduled_ingestion)
+        });
+        if let Err(err) = monitor.run().await {
+            error!(error = %err, "ingestion scheduler monitor crashed");
+        }
+    });
+}
+
 /// Build the moneymentum HTTP router.
 ///
 /// # Errors
@@ -752,6 +792,11 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 
     ensure_shared_database(&config.database_url)?;
+
+    // Parse the schedule before any setup or background task: an invalid cron
+    // expression must fail startup outright, never after a worker has already
+    // been detached.
+    let ingestion_schedule = cron::Schedule::from_str(&config.ingestion_schedule)?;
 
     let database_options = SqliteConnectOptions::from_str(&config.database_url)?
         .journal_mode(SqliteJournalMode::Wal)
@@ -818,6 +863,13 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
 
     spawn_ingestion_worker(apalis_pool.clone(), ingestion_context);
     debug!("ingestion worker started");
+
+    spawn_ingestion_scheduler(
+        ingestion_schedule,
+        Arc::clone(&ingestion_store),
+        Arc::clone(&ingestion_projection),
+    );
+    debug!("ingestion scheduler started");
 
     let state = Arc::new(AppState {
         config,
@@ -927,6 +979,7 @@ mod tests {
             log_level: LogLevel::Info,
             max_concurrent_requests: 3,
             max_retries: 5,
+            ingestion_schedule: "0 0 * * * *".to_string(),
             derive: None,
         };
 
@@ -1192,6 +1245,7 @@ mod tests {
                 log_level = "info"
                 max_concurrent_requests = 3
                 max_retries = 5
+                ingestion_schedule = "0 0 * * * *"
             "#);
             let config: Config = toml::from_str(&toml).unwrap();
             prop_assert_eq!(config.port, port);

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -98,6 +98,7 @@ async fn spawn_test_app(mock_server: &MockServer, data_dir: &TempDir) -> TestApp
         log_level = "debug"
         max_concurrent_requests = 3
         max_retries = 2
+        ingestion_schedule = "0 0 * * * *"
         "#,
         data_dir.path().display(),
         database_path.display(),


### PR DESCRIPTION
## Why

Ingestion only runs when an operator POSTs `/ingest`, so deployed OHLCV and
funding data go stale between manual triggers. For beta and downstream analytics
to stay useful, the service needs to refresh market data on a fixed cadence
without human intervention.

Closes #79.

## How

Adds required `ingestion_schedule` config (6-field cron expression) and starts
an apalis-cron worker at app boot that enqueues ingestion runs on that schedule.
The `/ingest` handler and the scheduler share `enqueue_run`, which delegates to
`create_run` from #406 so run creation and job queueing stay atomic. An
already-running run is the normal skip-this-tick case; other failures increment
a consecutive counter and warn so an operator can spot a wedged scheduler.
Invalid cron expressions fail startup before any background worker is spawned.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #408 👈
- <kbd>&nbsp;1&nbsp;</kbd> #406
<!-- GitButler Footer Boundary Bottom -->
