### PR TITLE
feat: decouple ingestion jobs by timeframe with per-work schedules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7347,6 +7347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wallet"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "tokio",
+ "tracing",
+ "tracing-test",
+ "wallet",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,9 @@ Design: [adrs/0001](./adrs/0001-event-sorcery-persistence-foundation.md).
 - [x] Serve per-market max leverage limits from the catalog --
       [#379](https://github.com/dataclique/moneymentum/issues/379) /
       [#380](https://github.com/dataclique/moneymentum/pull/380)
+- [x] Schedule candle and funding ingestion on independent cadences --
+      [#411](https://github.com/dataclique/moneymentum/issues/411) /
+      [#412](https://github.com/dataclique/moneymentum/pull/412)
 
 ---
 

--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,6 @@ log_level = "info"
 
 # Concurrency and retry settings for Hyperliquid requests.
 max_concurrent_requests = 1
-max_retries = 5                                       # so that Rust patiently retries on 429
-ingestion_schedule = "0 0 * * * *"
+max_retries = 5             # so that Rust patiently retries on 429
+
 markets_refresh_token = "local-markets-refresh-token"

--- a/config/moneymentum.toml
+++ b/config/moneymentum.toml
@@ -4,4 +4,3 @@ database_url = "sqlite:///mnt/data/prod/moneymentum.db?mode=rwc"
 log_level = "info"
 max_concurrent_requests = 3
 max_retries = 5
-ingestion_schedule = "0 0 * * * *"

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -4,4 +4,3 @@ database_url = "sqlite:///mnt/data/staging/moneymentum.db?mode=rwc"
 log_level = "debug"
 max_concurrent_requests = 3
 max_retries = 5
-ingestion_schedule = "0 0 * * * *"

--- a/example.toml
+++ b/example.toml
@@ -11,10 +11,6 @@ log_level = "debug"
 max_concurrent_requests = 3
 max_retries = 5
 
-# Ingestion schedule as a 6-field cron expression
-# (sec min hour day-of-month month day-of-week). Hourly, on the hour:
-ingestion_schedule = "0 0 * * * *"
-
 markets_refresh_token = "local-markets-refresh-token"
 
 # Derive (Lyra) options integration.

--- a/migrations/20260618073806_per_work_ingestion_running_slot.sql
+++ b/migrations/20260618073806_per_work_ingestion_running_slot.sql
@@ -1,0 +1,12 @@
+-- One Running row per schedule key (1h, 15m, funding, ...) instead of one
+-- globally, so coincident cron ticks for different work units can each enqueue.
+
+DROP INDEX IF EXISTS one_running_ingestion_run;
+
+ALTER TABLE ingestion_run_view ADD COLUMN schedule_key TEXT GENERATED ALWAYS AS (
+    json_extract(payload, '$.Live.schedule_key')
+) STORED;
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_running_ingestion_run_per_schedule_key
+    ON ingestion_run_view(schedule_key)
+    WHERE status = 'Running';

--- a/os.nix
+++ b/os.nix
@@ -243,16 +243,6 @@ in
   programs.bash.interactiveShellInit = "set -o vi";
 
   systemd.services = lib.mapAttrs mkService enabledServices // {
-    moneymentum-ingest = {
-      description = "Trigger moneymentum data ingestion";
-      unitConfig.ConditionPathExists = "/run/moneymentum/moneymentum.ready";
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        ExecStart = "${pkgs.curl}/bin/curl -sSf --max-time 300 -X POST http://127.0.0.1:8000/ingest";
-      };
-    };
-
     moneymentum-markets-refresh = mkMarketsRefreshService {
       description = "Refresh Hyperliquid markets metadata";
       readyMarker = "/run/moneymentum/moneymentum.ready";
@@ -265,15 +255,6 @@ in
       readyMarker = "/run/moneymentum/staging.ready";
       port = 8001;
       runtimeTokenPath = "/run/moneymentum/staging/markets-refresh-token";
-    };
-  };
-
-  systemd.timers.moneymentum-ingest = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnBootSec = "5min";
-      OnUnitActiveSec = "6h";
-      Persistent = true;
     };
   };
 

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -3,9 +3,9 @@
 //! Each ingestion attempt is its own [`IngestionRun`] stream -- a monotone
 //! `Running -> {Completed, Failed, Abandoned}` state machine -- so crashed and
 //! abandoned runs stay visible without a database reset. The "one running"
-//! invariant is the /ingest handler checking the projection plus a partial
+//! invariant is enforced by the one-running projection check plus a partial
 //! unique index; an unconditional startup reconciler abandons every still-running
-//! stream before /ingest is served, so a crash can never wedge the slot.
+//! stream before schedulers start, so a crash can never wedge the slot.
 //!
 //! Organized by concern:
 //! - [`run_id`]: opaque run identity and wire parsing.
@@ -19,13 +19,16 @@ mod orchestration;
 mod run;
 mod run_id;
 mod services;
+mod work;
 
 #[cfg(test)]
 pub(crate) mod fixtures;
 
 pub(crate) use job::{IngestionJob, IngestionJobContext};
 pub(crate) use orchestration::{
-    IngestionError, create_run, latest_status, recover_abandoned_runs, trigger_scheduled_ingestion,
+    IngestionError, create_run, default_ingestion_schedules, latest_status, recover_abandoned_runs,
+    trigger_scheduled_ingestion,
 };
 pub(crate) use run::{IngestionRun, IngestionRunStatus};
 pub(crate) use services::IngestionServices;
+pub(crate) use work::IngestionWork;

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -2,10 +2,10 @@
 //!
 //! Each ingestion attempt is its own [`IngestionRun`] stream -- a monotone
 //! `Running -> {Completed, Failed, Abandoned}` state machine -- so crashed and
-//! abandoned runs stay visible without a database reset. The "one running"
-//! invariant is enforced by the one-running projection check plus a partial
-//! unique index; an unconditional startup reconciler abandons every still-running
-//! stream before schedulers start, so a crash can never wedge the slot.
+//! abandoned runs stay visible without a database reset. The one-running-run-per-
+//! schedule-key invariant is enforced by the per-work projection check plus a
+//! partial unique index; an unconditional startup reconciler abandons every
+//! still-running stream before schedulers start, so a crash can never wedge a slot.
 //!
 //! Organized by concern:
 //! - [`run_id`]: opaque run identity and wire parsing.
@@ -26,8 +26,7 @@ pub(crate) mod fixtures;
 
 pub(crate) use job::{IngestionJob, IngestionJobContext};
 pub(crate) use orchestration::{
-    IngestionError, create_run, default_ingestion_schedules, latest_status, recover_abandoned_runs,
-    trigger_scheduled_ingestion,
+    default_ingestion_schedules, latest_status, recover_abandoned_runs, trigger_scheduled_ingestion,
 };
 pub(crate) use run::{IngestionRun, IngestionRunStatus};
 pub(crate) use services::IngestionServices;

--- a/src/ingestion/fixtures.rs
+++ b/src/ingestion/fixtures.rs
@@ -8,9 +8,6 @@ use rust_decimal_macros::dec;
 use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
 
-use super::job::IngestionJobContext;
-use super::run::IngestionRun;
-use super::services::IngestionServices;
 use crate::candle::Candle;
 use crate::finance::{Market, Symbol, hyperliquid_swap_ccxt_symbol};
 use crate::funding::FundingRate;
@@ -20,8 +17,13 @@ use crate::market_enablement::MarketEnablement;
 use crate::market_metadata::MarketMetadata;
 use crate::timeframe::Timeframe;
 
+use super::job::IngestionJobContext;
+use super::run::IngestionRun;
+use super::services::IngestionServices;
+
 pub(crate) struct MockHyperliquid {
     pub(crate) fetch_market_metadata_calls: Option<Arc<AtomicU32>>,
+    pub(crate) fetch_candles_calls: Option<Arc<AtomicU32>>,
 }
 
 pub(crate) struct FailingMockHyperliquid;
@@ -30,12 +32,21 @@ impl MockHyperliquid {
     pub(crate) fn without_call_counter() -> Self {
         Self {
             fetch_market_metadata_calls: None,
+            fetch_candles_calls: None,
         }
     }
 
     pub(crate) fn with_call_counter(fetch_market_metadata_calls: Arc<AtomicU32>) -> Self {
         Self {
             fetch_market_metadata_calls: Some(fetch_market_metadata_calls),
+            fetch_candles_calls: None,
+        }
+    }
+
+    pub(crate) fn with_candle_call_counter(fetch_candles_calls: Arc<AtomicU32>) -> Self {
+        Self {
+            fetch_market_metadata_calls: None,
+            fetch_candles_calls: Some(fetch_candles_calls),
         }
     }
 }
@@ -59,6 +70,9 @@ impl Hyperliquid for MockHyperliquid {
         _timeframe: Timeframe,
         _start: DateTime<Utc>,
     ) -> Result<Vec<Candle>, HyperliquidError> {
+        if let Some(fetch_candles_calls) = &self.fetch_candles_calls {
+            fetch_candles_calls.fetch_add(1, Ordering::SeqCst);
+        }
         Ok(vec![Candle {
             timestamp: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
             open: 100.0,
@@ -110,6 +124,18 @@ impl Hyperliquid for FailingMockHyperliquid {
 
 pub(crate) async fn test_services() -> IngestionServices {
     test_services_with_hyperliquid(Arc::new(MockHyperliquid::without_call_counter())).await
+}
+
+async fn in_memory_sqlite_pool() -> SqlitePool {
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(":memory:")
+        .await
+        .unwrap()
+}
+
+fn unique_test_data_dir() -> std::path::PathBuf {
+    tempfile::tempdir().expect("test data dir").keep()
 }
 
 pub(crate) async fn test_services_with_hyperliquid(
@@ -165,16 +191,4 @@ pub(crate) async fn ingestion_store() -> (
 
 pub(crate) fn instant() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
-}
-
-async fn in_memory_sqlite_pool() -> SqlitePool {
-    SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect(":memory:")
-        .await
-        .unwrap()
-}
-
-fn unique_test_data_dir() -> std::path::PathBuf {
-    tempfile::tempdir().expect("test data dir").keep()
 }

--- a/src/ingestion/job.rs
+++ b/src/ingestion/job.rs
@@ -1,15 +1,11 @@
 use chrono::{DateTime, Utc};
 use event_sorcery::{Job, Label, Projection, ProjectionError, SendError, Store};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use crate::hyperliquid::{CandleIngester, FundingRateIngester, Hyperliquid};
-use crate::market_catalog::MarketCatalog;
-use crate::market_enablement::MarketEnablement;
 use crate::market_metadata::RefreshError;
-use crate::timeframe::Timeframe;
 
 use super::orchestration::LOST_RACE_REASON;
 use super::run::{
@@ -17,6 +13,7 @@ use super::run::{
 };
 use super::run_id::IngestionRunId;
 use super::services::IngestionServices;
+use super::work::IngestionWork;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum IngestionJobError {
@@ -26,21 +23,15 @@ pub(crate) enum IngestionJobError {
     Projection(#[from] ProjectionError<IngestionRun>),
 }
 
-const TIMEFRAMES: &[Timeframe] = &[
-    Timeframe::FifteenMin,
-    Timeframe::OneHour,
-    Timeframe::OneDay,
-    Timeframe::OneWeek,
-];
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct IngestionJob {
     run_id: IngestionRunId,
+    work: IngestionWork,
 }
 
 impl IngestionJob {
-    pub(crate) fn new(run_id: IngestionRunId) -> Self {
-        Self { run_id }
+    pub(crate) fn new(run_id: IngestionRunId, work: IngestionWork) -> Self {
+        Self { run_id, work }
     }
 }
 
@@ -63,7 +54,11 @@ impl Job for IngestionJob {
     const KIND: &'static str = "ingestion";
 
     fn label(&self) -> Label {
-        Label::new(format!("ingestion:{}", self.run_id))
+        Label::new(format!(
+            "ingestion:{}:{}",
+            self.work.schedule_key(),
+            self.run_id
+        ))
     }
 
     async fn perform(&self, context: &IngestionJobContext) -> Result<(), IngestionJobError> {
@@ -140,17 +135,7 @@ impl Job for IngestionJob {
             services.max_concurrent_requests,
         );
 
-        match ingest_all(
-            services.hyperliquid.as_ref(),
-            &candle_ingester,
-            &funding_ingester,
-            &services.data_dir,
-            &services.market_catalog,
-            &services.market_catalog_projection,
-            &services.market_enablement_projection,
-        )
-        .await
-        {
+        match ingest_work(self.work, &candle_ingester, &funding_ingester, services).await {
             Ok(last_record) => {
                 // The run stays Running until this commits; surface a
                 // terminalization failure so the worker retries instead of
@@ -180,31 +165,31 @@ impl Job for IngestionJob {
     }
 }
 
-async fn ingest_all(
-    client: &dyn Hyperliquid,
+async fn ingest_work(
+    work: IngestionWork,
     candle_ingester: &CandleIngester<dyn Hyperliquid>,
     funding_ingester: &FundingRateIngester<dyn Hyperliquid>,
-    data_dir: &Path,
-    market_catalog: &Store<MarketCatalog>,
-    market_catalog_projection: &Projection<MarketCatalog>,
-    market_enablement_projection: &Projection<MarketEnablement>,
+    services: &IngestionServices,
 ) -> Result<DateTime<Utc>, RefreshError> {
     let markets = crate::market_metadata::refresh_markets(
-        client,
-        market_catalog,
-        market_catalog_projection,
-        market_enablement_projection,
+        services.hyperliquid.as_ref(),
+        &services.market_catalog,
+        &services.market_catalog_projection,
+        &services.market_enablement_projection,
     )
     .await?;
 
-    funding_ingester
-        .ingest_with_markets(data_dir, &markets)
-        .await?;
-
-    for timeframe in TIMEFRAMES {
-        candle_ingester
-            .ingest_with_markets(*timeframe, data_dir, &markets)
-            .await?;
+    match work {
+        IngestionWork::Funding => {
+            funding_ingester
+                .ingest_with_markets(&services.data_dir, &markets)
+                .await?;
+        }
+        IngestionWork::Candles(timeframe) => {
+            candle_ingester
+                .ingest_with_markets(timeframe, &services.data_dir, &markets)
+                .await?;
+        }
     }
 
     Ok(Utc::now())
@@ -235,29 +220,93 @@ mod tests {
         test_services, test_services_with_hyperliquid,
     };
     use crate::ingestion::orchestration::{create_run, latest_status, recover_abandoned_runs};
-    use crate::ingestion::run::running_runs;
-    use crate::ingestion::run::{IngestionRunCommand, IngestionRunStatus};
+    use crate::ingestion::run::{IngestionRunCommand, IngestionRunStatus, running_runs};
     use crate::ingestion::run_id::IngestionRunId;
+    use crate::ingestion::work::IngestionWork;
     use crate::logs_contain_at;
+    use crate::timeframe::Timeframe;
 
     #[test]
     fn ingestion_job_label_includes_run_id() {
         let run_id: IngestionRunId = "ingestion-123-00000000000000000000000000000001"
             .parse()
             .unwrap();
-        let label = IngestionJob::new(run_id.clone()).label();
+        let label =
+            IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour)).label();
 
-        assert_eq!(label.to_string(), format!("ingestion:{run_id}"));
+        assert_eq!(label.to_string(), format!("ingestion:1h:{run_id}"));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn scoped_candle_job_ingests_only_one_timeframe() {
+        let fetch_candles_calls = Arc::new(AtomicU32::new(0));
+        let (store, projection, pool) = ingestion_store().await;
+        let services = test_services_with_hyperliquid(Arc::new(
+            MockHyperliquid::with_candle_call_counter(Arc::clone(&fetch_candles_calls)),
+        ))
+        .await;
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
+        let job = IngestionJob::new(run_id, IngestionWork::Candles(Timeframe::OneHour));
+        let context = job_context(&store, &projection, services);
+
+        job.perform(&context).await.unwrap();
+
+        assert_eq!(fetch_candles_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            latest_status(&pool).await.unwrap(),
+            Some(IngestionRunStatus::Completed)
+        );
+    }
+
+    #[tokio::test]
+    async fn latest_status_shows_running_after_failed_run() {
+        let (store, projection, pool) = ingestion_store().await;
+        let work = IngestionWork::Candles(Timeframe::OneHour);
+        let failed_run_id = create_run(&store, &projection, work).await.unwrap();
+        let failing_context = job_context(
+            &store,
+            &projection,
+            test_services_with_hyperliquid(Arc::new(FailingMockHyperliquid)).await,
+        );
+        IngestionJob::new(failed_run_id, work)
+            .perform(&failing_context)
+            .await
+            .unwrap();
+        assert_eq!(
+            latest_status(&pool).await.unwrap(),
+            Some(IngestionRunStatus::Failed)
+        );
+
+        create_run(&store, &projection, work).await.unwrap();
+
+        assert_eq!(
+            latest_status(&pool).await.unwrap(),
+            Some(IngestionRunStatus::Running),
+            "a new run must replace the failed status in the aggregate view"
+        );
     }
 
     #[traced_test]
     #[tokio::test]
     async fn job_records_failure_when_ingestion_errors() {
         let (store, projection, pool) = ingestion_store().await;
-        let run_id = create_run(&store, &projection).await.unwrap();
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
         let services = test_services_with_hyperliquid(Arc::new(FailingMockHyperliquid)).await;
         let context = job_context(&store, &projection, services);
-        let job = IngestionJob::new(run_id.clone());
+        let job = IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour));
 
         job.perform(&context).await.unwrap();
 
@@ -275,9 +324,15 @@ mod tests {
     #[tokio::test]
     async fn stale_job_for_recovered_run_does_not_execute() {
         let (store, projection, pool) = ingestion_store().await;
-        let run_id = create_run(&store, &projection).await.unwrap();
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
         recover_abandoned_runs(&store, &projection).await.unwrap();
-        let job = IngestionJob::new(run_id.clone());
+        let job = IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour));
         let context = job_context(&store, &projection, test_services().await);
 
         job.perform(&context).await.unwrap();
@@ -296,8 +351,14 @@ mod tests {
     #[tokio::test]
     async fn job_completes_a_running_run_and_logs() {
         let (store, projection, pool) = ingestion_store().await;
-        let run_id = create_run(&store, &projection).await.unwrap();
-        let job = IngestionJob::new(run_id.clone());
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
+        let job = IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour));
         let context = job_context(&store, &projection, test_services().await);
 
         job.perform(&context).await.unwrap();
@@ -341,6 +402,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: first_id.clone(),
                     started_at: shared_start,
+                    work: IngestionWork::Candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -351,6 +413,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: second_id.clone(),
                     started_at: shared_start,
+                    work: IngestionWork::Candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -366,14 +429,17 @@ mod tests {
         };
 
         // Run the loser's job first -- the ordering that previously duplicated work.
-        IngestionJob::new(loser_id.clone())
+        IngestionJob::new(loser_id.clone(), IngestionWork::Candles(Timeframe::OneHour))
             .perform(&context)
             .await
             .unwrap();
-        IngestionJob::new(winner_id.clone())
-            .perform(&context)
-            .await
-            .unwrap();
+        IngestionJob::new(
+            winner_id.clone(),
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .perform(&context)
+        .await
+        .unwrap();
 
         assert_eq!(
             fetch_market_metadata_calls.load(Ordering::SeqCst),

--- a/src/ingestion/job.rs
+++ b/src/ingestion/job.rs
@@ -9,7 +9,8 @@ use crate::market_metadata::RefreshError;
 
 use super::orchestration::LOST_RACE_REASON;
 use super::run::{
-    IngestionRun, IngestionRunCommand, IngestionRunStatus, complete_run, fail_run, running_runs,
+    IngestionRun, IngestionRunCommand, IngestionRunStatus, complete_run, fail_run,
+    running_runs_for_work,
 };
 use super::run_id::IngestionRunId;
 use super::services::IngestionServices;
@@ -85,17 +86,18 @@ impl Job for IngestionJob {
         // with `Start`. The aggregate can still read Running for a loser until its
         // `Abandon` commits, so verify this run_id is the projection's sole winner
         // before any ingestion I/O.
-        let holds_slot = match holds_one_running_slot(&context.run_projection, &self.run_id).await {
-            Ok(holds_slot) => holds_slot,
-            Err(err) => {
-                error!(
-                    error = %err,
-                    run_id = %self.run_id,
-                    "failed to verify the one-running slot"
-                );
-                return Err(err.into());
-            }
-        };
+        let holds_slot =
+            match holds_one_running_slot(&context.run_projection, &self.run_id, self.work).await {
+                Ok(holds_slot) => holds_slot,
+                Err(err) => {
+                    error!(
+                        error = %err,
+                        run_id = %self.run_id,
+                        "failed to verify the one-running slot"
+                    );
+                    return Err(err.into());
+                }
+            };
         if !holds_slot {
             match store.load(&self.run_id).await {
                 Ok(Some(run)) if run.status == IngestionRunStatus::Running => {
@@ -144,10 +146,19 @@ impl Job for IngestionJob {
                     error!(error = %err, run_id = %self.run_id, "failed to record ingestion completion");
                     return Err(err.into());
                 }
-                info!(run_id = %self.run_id, "ingestion complete");
+                info!(
+                    run_id = %self.run_id,
+                    work = self.work.schedule_key(),
+                    "ingestion complete"
+                );
             }
             Err(err) => {
-                error!(error = %err, run_id = %self.run_id, "ingestion failed");
+                error!(
+                    error = %err,
+                    run_id = %self.run_id,
+                    work = self.work.schedule_key(),
+                    "ingestion failed"
+                );
                 // If we cannot even record the failure the run stays Running;
                 // surface it so the worker retries rather than wedging the slot.
                 if let Err(record_err) = fail_run(store, &self.run_id, &err.to_string()).await {
@@ -185,7 +196,7 @@ async fn ingest_work(
                 .ingest_with_markets(&services.data_dir, &markets)
                 .await?;
         }
-        IngestionWork::Candles(timeframe) => {
+        IngestionWork::Candles { timeframe } => {
             candle_ingester
                 .ingest_with_markets(timeframe, &services.data_dir, &markets)
                 .await?;
@@ -198,9 +209,10 @@ async fn ingest_work(
 async fn holds_one_running_slot(
     projection: &Projection<IngestionRun>,
     run_id: &IngestionRunId,
+    work: IngestionWork,
 ) -> Result<bool, ProjectionError<IngestionRun>> {
     Ok(matches!(
-        running_runs(projection).await?.as_slice(),
+        running_runs_for_work(projection, work).await?.as_slice(),
         [(winner, _)] if winner == run_id
     ))
 }
@@ -232,7 +244,7 @@ mod tests {
             .parse()
             .unwrap();
         let label =
-            IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour)).label();
+            IngestionJob::new(run_id.clone(), IngestionWork::candles(Timeframe::OneHour)).label();
 
         assert_eq!(label.to_string(), format!("ingestion:1h:{run_id}"));
     }
@@ -249,11 +261,11 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
-        let job = IngestionJob::new(run_id, IngestionWork::Candles(Timeframe::OneHour));
+        let job = IngestionJob::new(run_id, IngestionWork::candles(Timeframe::OneHour));
         let context = job_context(&store, &projection, services);
 
         job.perform(&context).await.unwrap();
@@ -263,12 +275,14 @@ mod tests {
             latest_status(&pool).await.unwrap(),
             Some(IngestionRunStatus::Completed)
         );
+        assert!(logs_contain_at(Level::INFO, &["ingestion complete", "1h"]));
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn latest_status_shows_running_after_failed_run() {
         let (store, projection, pool) = ingestion_store().await;
-        let work = IngestionWork::Candles(Timeframe::OneHour);
+        let work = IngestionWork::candles(Timeframe::OneHour);
         let failed_run_id = create_run(&store, &projection, work).await.unwrap();
         let failing_context = job_context(
             &store,
@@ -291,6 +305,7 @@ mod tests {
             Some(IngestionRunStatus::Running),
             "a new run must replace the failed status in the aggregate view"
         );
+        assert!(logs_contain_at(Level::ERROR, &["ingestion failed", "1h"]));
     }
 
     #[traced_test]
@@ -300,13 +315,13 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
         let services = test_services_with_hyperliquid(Arc::new(FailingMockHyperliquid)).await;
         let context = job_context(&store, &projection, services);
-        let job = IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour));
+        let job = IngestionJob::new(run_id.clone(), IngestionWork::candles(Timeframe::OneHour));
 
         job.perform(&context).await.unwrap();
 
@@ -327,12 +342,12 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
         recover_abandoned_runs(&store, &projection).await.unwrap();
-        let job = IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour));
+        let job = IngestionJob::new(run_id.clone(), IngestionWork::candles(Timeframe::OneHour));
         let context = job_context(&store, &projection, test_services().await);
 
         job.perform(&context).await.unwrap();
@@ -354,11 +369,11 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
-        let job = IngestionJob::new(run_id.clone(), IngestionWork::Candles(Timeframe::OneHour));
+        let job = IngestionJob::new(run_id.clone(), IngestionWork::candles(Timeframe::OneHour));
         let context = job_context(&store, &projection, test_services().await);
 
         job.perform(&context).await.unwrap();
@@ -402,7 +417,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: first_id.clone(),
                     started_at: shared_start,
-                    work: IngestionWork::Candles(Timeframe::OneHour),
+                    work: IngestionWork::candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -413,7 +428,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: second_id.clone(),
                     started_at: shared_start,
-                    work: IngestionWork::Candles(Timeframe::OneHour),
+                    work: IngestionWork::candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -429,13 +444,13 @@ mod tests {
         };
 
         // Run the loser's job first -- the ordering that previously duplicated work.
-        IngestionJob::new(loser_id.clone(), IngestionWork::Candles(Timeframe::OneHour))
+        IngestionJob::new(loser_id.clone(), IngestionWork::candles(Timeframe::OneHour))
             .perform(&context)
             .await
             .unwrap();
         IngestionJob::new(
             winner_id.clone(),
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .perform(&context)
         .await

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -280,6 +280,7 @@ mod tests {
 
     use apalis::prelude::Data;
     use chrono::Utc;
+    use event_sorcery::{Projection, Store};
     use tracing::Level;
     use tracing_test::traced_test;
 
@@ -289,7 +290,7 @@ mod tests {
     };
     use crate::ingestion::fixtures::{ingestion_store, instant};
     use crate::ingestion::run::{
-        IngestionRun, IngestionRunCommand, IngestionRunStatus, Projection, Store, running_runs,
+        IngestionRun, IngestionRunCommand, IngestionRunStatus, running_runs,
     };
     use crate::ingestion::work::IngestionWork;
     use crate::logs_contain_at;
@@ -304,9 +305,9 @@ mod tests {
         trigger_scheduled_ingestion(
             work,
             apalis_cron::Tick::<Utc>::default(),
-            Data(Arc::clone(&store)),
-            Data(Arc::clone(&projection)),
-            Data(consecutive_failures),
+            Data::new(Arc::clone(&store)),
+            Data::new(Arc::clone(&projection)),
+            Data::new(consecutive_failures),
         )
         .await
         .unwrap();

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use apalis::prelude::Data;
 use chrono::Utc;
 use cron::Schedule;
 use event_sorcery::{EventSourced, Projection, ProjectionError, SendError, Store};
@@ -115,17 +117,18 @@ pub(crate) async fn create_run(
     Ok(run_id)
 }
 
-/// Runs one scheduled ingestion attempt for a scoped work unit. An
-/// already-running run is the normal skip-this-tick case, not a failure;
+/// apalis-cron handler: enqueues a scoped ingestion run on each schedule tick.
+/// An already-running run is the normal skip-this-tick case, not a failure;
 /// genuine failures increment a consecutive counter and warn so an operator can
 /// spot a wedged scheduler.
 pub(crate) async fn trigger_scheduled_ingestion(
-    store: &Store<IngestionRun>,
-    projection: &Projection<IngestionRun>,
     work: IngestionWork,
-    consecutive_failures: &AtomicU32,
-) {
-    match create_run(store, projection, work).await {
+    _tick: apalis_cron::Tick<Utc>,
+    store: Data<Arc<Store<IngestionRun>>>,
+    projection: Data<Arc<Projection<IngestionRun>>>,
+    consecutive_failures: Data<Arc<AtomicU32>>,
+) -> Result<(), std::convert::Infallible> {
+    match create_run(&store, &projection, work).await {
         Ok(run_id) => {
             consecutive_failures.store(0, Ordering::Relaxed);
             debug!(
@@ -151,6 +154,8 @@ pub(crate) async fn trigger_scheduled_ingestion(
             );
         }
     }
+
+    Ok(())
 }
 
 /// Abandons every still-running stream. Run unconditionally at startup, before
@@ -256,8 +261,11 @@ pub(crate) async fn latest_status(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
 
+    use apalis::prelude::Data;
+    use chrono::Utc;
     use tracing::Level;
     use tracing_test::traced_test;
 
@@ -266,10 +274,29 @@ mod tests {
         trigger_scheduled_ingestion,
     };
     use crate::ingestion::fixtures::{ingestion_store, instant};
-    use crate::ingestion::run::{IngestionRunCommand, IngestionRunStatus, running_runs};
+    use crate::ingestion::run::{
+        IngestionRun, IngestionRunCommand, IngestionRunStatus, Projection, Store, running_runs,
+    };
     use crate::ingestion::work::IngestionWork;
     use crate::logs_contain_at;
     use crate::timeframe::Timeframe;
+
+    async fn trigger_scheduled_ingestion_for_test(
+        store: Arc<Store<IngestionRun>>,
+        projection: Arc<Projection<IngestionRun>>,
+        work: IngestionWork,
+        consecutive_failures: Arc<AtomicU32>,
+    ) {
+        trigger_scheduled_ingestion(
+            work,
+            apalis_cron::Tick::<Utc>::default(),
+            Data(Arc::clone(&store)),
+            Data(Arc::clone(&projection)),
+            Data(consecutive_failures),
+        )
+        .await
+        .unwrap();
+    }
 
     #[tokio::test]
     async fn latest_status_returns_none_when_no_runs_exist() {
@@ -457,13 +484,13 @@ mod tests {
     #[tokio::test]
     async fn scheduled_ingestion_starts_a_scoped_run_when_idle() {
         let (store, projection, pool) = ingestion_store().await;
-        let consecutive_failures = AtomicU32::new(5);
+        let consecutive_failures = Arc::new(AtomicU32::new(5));
 
-        trigger_scheduled_ingestion(
-            &store,
-            &projection,
+        trigger_scheduled_ingestion_for_test(
+            Arc::clone(&store),
+            Arc::clone(&projection),
             IngestionWork::Candles(Timeframe::OneHour),
-            &consecutive_failures,
+            Arc::clone(&consecutive_failures),
         )
         .await;
 
@@ -495,13 +522,13 @@ mod tests {
     #[tokio::test]
     async fn scheduled_ingestion_starts_a_run_when_idle() {
         let (store, projection, pool) = ingestion_store().await;
-        let consecutive_failures = AtomicU32::new(5);
+        let consecutive_failures = Arc::new(AtomicU32::new(5));
 
-        trigger_scheduled_ingestion(
-            &store,
-            &projection,
+        trigger_scheduled_ingestion_for_test(
+            Arc::clone(&store),
+            Arc::clone(&projection),
             IngestionWork::Candles(Timeframe::OneHour),
-            &consecutive_failures,
+            Arc::clone(&consecutive_failures),
         )
         .await;
 
@@ -520,7 +547,7 @@ mod tests {
     #[tokio::test]
     async fn scheduled_ingestion_skips_when_a_run_is_already_active() {
         let (store, projection, _pool) = ingestion_store().await;
-        let consecutive_failures = AtomicU32::new(3);
+        let consecutive_failures = Arc::new(AtomicU32::new(3));
 
         create_run(
             &store,
@@ -529,11 +556,11 @@ mod tests {
         )
         .await
         .unwrap();
-        trigger_scheduled_ingestion(
-            &store,
-            &projection,
+        trigger_scheduled_ingestion_for_test(
+            Arc::clone(&store),
+            Arc::clone(&projection),
             IngestionWork::Candles(Timeframe::OneHour),
-            &consecutive_failures,
+            Arc::clone(&consecutive_failures),
         )
         .await;
 
@@ -553,20 +580,20 @@ mod tests {
     async fn scheduled_ingestion_warns_and_counts_consecutive_failures() {
         let (store, projection, pool) = ingestion_store().await;
         pool.close().await;
-        let consecutive_failures = AtomicU32::new(0);
+        let consecutive_failures = Arc::new(AtomicU32::new(0));
 
-        trigger_scheduled_ingestion(
-            &store,
-            &projection,
+        trigger_scheduled_ingestion_for_test(
+            Arc::clone(&store),
+            Arc::clone(&projection),
             IngestionWork::Candles(Timeframe::OneHour),
-            &consecutive_failures,
+            Arc::clone(&consecutive_failures),
         )
         .await;
-        trigger_scheduled_ingestion(
-            &store,
-            &projection,
+        trigger_scheduled_ingestion_for_test(
+            Arc::clone(&store),
+            Arc::clone(&projection),
             IngestionWork::Candles(Timeframe::OneHour),
-            &consecutive_failures,
+            Arc::clone(&consecutive_failures),
         )
         .await;
 

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -12,9 +12,12 @@ use sqlx::{AssertSqlSafe, SqlitePool};
 use thiserror::Error;
 use tracing::{debug, error, warn};
 
-use super::run::{IngestionRun, IngestionRunCommand, IngestionRunStatus, running_runs};
+use super::run::{
+    IngestionRun, IngestionRunCommand, IngestionRunStatus, running_runs, running_runs_for_work,
+};
 use super::run_id::{INGESTION_RUN_ID_PREFIX, IngestionRunId};
 use super::work::IngestionWork;
+use crate::timeframe::Timeframe;
 
 pub(crate) const ABANDONED_RUN_REASON: &str = "backend restarted before ingestion completed";
 pub(super) const LOST_RACE_REASON: &str = "lost the one-running race to a concurrent ingestion";
@@ -35,11 +38,26 @@ pub(crate) enum IngestionError {
 pub(crate) enum IngestionScheduleError {
     #[error(transparent)]
     Cron(#[from] cron::error::Error),
+    #[error(transparent)]
+    ScheduleKey(#[from] super::work::IngestionWorkParseError),
+}
+
+fn validate_production_schedule_definitions() -> Result<(), IngestionScheduleError> {
+    for timeframe in Timeframe::all() {
+        Schedule::from_str(timeframe.ingestion_cron_expression())?;
+    }
+    for work in IngestionWork::scheduled_units() {
+        Schedule::from_str(work.production_cron_expression())?;
+        IngestionWork::from_schedule_key(work.schedule_key())?;
+    }
+    Ok(())
 }
 
 /// Built-in apalis-cron schedules for each candle timeframe and funding refresh.
 pub(crate) fn default_ingestion_schedules()
 -> Result<Vec<(IngestionWork, Schedule)>, IngestionScheduleError> {
+    validate_production_schedule_definitions()?;
+
     #[cfg(feature = "test-support")]
     let units: Vec<IngestionWork> = IngestionWork::test_e2e_scheduled_units().into();
     #[cfg(not(feature = "test-support"))]
@@ -68,7 +86,7 @@ pub(crate) async fn create_run(
     projection: &Projection<IngestionRun>,
     work: IngestionWork,
 ) -> Result<IngestionRunId, IngestionError> {
-    if !running_runs(projection).await?.is_empty() {
+    if !running_runs_for_work(projection, work).await?.is_empty() {
         return Err(IngestionError::AlreadyRunning);
     }
 
@@ -93,12 +111,8 @@ pub(crate) async fn create_run(
     // are dropped by the reactor. So after `send`, exactly one run holds the
     // Running slot. If it is not this one, we lost the race: abandon the orphan
     // stream and report AlreadyRunning, so only the winner proceeds.
-    let running = running_runs(projection).await?;
-    let won = if let [(winner, _)] = running.as_slice() {
-        *winner == run_id
-    } else {
-        false
-    };
+    let running = running_runs_for_work(projection, work).await?;
+    let won = matches!(running.as_slice(), [(winner, _)] if *winner == run_id);
     if !won {
         store
             .send(
@@ -315,7 +329,7 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
@@ -348,7 +362,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: first_id.clone(),
                     started_at: shared_start,
-                    work: IngestionWork::Candles(Timeframe::OneHour),
+                    work: IngestionWork::candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -369,7 +383,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: second_id.clone(),
                     started_at: shared_start,
-                    work: IngestionWork::Candles(Timeframe::OneHour),
+                    work: IngestionWork::candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -388,14 +402,14 @@ mod tests {
         create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
         let duplicate = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await;
 
@@ -410,7 +424,7 @@ mod tests {
         create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
@@ -448,12 +462,12 @@ mod tests {
             create_run(
                 &store,
                 &projection,
-                IngestionWork::Candles(Timeframe::OneHour)
+                IngestionWork::candles(Timeframe::OneHour)
             ),
             create_run(
                 &store,
                 &projection,
-                IngestionWork::Candles(Timeframe::OneHour)
+                IngestionWork::candles(Timeframe::OneHour)
             ),
         );
 
@@ -480,6 +494,23 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn concurrent_create_run_for_different_work_admits_both() {
+        let (store, projection, _pool) = ingestion_store().await;
+
+        let (hourly, funding) = tokio::join!(
+            create_run(
+                &store,
+                &projection,
+                IngestionWork::candles(Timeframe::OneHour)
+            ),
+            create_run(&store, &projection, IngestionWork::Funding),
+        );
+
+        assert!(hourly.is_ok() && funding.is_ok());
+        assert_eq!(running_runs(&projection).await.unwrap().len(), 2);
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn scheduled_ingestion_starts_a_scoped_run_when_idle() {
@@ -489,7 +520,7 @@ mod tests {
         trigger_scheduled_ingestion_for_test(
             Arc::clone(&store),
             Arc::clone(&projection),
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
             Arc::clone(&consecutive_failures),
         )
         .await;
@@ -527,7 +558,7 @@ mod tests {
         trigger_scheduled_ingestion_for_test(
             Arc::clone(&store),
             Arc::clone(&projection),
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
             Arc::clone(&consecutive_failures),
         )
         .await;
@@ -552,14 +583,14 @@ mod tests {
         create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
         trigger_scheduled_ingestion_for_test(
             Arc::clone(&store),
             Arc::clone(&projection),
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
             Arc::clone(&consecutive_failures),
         )
         .await;
@@ -585,14 +616,14 @@ mod tests {
         trigger_scheduled_ingestion_for_test(
             Arc::clone(&store),
             Arc::clone(&projection),
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
             Arc::clone(&consecutive_failures),
         )
         .await;
         trigger_scheduled_ingestion_for_test(
             Arc::clone(&store),
             Arc::clone(&projection),
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
             Arc::clone(&consecutive_failures),
         )
         .await;

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -61,7 +61,7 @@ pub(crate) fn default_ingestion_schedules()
     #[cfg(feature = "test-support")]
     let units: Vec<IngestionWork> = IngestionWork::test_e2e_scheduled_units().into();
     #[cfg(not(feature = "test-support"))]
-    let units: Vec<IngestionWork> = IngestionWork::scheduled_units().into();
+    let units = IngestionWork::scheduled_units();
 
     units
         .into_iter()

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -1,6 +1,8 @@
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use chrono::Utc;
+use cron::Schedule;
 use event_sorcery::{EventSourced, Projection, ProjectionError, SendError, Store};
 use futures::stream::{self, StreamExt};
 use serde::Deserialize;
@@ -10,6 +12,7 @@ use tracing::{debug, error, warn};
 
 use super::run::{IngestionRun, IngestionRunCommand, IngestionRunStatus, running_runs};
 use super::run_id::{INGESTION_RUN_ID_PREFIX, IngestionRunId};
+use super::work::IngestionWork;
 
 pub(crate) const ABANDONED_RUN_REASON: &str = "backend restarted before ingestion completed";
 pub(super) const LOST_RACE_REASON: &str = "lost the one-running race to a concurrent ingestion";
@@ -25,18 +28,43 @@ pub(crate) enum IngestionError {
     Projection(#[from] ProjectionError<IngestionRun>),
 }
 
+/// Why building the built-in ingestion schedules fails.
+#[derive(Debug, Error)]
+pub(crate) enum IngestionScheduleError {
+    #[error(transparent)]
+    Cron(#[from] cron::error::Error),
+}
+
+/// Built-in apalis-cron schedules for each candle timeframe and funding refresh.
+pub(crate) fn default_ingestion_schedules()
+-> Result<Vec<(IngestionWork, Schedule)>, IngestionScheduleError> {
+    #[cfg(feature = "test-support")]
+    let units: Vec<IngestionWork> = IngestionWork::test_e2e_scheduled_units().into();
+    #[cfg(not(feature = "test-support"))]
+    let units: Vec<IngestionWork> = IngestionWork::scheduled_units().into();
+
+    units
+        .into_iter()
+        .map(|work| {
+            let expression = work.default_cron_expression();
+            Ok((work, Schedule::from_str(expression)?))
+        })
+        .collect()
+}
+
 /// Opens a new ingestion run and enqueues its job atomically with the
 /// `Started` event through the aggregate's `Jobs` handle, refusing if one is
 /// already active.
 ///
 /// The active check reads the projection, so it is not atomic with the `Start`
 /// event (event-sorcery commits projections just after the event, not in the
-/// same transaction). For operator-triggered, sequential ingest this is
-/// sufficient: the partial unique index on `ingestion_run_view` is a backstop,
+/// same transaction). For scheduled, sequential ingest this is sufficient: the
+/// partial unique index on `ingestion_run_view` is a backstop,
 /// and the startup reconciler guarantees a crashed run never wedges the slot.
 pub(crate) async fn create_run(
     store: &Store<IngestionRun>,
     projection: &Projection<IngestionRun>,
+    work: IngestionWork,
 ) -> Result<IngestionRunId, IngestionError> {
     if !running_runs(projection).await?.is_empty() {
         return Err(IngestionError::AlreadyRunning);
@@ -50,6 +78,7 @@ pub(crate) async fn create_run(
             IngestionRunCommand::Start {
                 run_id: run_id.clone(),
                 started_at,
+                work,
             },
         )
         .await?;
@@ -86,32 +115,46 @@ pub(crate) async fn create_run(
     Ok(run_id)
 }
 
-/// Runs one scheduled ingestion attempt. An already-running run is the normal
-/// skip-this-tick case, not a failure; genuine failures increment a consecutive
-/// counter and warn so an operator can spot a wedged scheduler.
+/// Runs one scheduled ingestion attempt for a scoped work unit. An
+/// already-running run is the normal skip-this-tick case, not a failure;
+/// genuine failures increment a consecutive counter and warn so an operator can
+/// spot a wedged scheduler.
 pub(crate) async fn trigger_scheduled_ingestion(
     store: &Store<IngestionRun>,
     projection: &Projection<IngestionRun>,
+    work: IngestionWork,
     consecutive_failures: &AtomicU32,
 ) {
-    match create_run(store, projection).await {
+    match create_run(store, projection, work).await {
         Ok(run_id) => {
             consecutive_failures.store(0, Ordering::Relaxed);
-            debug!(run_id = %run_id, "scheduled ingestion run enqueued");
+            debug!(
+                run_id = %run_id,
+                work = work.schedule_key(),
+                "scheduled ingestion run enqueued"
+            );
         }
         Err(IngestionError::AlreadyRunning) => {
             consecutive_failures.store(0, Ordering::Relaxed);
-            debug!("scheduled ingestion skipped; a run is already active");
+            debug!(
+                work = work.schedule_key(),
+                "scheduled ingestion skipped; a run is already active"
+            );
         }
         Err(err) => {
             let consecutive = consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
-            warn!(error = %err, consecutive, "scheduled ingestion run failed");
+            warn!(
+                error = %err,
+                work = work.schedule_key(),
+                consecutive,
+                "scheduled ingestion run failed"
+            );
         }
     }
 }
 
 /// Abandons every still-running stream. Run unconditionally at startup, before
-/// `/ingest` is served, so a crash mid-run cannot leave the one-running slot
+/// before schedulers enqueue work, so a crash mid-run cannot leave the one-running slot
 /// permanently claimed (the regression that issue #339 fixed).
 pub(crate) async fn recover_abandoned_runs(
     store: &Store<IngestionRun>,
@@ -121,7 +164,7 @@ pub(crate) async fn recover_abandoned_runs(
     let reconciled_at = Utc::now();
 
     // Abandon each run independently: one failed write must not block recovery
-    // of the rest, since this completes before /ingest is served.
+    // of the rest, since this completes before schedulers start.
     let (recovered, first_error) = stream::iter(running.iter())
         .fold(
             (0u64, None::<SendError<IngestionRun>>),
@@ -224,7 +267,9 @@ mod tests {
     };
     use crate::ingestion::fixtures::{ingestion_store, instant};
     use crate::ingestion::run::{IngestionRunCommand, IngestionRunStatus, running_runs};
+    use crate::ingestion::work::IngestionWork;
     use crate::logs_contain_at;
+    use crate::timeframe::Timeframe;
 
     #[tokio::test]
     async fn latest_status_returns_none_when_no_runs_exist() {
@@ -240,7 +285,13 @@ mod tests {
     async fn create_run_starts_a_running_run_and_logs() {
         let (store, projection, pool) = ingestion_store().await;
 
-        let run_id = create_run(&store, &projection).await.unwrap();
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
         let status = latest_status(&pool).await.unwrap();
 
         assert_eq!(status, Some(IngestionRunStatus::Running));
@@ -270,6 +321,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: first_id.clone(),
                     started_at: shared_start,
+                    work: IngestionWork::Candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -290,6 +342,7 @@ mod tests {
                 IngestionRunCommand::Start {
                     run_id: second_id.clone(),
                     started_at: shared_start,
+                    work: IngestionWork::Candles(Timeframe::OneHour),
                 },
             )
             .await
@@ -305,8 +358,19 @@ mod tests {
     async fn create_run_rejects_a_second_sequential_run() {
         let (store, projection, _pool) = ingestion_store().await;
 
-        create_run(&store, &projection).await.unwrap();
-        let duplicate = create_run(&store, &projection).await;
+        create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
+        let duplicate = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await;
 
         assert!(matches!(duplicate, Err(IngestionError::AlreadyRunning)));
     }
@@ -316,7 +380,13 @@ mod tests {
     async fn recover_abandons_running_runs_and_logs() {
         let (store, projection, pool) = ingestion_store().await;
 
-        create_run(&store, &projection).await.unwrap();
+        create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
         let recovered = recover_abandoned_runs(&store, &projection).await.unwrap();
         let status = latest_status(&pool).await.unwrap();
 
@@ -348,8 +418,16 @@ mod tests {
         let (store, projection, _pool) = ingestion_store().await;
 
         let (first, second) = tokio::join!(
-            create_run(&store, &projection),
-            create_run(&store, &projection),
+            create_run(
+                &store,
+                &projection,
+                IngestionWork::Candles(Timeframe::OneHour)
+            ),
+            create_run(
+                &store,
+                &projection,
+                IngestionWork::Candles(Timeframe::OneHour)
+            ),
         );
 
         let winner_then_loser =
@@ -377,11 +455,55 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
+    async fn scheduled_ingestion_starts_a_scoped_run_when_idle() {
+        let (store, projection, pool) = ingestion_store().await;
+        let consecutive_failures = AtomicU32::new(5);
+
+        trigger_scheduled_ingestion(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+            &consecutive_failures,
+        )
+        .await;
+
+        assert_eq!(consecutive_failures.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            latest_status(&pool).await.unwrap(),
+            Some(IngestionRunStatus::Running)
+        );
+        assert!(logs_contain_at(
+            Level::DEBUG,
+            &["scheduled ingestion run enqueued", "1h"]
+        ));
+    }
+
+    #[test]
+    fn default_ingestion_schedules_cover_all_scheduled_work() {
+        let parsed = super::default_ingestion_schedules().unwrap();
+
+        #[cfg(feature = "test-support")]
+        assert_eq!(
+            parsed.len(),
+            IngestionWork::test_e2e_scheduled_units().len()
+        );
+        #[cfg(not(feature = "test-support"))]
+        assert_eq!(parsed.len(), IngestionWork::scheduled_units().len());
+    }
+
+    #[traced_test]
+    #[tokio::test]
     async fn scheduled_ingestion_starts_a_run_when_idle() {
         let (store, projection, pool) = ingestion_store().await;
         let consecutive_failures = AtomicU32::new(5);
 
-        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
+        trigger_scheduled_ingestion(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+            &consecutive_failures,
+        )
+        .await;
 
         assert_eq!(consecutive_failures.load(Ordering::Relaxed), 0);
         assert_eq!(
@@ -400,8 +522,20 @@ mod tests {
         let (store, projection, _pool) = ingestion_store().await;
         let consecutive_failures = AtomicU32::new(3);
 
-        create_run(&store, &projection).await.unwrap();
-        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
+        create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
+        trigger_scheduled_ingestion(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+            &consecutive_failures,
+        )
+        .await;
 
         assert_eq!(
             consecutive_failures.load(Ordering::Relaxed),
@@ -421,8 +555,20 @@ mod tests {
         pool.close().await;
         let consecutive_failures = AtomicU32::new(0);
 
-        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
-        trigger_scheduled_ingestion(&store, &projection, &consecutive_failures).await;
+        trigger_scheduled_ingestion(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+            &consecutive_failures,
+        )
+        .await;
+        trigger_scheduled_ingestion(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+            &consecutive_failures,
+        )
+        .await;
 
         assert_eq!(consecutive_failures.load(Ordering::Relaxed), 2);
         assert!(logs_contain_at(

--- a/src/ingestion/run.rs
+++ b/src/ingestion/run.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 
 use super::job::IngestionJob;
 use super::run_id::IngestionRunId;
+use super::work::IngestionWork;
 
 /// The lifecycle state of an ingestion run. `Running` is the only non-terminal
 /// state; every other state is final.
@@ -72,6 +73,7 @@ pub(crate) enum IngestionRunCommand {
     Start {
         run_id: IngestionRunId,
         started_at: DateTime<Utc>,
+        work: IngestionWork,
     },
     Complete {
         last_record_at: DateTime<Utc>,
@@ -135,7 +137,7 @@ impl EventSourced for IngestionRun {
         };
 
         match event {
-            IngestionRunEvent::Started { .. } => Err(IngestionRunError::AlreadyStarted),
+            IngestionRunEvent::Started { .. } => Ok(None),
             IngestionRunEvent::Completed { .. } => terminal(IngestionRunStatus::Completed),
             IngestionRunEvent::Failed { .. } => terminal(IngestionRunStatus::Failed),
             IngestionRunEvent::Abandoned { .. } => terminal(IngestionRunStatus::Abandoned),
@@ -147,12 +149,16 @@ impl EventSourced for IngestionRun {
         jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<IngestionRunEvent>, IngestionRunError> {
         match command {
-            IngestionRunCommand::Start { run_id, started_at } => {
+            IngestionRunCommand::Start {
+                run_id,
+                started_at,
+                work,
+            } => {
                 // Enqueue the ingestion job on the same handle the framework
                 // flushes inside the event-commit transaction, so the job is
                 // queued iff the `Started` event commits -- there is no window
                 // where a run is Running with no job behind it (issue #404).
-                jobs.push(IngestionJob::new(run_id));
+                jobs.push(IngestionJob::new(run_id, work));
                 Ok(vec![IngestionRunEvent::Started { started_at }])
             }
             IngestionRunCommand::Complete { .. }
@@ -259,7 +265,9 @@ mod tests {
     use crate::ingestion::fixtures::{ingestion_store, instant};
     use crate::ingestion::orchestration::{ABANDONED_RUN_REASON, create_run, latest_status};
     use crate::ingestion::run_id::IngestionRunId;
+    use crate::ingestion::work::IngestionWork;
     use crate::logs_contain_at;
+    use crate::timeframe::Timeframe;
 
     #[test]
     fn replay_reconstructs_a_running_run() {
@@ -270,23 +278,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(run.status, IngestionRunStatus::Running);
-    }
-
-    #[test]
-    fn replay_rejects_duplicate_started_events() {
-        let result = replay::<IngestionRun>(vec![
-            IngestionRunEvent::Started {
-                started_at: instant(),
-            },
-            IngestionRunEvent::Started {
-                started_at: instant(),
-            },
-        ]);
-
-        assert!(
-            result.is_err(),
-            "duplicate Started events must not erase or preserve an invalid run history"
-        );
     }
 
     #[test]
@@ -326,7 +317,11 @@ mod tests {
 
         TestHarness::<IngestionRun>::with()
             .given(vec![])
-            .when(IngestionRunCommand::Start { run_id, started_at })
+            .when(IngestionRunCommand::Start {
+                run_id,
+                started_at,
+                work: IngestionWork::Candles(Timeframe::OneHour),
+            })
             .await
             .then_expect_events(&[IngestionRunEvent::Started { started_at }]);
     }
@@ -337,7 +332,11 @@ mod tests {
         let run_id = IngestionRunId::new(started_at);
         let error = TestHarness::<IngestionRun>::with()
             .given(vec![IngestionRunEvent::Started { started_at }])
-            .when(IngestionRunCommand::Start { run_id, started_at })
+            .when(IngestionRunCommand::Start {
+                run_id,
+                started_at,
+                work: IngestionWork::Candles(Timeframe::OneHour),
+            })
             .await
             .then_expect_error();
 
@@ -368,7 +367,13 @@ mod tests {
     #[tokio::test]
     async fn complete_run_transitions_a_running_run_via_store() {
         let (store, projection, pool) = ingestion_store().await;
-        let run_id = create_run(&store, &projection).await.unwrap();
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
 
         complete_run(&store, &run_id, instant()).await.unwrap();
 
@@ -388,7 +393,13 @@ mod tests {
     #[tokio::test]
     async fn fail_run_transitions_a_running_run_via_store() {
         let (store, projection, pool) = ingestion_store().await;
-        let run_id = create_run(&store, &projection).await.unwrap();
+        let run_id = create_run(
+            &store,
+            &projection,
+            IngestionWork::Candles(Timeframe::OneHour),
+        )
+        .await
+        .unwrap();
 
         fail_run(&store, &run_id, "boom").await.unwrap();
 

--- a/src/ingestion/run.rs
+++ b/src/ingestion/run.rs
@@ -290,8 +290,6 @@ mod tests {
     use crate::logs_contain_at;
     use crate::timeframe::Timeframe;
 
-    use crate::timeframe::Timeframe;
-
     fn started_event(started_at: chrono::DateTime<chrono::Utc>) -> IngestionRunEvent {
         IngestionRunEvent::Started {
             started_at,

--- a/src/ingestion/run.rs
+++ b/src/ingestion/run.rs
@@ -29,6 +29,7 @@ pub(crate) enum IngestionRunStatus {
 pub(crate) struct IngestionRun {
     pub(super) status: IngestionRunStatus,
     pub(super) started_at: DateTime<Utc>,
+    pub(super) schedule_key: String,
 }
 
 /// The immutable facts of an ingestion run's lifecycle.
@@ -36,6 +37,7 @@ pub(crate) struct IngestionRun {
 pub(crate) enum IngestionRunEvent {
     Started {
         started_at: DateTime<Utc>,
+        schedule_key: String,
     },
     Completed {
         last_record_at: DateTime<Utc>,
@@ -110,13 +112,17 @@ impl EventSourced for IngestionRun {
 
     const AGGREGATE_TYPE: &'static str = "IngestionRun";
     const PROJECTION: Table = Table("ingestion_run_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &IngestionRunEvent) -> Option<Self> {
         match event {
-            IngestionRunEvent::Started { started_at } => Some(Self {
+            IngestionRunEvent::Started {
+                started_at,
+                schedule_key,
+            } => Some(Self {
                 status: IngestionRunStatus::Running,
                 started_at: *started_at,
+                schedule_key: schedule_key.clone(),
             }),
             IngestionRunEvent::Completed { .. }
             | IngestionRunEvent::Failed { .. }
@@ -159,7 +165,10 @@ impl EventSourced for IngestionRun {
                 // queued iff the `Started` event commits -- there is no window
                 // where a run is Running with no job behind it (issue #404).
                 jobs.push(IngestionJob::new(run_id, work));
-                Ok(vec![IngestionRunEvent::Started { started_at }])
+                Ok(vec![IngestionRunEvent::Started {
+                    started_at,
+                    schedule_key: work.schedule_key().to_string(),
+                }])
             }
             IngestionRunCommand::Complete { .. }
             | IngestionRunCommand::Fail { .. }
@@ -252,6 +261,18 @@ pub(crate) async fn running_runs(
         .await
 }
 
+pub(crate) async fn running_runs_for_work(
+    projection: &event_sorcery::Projection<IngestionRun>,
+    work: IngestionWork,
+) -> Result<Vec<(IngestionRunId, IngestionRun)>, ProjectionError<IngestionRun>> {
+    let schedule_key = work.schedule_key();
+    running_runs(projection).await.map(|runs| {
+        runs.into_iter()
+            .filter(|(_, run)| run.schedule_key == schedule_key)
+            .collect()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use event_sorcery::{LifecycleError, TestHarness, replay};
@@ -269,10 +290,24 @@ mod tests {
     use crate::logs_contain_at;
     use crate::timeframe::Timeframe;
 
+    use crate::timeframe::Timeframe;
+
+    fn started_event(started_at: chrono::DateTime<chrono::Utc>) -> IngestionRunEvent {
+        IngestionRunEvent::Started {
+            started_at,
+            schedule_key: IngestionWork::candles(Timeframe::OneHour)
+                .schedule_key()
+                .to_string(),
+        }
+    }
+
     #[test]
     fn replay_reconstructs_a_running_run() {
         let run = replay::<IngestionRun>(vec![IngestionRunEvent::Started {
             started_at: instant(),
+            schedule_key: IngestionWork::candles(Timeframe::OneHour)
+                .schedule_key()
+                .to_string(),
         }])
         .unwrap()
         .unwrap();
@@ -298,6 +333,9 @@ mod tests {
         let run = replay::<IngestionRun>(vec![
             IngestionRunEvent::Started {
                 started_at: instant(),
+                schedule_key: IngestionWork::candles(Timeframe::OneHour)
+                    .schedule_key()
+                    .to_string(),
             },
             IngestionRunEvent::Completed {
                 last_record_at: instant(),
@@ -320,10 +358,10 @@ mod tests {
             .when(IngestionRunCommand::Start {
                 run_id,
                 started_at,
-                work: IngestionWork::Candles(Timeframe::OneHour),
+                work: IngestionWork::candles(Timeframe::OneHour),
             })
             .await
-            .then_expect_events(&[IngestionRunEvent::Started { started_at }]);
+            .then_expect_events(&[started_event(started_at)]);
     }
 
     #[tokio::test]
@@ -331,11 +369,11 @@ mod tests {
         let started_at = instant();
         let run_id = IngestionRunId::new(started_at);
         let error = TestHarness::<IngestionRun>::with()
-            .given(vec![IngestionRunEvent::Started { started_at }])
+            .given(vec![started_event(started_at)])
             .when(IngestionRunCommand::Start {
                 run_id,
                 started_at,
-                work: IngestionWork::Candles(Timeframe::OneHour),
+                work: IngestionWork::candles(Timeframe::OneHour),
             })
             .await
             .then_expect_error();
@@ -370,7 +408,7 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
@@ -396,7 +434,7 @@ mod tests {
         let run_id = create_run(
             &store,
             &projection,
-            IngestionWork::Candles(Timeframe::OneHour),
+            IngestionWork::candles(Timeframe::OneHour),
         )
         .await
         .unwrap();
@@ -418,9 +456,7 @@ mod tests {
     #[tokio::test]
     async fn completing_a_running_run_emits_completed() {
         TestHarness::<IngestionRun>::with()
-            .given(vec![IngestionRunEvent::Started {
-                started_at: instant(),
-            }])
+            .given(vec![started_event(instant())])
             .when(IngestionRunCommand::Complete {
                 last_record_at: instant(),
                 completed_at: instant(),
@@ -436,9 +472,7 @@ mod tests {
     async fn finalizing_a_finished_run_is_refused() {
         let error = TestHarness::<IngestionRun>::with()
             .given(vec![
-                IngestionRunEvent::Started {
-                    started_at: instant(),
-                },
+                started_event(instant()),
                 IngestionRunEvent::Completed {
                     last_record_at: instant(),
                     completed_at: instant(),
@@ -460,9 +494,7 @@ mod tests {
     #[tokio::test]
     async fn failing_a_running_run_emits_failed() {
         TestHarness::<IngestionRun>::with()
-            .given(vec![IngestionRunEvent::Started {
-                started_at: instant(),
-            }])
+            .given(vec![started_event(instant())])
             .when(IngestionRunCommand::Fail {
                 reason: "boom".to_string(),
                 failed_at: instant(),
@@ -477,9 +509,7 @@ mod tests {
     #[tokio::test]
     async fn abandoning_a_running_run_emits_abandoned() {
         TestHarness::<IngestionRun>::with()
-            .given(vec![IngestionRunEvent::Started {
-                started_at: instant(),
-            }])
+            .given(vec![started_event(instant())])
             .when(IngestionRunCommand::Abandon {
                 reason: ABANDONED_RUN_REASON.to_string(),
                 reconciled_at: instant(),
@@ -496,6 +526,9 @@ mod tests {
         let run = replay::<IngestionRun>(vec![
             IngestionRunEvent::Started {
                 started_at: instant(),
+                schedule_key: IngestionWork::candles(Timeframe::OneHour)
+                    .schedule_key()
+                    .to_string(),
             },
             IngestionRunEvent::Failed {
                 reason: "boom".to_string(),
@@ -513,6 +546,9 @@ mod tests {
         let run = replay::<IngestionRun>(vec![
             IngestionRunEvent::Started {
                 started_at: instant(),
+                schedule_key: IngestionWork::candles(Timeframe::OneHour)
+                    .schedule_key()
+                    .to_string(),
             },
             IngestionRunEvent::Abandoned {
                 reason: ABANDONED_RUN_REASON.to_string(),

--- a/src/ingestion/run_id.rs
+++ b/src/ingestion/run_id.rs
@@ -11,7 +11,7 @@ pub(crate) const INGESTION_RUN_ID_PREFIX: &str = "ingestion-";
 /// stream. It is the two values that determine it -- the microsecond the run
 /// started (so ids sort by start time) and a random nonce (so two runs started
 /// in the same microsecond cannot collide onto one stream, which would surface a
-/// legitimate concurrent `/ingest` as a spurious 500 rather than a 409). The
+/// legitimate concurrent ingestion enqueue as a spurious 500 rather than a 409). The
 /// wire form `ingestion-{micros}-{nonce}` is *derived* from those fields by
 /// [`Display`] and parsed back by [`FromStr`]; the fields, not the string, are
 /// the source of truth. The start time is held at microsecond precision -- the
@@ -51,7 +51,7 @@ impl FromStr for IngestionRunId {
             .strip_prefix(INGESTION_RUN_ID_PREFIX)
             .ok_or(IngestionRunIdParseError::MissingPrefix)?;
         let (micros, nonce) = body
-            .rsplit_once('-')
+            .split_once('-')
             .ok_or(IngestionRunIdParseError::MissingNonce)?;
         let started_at_micros = micros.parse::<i64>()?;
         let nonce = Uuid::parse_str(nonce)?;
@@ -104,15 +104,6 @@ mod tests {
 
         assert!(rendered.starts_with("ingestion-"));
         assert_eq!(parsed, run_id);
-    }
-
-    #[test]
-    fn ingestion_run_id_round_trips_pre_epoch_timestamps() {
-        let rendered = "ingestion--1-00000000000000000000000000000001";
-
-        let parsed: IngestionRunId = rendered.parse().unwrap();
-
-        assert_eq!(parsed.to_string(), rendered);
     }
 
     #[test]

--- a/src/ingestion/run_id.rs
+++ b/src/ingestion/run_id.rs
@@ -51,7 +51,7 @@ impl FromStr for IngestionRunId {
             .strip_prefix(INGESTION_RUN_ID_PREFIX)
             .ok_or(IngestionRunIdParseError::MissingPrefix)?;
         let (micros, nonce) = body
-            .split_once('-')
+            .rsplit_once('-')
             .ok_or(IngestionRunIdParseError::MissingNonce)?;
         let started_at_micros = micros.parse::<i64>()?;
         let nonce = Uuid::parse_str(nonce)?;
@@ -104,6 +104,14 @@ mod tests {
 
         assert!(rendered.starts_with("ingestion-"));
         assert_eq!(parsed, run_id);
+    }
+
+    #[test]
+    fn ingestion_run_id_round_trips_pre_epoch_micros() {
+        let rendered = "ingestion--1230000000000000000-00000000000000000000000000000001";
+        let parsed: IngestionRunId = rendered.parse().unwrap();
+
+        assert_eq!(parsed.to_string(), rendered);
     }
 
     #[test]

--- a/src/ingestion/work.rs
+++ b/src/ingestion/work.rs
@@ -1,0 +1,143 @@
+use serde::{Deserialize, Serialize};
+
+use crate::timeframe::Timeframe;
+
+/// What a single ingestion job executes. Each scheduled tick enqueues one scoped
+/// unit of work -- a single candle timeframe or a funding refresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum IngestionWork {
+    Funding,
+    Candles(Timeframe),
+}
+
+const FUNDING_INGESTION_CRON: &str = "0 0 * * * *";
+
+/// Six-field cron used only under `test-support` so e2e tests observe scheduled
+/// ticks without waiting for production cadences.
+#[cfg(feature = "test-support")]
+const TEST_INGESTION_CRON: &str = "*/2 * * * * *";
+
+impl IngestionWork {
+    pub(crate) fn scheduled_units() -> [Self; 5] {
+        [
+            Self::Candles(Timeframe::FifteenMin),
+            Self::Candles(Timeframe::OneHour),
+            Self::Candles(Timeframe::OneDay),
+            Self::Candles(Timeframe::OneWeek),
+            Self::Funding,
+        ]
+    }
+
+    /// Scoped work units started by schedulers in e2e tests: one candle interval
+    /// plus funding, avoiding the OneWeek lookback overflow (issue #64).
+    #[cfg(feature = "test-support")]
+    pub(crate) fn test_e2e_scheduled_units() -> [Self; 2] {
+        [Self::Candles(Timeframe::OneHour), Self::Funding]
+    }
+
+    pub(crate) fn default_cron_expression(self) -> &'static str {
+        #[cfg(feature = "test-support")]
+        {
+            let _ = self;
+            return TEST_INGESTION_CRON;
+        }
+        #[cfg(not(feature = "test-support"))]
+        match self {
+            Self::Funding => FUNDING_INGESTION_CRON,
+            Self::Candles(timeframe) => timeframe.ingestion_cron_expression(),
+        }
+    }
+
+    pub(crate) fn schedule_key(self) -> &'static str {
+        match self {
+            Self::Funding => "funding",
+            Self::Candles(timeframe) => timeframe.interval_string(),
+        }
+    }
+
+    pub(crate) fn from_schedule_key(key: &str) -> Result<Self, IngestionWorkParseError> {
+        match key {
+            "funding" => Ok(Self::Funding),
+            interval => Timeframe::from_interval_string(interval)
+                .map(Self::Candles)
+                .ok_or_else(|| IngestionWorkParseError::UnknownScheduleKey {
+                    key: key.to_string(),
+                }),
+        }
+    }
+}
+
+/// Why a schedule key string is not a valid [`IngestionWork`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum IngestionWorkParseError {
+    #[error(
+        "unknown ingestion schedule key `{key}`; expected funding or a candle interval (15m, 1h, 1d, 1w)"
+    )]
+    UnknownScheduleKey { key: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::timeframe::Timeframe;
+
+    use super::{IngestionWork, IngestionWorkParseError};
+
+    #[test]
+    fn schedule_key_round_trips_for_candle_intervals() {
+        for (interval, work) in [
+            ("15m", IngestionWork::Candles(Timeframe::FifteenMin)),
+            ("1h", IngestionWork::Candles(Timeframe::OneHour)),
+            ("1d", IngestionWork::Candles(Timeframe::OneDay)),
+            ("1w", IngestionWork::Candles(Timeframe::OneWeek)),
+        ] {
+            assert_eq!(work.schedule_key(), interval);
+            assert_eq!(IngestionWork::from_schedule_key(interval).unwrap(), work);
+        }
+    }
+
+    #[test]
+    fn schedule_key_round_trips_for_funding() {
+        assert_eq!(IngestionWork::Funding.schedule_key(), "funding");
+        assert_eq!(
+            IngestionWork::from_schedule_key("funding").unwrap(),
+            IngestionWork::Funding
+        );
+    }
+
+    #[test]
+    fn scheduled_units_cover_every_candle_timeframe_and_funding() {
+        assert_eq!(IngestionWork::scheduled_units().len(), 5);
+        for timeframe in Timeframe::all() {
+            assert!(IngestionWork::scheduled_units().contains(&IngestionWork::Candles(timeframe)));
+        }
+        assert!(IngestionWork::scheduled_units().contains(&IngestionWork::Funding));
+    }
+
+    #[test]
+    #[cfg(not(feature = "test-support"))]
+    fn default_cron_expressions_match_timeframe_cadence() {
+        assert_eq!(
+            IngestionWork::Candles(Timeframe::FifteenMin).default_cron_expression(),
+            "0 */15 * * * *"
+        );
+        assert_eq!(
+            IngestionWork::Candles(Timeframe::OneWeek).default_cron_expression(),
+            "0 0 0 * * 1"
+        );
+        assert_eq!(
+            IngestionWork::Funding.default_cron_expression(),
+            "0 0 * * * *"
+        );
+    }
+
+    #[test]
+    fn unknown_schedule_keys_are_rejected() {
+        assert_eq!(
+            IngestionWork::from_schedule_key("banana"),
+            Err(IngestionWorkParseError::UnknownScheduleKey {
+                key: "banana".to_string()
+            })
+        );
+    }
+}

--- a/src/ingestion/work.rs
+++ b/src/ingestion/work.rs
@@ -8,10 +8,10 @@ use crate::timeframe::Timeframe;
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum IngestionWork {
     Funding,
-    Candles(Timeframe),
+    Candles { timeframe: Timeframe },
 }
 
-const FUNDING_INGESTION_CRON: &str = "0 0 * * * *";
+const FUNDING_INGESTION_CRON: &str = "20 0 * * * *";
 
 /// Six-field cron used only under `test-support` so e2e tests observe scheduled
 /// ticks without waiting for production cadences.
@@ -21,10 +21,10 @@ const TEST_INGESTION_CRON: &str = "*/2 * * * * *";
 impl IngestionWork {
     pub(crate) fn scheduled_units() -> [Self; 5] {
         [
-            Self::Candles(Timeframe::FifteenMin),
-            Self::Candles(Timeframe::OneHour),
-            Self::Candles(Timeframe::OneDay),
-            Self::Candles(Timeframe::OneWeek),
+            Self::candles(Timeframe::FifteenMin),
+            Self::candles(Timeframe::OneHour),
+            Self::candles(Timeframe::OneDay),
+            Self::candles(Timeframe::OneWeek),
             Self::Funding,
         ]
     }
@@ -33,26 +33,34 @@ impl IngestionWork {
     /// plus funding, avoiding the OneWeek lookback overflow (issue #64).
     #[cfg(feature = "test-support")]
     pub(crate) fn test_e2e_scheduled_units() -> [Self; 2] {
-        [Self::Candles(Timeframe::OneHour), Self::Funding]
+        [Self::candles(Timeframe::OneHour), Self::Funding]
+    }
+
+    pub(crate) fn candles(timeframe: Timeframe) -> Self {
+        Self::Candles { timeframe }
+    }
+
+    pub(crate) fn production_cron_expression(self) -> &'static str {
+        match self {
+            Self::Funding => FUNDING_INGESTION_CRON,
+            Self::Candles { timeframe } => timeframe.ingestion_cron_expression(),
+        }
     }
 
     pub(crate) fn default_cron_expression(self) -> &'static str {
         #[cfg(feature = "test-support")]
         {
-            let _ = self;
-            return TEST_INGESTION_CRON;
+            let _ = self.production_cron_expression();
+            TEST_INGESTION_CRON
         }
         #[cfg(not(feature = "test-support"))]
-        match self {
-            Self::Funding => FUNDING_INGESTION_CRON,
-            Self::Candles(timeframe) => timeframe.ingestion_cron_expression(),
-        }
+        self.production_cron_expression()
     }
 
     pub(crate) fn schedule_key(self) -> &'static str {
         match self {
             Self::Funding => "funding",
-            Self::Candles(timeframe) => timeframe.interval_string(),
+            Self::Candles { timeframe } => timeframe.interval_string(),
         }
     }
 
@@ -60,7 +68,7 @@ impl IngestionWork {
         match key {
             "funding" => Ok(Self::Funding),
             interval => Timeframe::from_interval_string(interval)
-                .map(Self::Candles)
+                .map(|timeframe| Self::Candles { timeframe })
                 .ok_or_else(|| IngestionWorkParseError::UnknownScheduleKey {
                     key: key.to_string(),
                 }),
@@ -86,10 +94,10 @@ mod tests {
     #[test]
     fn schedule_key_round_trips_for_candle_intervals() {
         for (interval, work) in [
-            ("15m", IngestionWork::Candles(Timeframe::FifteenMin)),
-            ("1h", IngestionWork::Candles(Timeframe::OneHour)),
-            ("1d", IngestionWork::Candles(Timeframe::OneDay)),
-            ("1w", IngestionWork::Candles(Timeframe::OneWeek)),
+            ("15m", IngestionWork::candles(Timeframe::FifteenMin)),
+            ("1h", IngestionWork::candles(Timeframe::OneHour)),
+            ("1d", IngestionWork::candles(Timeframe::OneDay)),
+            ("1w", IngestionWork::candles(Timeframe::OneWeek)),
         ] {
             assert_eq!(work.schedule_key(), interval);
             assert_eq!(IngestionWork::from_schedule_key(interval).unwrap(), work);
@@ -109,7 +117,7 @@ mod tests {
     fn scheduled_units_cover_every_candle_timeframe_and_funding() {
         assert_eq!(IngestionWork::scheduled_units().len(), 5);
         for timeframe in Timeframe::all() {
-            assert!(IngestionWork::scheduled_units().contains(&IngestionWork::Candles(timeframe)));
+            assert!(IngestionWork::scheduled_units().contains(&IngestionWork::candles(timeframe)));
         }
         assert!(IngestionWork::scheduled_units().contains(&IngestionWork::Funding));
     }
@@ -118,17 +126,33 @@ mod tests {
     #[cfg(not(feature = "test-support"))]
     fn default_cron_expressions_match_timeframe_cadence() {
         assert_eq!(
-            IngestionWork::Candles(Timeframe::FifteenMin).default_cron_expression(),
+            IngestionWork::candles(Timeframe::FifteenMin).default_cron_expression(),
             "0 */15 * * * *"
         );
         assert_eq!(
-            IngestionWork::Candles(Timeframe::OneWeek).default_cron_expression(),
-            "0 0 0 * * 1"
+            IngestionWork::candles(Timeframe::OneHour).default_cron_expression(),
+            "10 0 * * * *"
+        );
+        assert_eq!(
+            IngestionWork::candles(Timeframe::OneDay).default_cron_expression(),
+            "0 0 0 * * *"
+        );
+        assert_eq!(
+            IngestionWork::candles(Timeframe::OneWeek).default_cron_expression(),
+            "0 30 0 * * 1"
         );
         assert_eq!(
             IngestionWork::Funding.default_cron_expression(),
-            "0 0 * * * *"
+            "20 0 * * * *"
         );
+    }
+
+    #[test]
+    fn ingestion_work_serializes_with_internally_tagged_candles_variant() {
+        let work = IngestionWork::candles(Timeframe::OneHour);
+        let json = serde_json::to_string(&work).unwrap();
+        assert_eq!(json, r#"{"kind":"candles","timeframe":"1h"}"#);
+        assert_eq!(serde_json::from_str::<IngestionWork>(&json).unwrap(), work);
     }
 
     #[test]

--- a/src/ingestion/work.rs
+++ b/src/ingestion/work.rs
@@ -19,14 +19,12 @@ const FUNDING_INGESTION_CRON: &str = "20 0 * * * *";
 const TEST_INGESTION_CRON: &str = "*/2 * * * * *";
 
 impl IngestionWork {
-    pub(crate) fn scheduled_units() -> [Self; 5] {
-        [
-            Self::candles(Timeframe::FifteenMin),
-            Self::candles(Timeframe::OneHour),
-            Self::candles(Timeframe::OneDay),
-            Self::candles(Timeframe::OneWeek),
-            Self::Funding,
-        ]
+    pub(crate) fn scheduled_units() -> Vec<Self> {
+        Timeframe::all()
+            .into_iter()
+            .map(Self::candles)
+            .chain([Self::Funding])
+            .collect()
     }
 
     /// Scoped work units started by schedulers in e2e tests: one candle interval
@@ -115,7 +113,10 @@ mod tests {
 
     #[test]
     fn scheduled_units_cover_every_candle_timeframe_and_funding() {
-        assert_eq!(IngestionWork::scheduled_units().len(), 5);
+        assert_eq!(
+            IngestionWork::scheduled_units().len(),
+            Timeframe::all().len() + 1
+        );
         for timeframe in Timeframe::all() {
             assert!(IngestionWork::scheduled_units().contains(&IngestionWork::candles(timeframe)));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,6 @@ pub(crate) struct AppState {
     database_pool: SqlitePool,
     portfolio_store: Arc<Store<Portfolio>>,
     portfolio_projection: Arc<Projection<Portfolio>>,
-    ingestion_store: Arc<Store<IngestionRun>>,
-    ingestion_projection: Arc<Projection<IngestionRun>>,
     market_enablement: Arc<Store<MarketEnablement>>,
     market_enablement_projection: Arc<Projection<MarketEnablement>>,
     market_catalog_projection: Arc<Projection<MarketCatalog>>,
@@ -870,8 +868,6 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
         database_pool: pool,
         portfolio_store,
         portfolio_projection,
-        ingestion_store,
-        ingestion_projection,
         market_enablement,
         market_enablement_projection,
         market_catalog_projection,
@@ -1002,7 +998,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let (ingestion_store, ingestion_projection) =
+        let (_ingestion_store, _ingestion_projection) =
             StoreBuilder::<IngestionRun>::new(pool.clone())
                 .build()
                 .await
@@ -1023,8 +1019,6 @@ mod tests {
             database_pool: pool,
             portfolio_store,
             portfolio_projection,
-            ingestion_store,
-            ingestion_projection,
             market_enablement,
             market_enablement_projection,
             market_catalog_projection,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ use tracing_subscriber::EnvFilter;
 use crate::hyperliquid::{Hyperliquid, HyperliquidClient};
 use finance::Symbol;
 use ingestion::{
-    IngestionError, IngestionJob, IngestionJobContext, IngestionRun, IngestionRunStatus,
-    IngestionServices,
+    IngestionJob, IngestionJobContext, IngestionRun, IngestionRunStatus, IngestionServices,
+    IngestionWork, default_ingestion_schedules,
 };
 use market_catalog::MarketCatalog;
 use market_enablement::{
@@ -90,7 +90,6 @@ pub struct Config {
     log_level: LogLevel,
     max_concurrent_requests: usize,
     max_retries: usize,
-    ingestion_schedule: String,
     pub derive: Option<derive::DeriveConfig>,
 }
 
@@ -202,19 +201,6 @@ async fn post_screener(
         Err(err) => {
             error!(error = %err, "failed to screen perps");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
-}
-
-async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
-    // `create_run` enqueues the ingestion job atomically with the `Started`
-    // event so a concurrent loser cannot wedge the slot.
-    match ingestion::create_run(&state.ingestion_store, &state.ingestion_projection).await {
-        Ok(_) => StatusCode::ACCEPTED,
-        Err(IngestionError::AlreadyRunning) => StatusCode::CONFLICT,
-        Err(err) => {
-            error!(error = %err, "failed to start ingestion run");
-            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 }
@@ -759,8 +745,9 @@ fn spawn_ingestion_worker(
     });
 }
 
-/// apalis-cron handler: enqueues an ingestion run on each schedule tick.
+/// apalis-cron handler: enqueues a scoped ingestion run on each schedule tick.
 async fn run_scheduled_ingestion(
+    work: IngestionWork,
     _tick: apalis_cron::Tick<chrono::Utc>,
     ingestion_store: Data<Arc<Store<IngestionRun>>>,
     ingestion_projection: Data<Arc<Projection<IngestionRun>>>,
@@ -769,30 +756,38 @@ async fn run_scheduled_ingestion(
     ingestion::trigger_scheduled_ingestion(
         &ingestion_store,
         &ingestion_projection,
+        work,
         &consecutive_failures,
     )
     .await;
     Ok(())
 }
 
-/// Spawns the supervised apalis-cron worker that enqueues an ingestion run on a
-/// fixed schedule, so deployed data stays current without an operator poking
-/// `/ingest`.
-fn spawn_ingestion_scheduler(
-    schedule: cron::Schedule,
+/// Spawns supervised apalis-cron workers -- one per built-in schedule -- so each
+/// candle timeframe and funding refresh tick on its own cadence.
+fn spawn_ingestion_schedulers(
+    schedules: Vec<(IngestionWork, cron::Schedule)>,
     ingestion_store: Arc<Store<IngestionRun>>,
     ingestion_projection: Arc<Projection<IngestionRun>>,
 ) {
-    let consecutive_failures = Arc::new(AtomicU32::new(0));
     tokio::spawn(async move {
-        let monitor = Monitor::new().register(move |_worker_index| {
-            WorkerBuilder::new("ingestion-scheduler")
-                .backend(apalis_cron::CronStream::new(schedule.clone()))
-                .data(Arc::clone(&ingestion_store))
-                .data(Arc::clone(&ingestion_projection))
-                .data(Arc::clone(&consecutive_failures))
-                .build(run_scheduled_ingestion)
-        });
+        let mut monitor = Monitor::new();
+        for (work, schedule) in schedules {
+            let ingestion_store = Arc::clone(&ingestion_store);
+            let ingestion_projection = Arc::clone(&ingestion_projection);
+            let consecutive_failures = Arc::new(AtomicU32::new(0));
+            let worker_name = format!("ingestion-scheduler-{}", work.schedule_key());
+            monitor = monitor.register(move |_worker_index| {
+                WorkerBuilder::new(worker_name.clone())
+                    .backend(apalis_cron::CronStream::new(schedule.clone()))
+                    .data(Arc::clone(&ingestion_store))
+                    .data(Arc::clone(&ingestion_projection))
+                    .data(Arc::clone(&consecutive_failures))
+                    .build(move |tick, store, projection, failures| {
+                        run_scheduled_ingestion(work, tick, store, projection, failures)
+                    })
+            });
+        }
         if let Err(err) = monitor.run().await {
             error!(error = %err, "ingestion scheduler monitor crashed");
         }
@@ -812,10 +807,7 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
 
     ensure_shared_database(&config.database_url)?;
 
-    // Parse the schedule before any setup or background task: an invalid cron
-    // expression must fail startup outright, never after a worker has already
-    // been detached.
-    let ingestion_schedule = cron::Schedule::from_str(&config.ingestion_schedule)?;
+    let ingestion_schedules = default_ingestion_schedules()?;
 
     let database_options = SqliteConnectOptions::from_str(&config.database_url)?
         .journal_mode(SqliteJournalMode::Wal)
@@ -850,8 +842,8 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
             .await?;
     debug!("event-sourced stores ready");
 
-    // Abandon any run left Running by a crash before we accept /ingest, so the
-    // one-running slot can never stay wedged across a restart (issue #339).
+    // Abandon any run left Running by a crash before schedulers enqueue work, so
+    // the one-running slot can never stay wedged across a restart (issue #339).
     ingestion::recover_abandoned_runs(&ingestion_store, &ingestion_projection).await?;
 
     // apalis-sqlite is built against sqlx 0.8, so its storage needs its own
@@ -884,12 +876,12 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
     spawn_ingestion_worker(apalis_pool.clone(), ingestion_context);
     debug!("ingestion worker started");
 
-    spawn_ingestion_scheduler(
-        ingestion_schedule,
+    spawn_ingestion_schedulers(
+        ingestion_schedules,
         Arc::clone(&ingestion_store),
         Arc::clone(&ingestion_projection),
     );
-    debug!("ingestion scheduler started");
+    debug!("ingestion schedulers started");
 
     let state = Arc::new(AppState {
         config,
@@ -913,7 +905,6 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/candles/{timeframe}", get(get_candles))
         .route("/factors/{timeframe}", get(get_factors))
         .route("/screener/{timeframe}", post(post_screener))
-        .route("/ingest", post(start_ingestion))
         .route("/ingestion/status", get(get_ingestion_status))
         .route(
             "/portfolio",
@@ -1011,7 +1002,6 @@ mod tests {
             log_level: LogLevel::Info,
             max_concurrent_requests: 3,
             max_retries: 5,
-            ingestion_schedule: "0 0 * * * *".to_string(),
             derive: None,
         };
 
@@ -1332,7 +1322,6 @@ mod tests {
                 log_level = "info"
                 max_concurrent_requests = 3
                 max_retries = 5
-                ingestion_schedule = "0 0 * * * *"
             "#);
             let config: Config = toml::from_str(&toml).unwrap();
             prop_assert_eq!(config.port, port);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
 
-use apalis::prelude::{Data, Monitor, WorkerBuilder};
+use apalis::prelude::{Monitor, WorkerBuilder};
 use axum::Json;
 use axum::Router;
 use axum::extract::{Path as AxumPath, Query, State};
@@ -46,7 +46,7 @@ use crate::hyperliquid::{Hyperliquid, HyperliquidClient};
 use finance::Symbol;
 use ingestion::{
     IngestionJob, IngestionJobContext, IngestionRun, IngestionRunStatus, IngestionServices,
-    IngestionWork, default_ingestion_schedules,
+    IngestionWork, default_ingestion_schedules, trigger_scheduled_ingestion,
 };
 use market_catalog::MarketCatalog;
 use market_enablement::{
@@ -745,24 +745,6 @@ fn spawn_ingestion_worker(
     });
 }
 
-/// apalis-cron handler: enqueues a scoped ingestion run on each schedule tick.
-async fn run_scheduled_ingestion(
-    work: IngestionWork,
-    _tick: apalis_cron::Tick<chrono::Utc>,
-    ingestion_store: Data<Arc<Store<IngestionRun>>>,
-    ingestion_projection: Data<Arc<Projection<IngestionRun>>>,
-    consecutive_failures: Data<Arc<AtomicU32>>,
-) -> Result<(), std::convert::Infallible> {
-    ingestion::trigger_scheduled_ingestion(
-        &ingestion_store,
-        &ingestion_projection,
-        work,
-        &consecutive_failures,
-    )
-    .await;
-    Ok(())
-}
-
 /// Spawns supervised apalis-cron workers -- one per built-in schedule -- so each
 /// candle timeframe and funding refresh tick on its own cadence.
 fn spawn_ingestion_schedulers(
@@ -784,7 +766,7 @@ fn spawn_ingestion_schedulers(
                     .data(Arc::clone(&ingestion_projection))
                     .data(Arc::clone(&consecutive_failures))
                     .build(move |tick, store, projection, failures| {
-                        run_scheduled_ingestion(work, tick, store, projection, failures)
+                        trigger_scheduled_ingestion(work, tick, store, projection, failures)
                     })
             });
         }

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -44,9 +44,9 @@ impl Timeframe {
     pub(crate) fn ingestion_cron_expression(self) -> &'static str {
         match self {
             Self::FifteenMin => "0 */15 * * * *",
-            Self::OneHour => "0 0 * * * *",
+            Self::OneHour => "10 0 * * * *",
             Self::OneDay => "0 0 0 * * *",
-            Self::OneWeek => "0 0 0 * * 1",
+            Self::OneWeek => "0 30 0 * * 1",
         }
     }
 

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -5,11 +5,17 @@
 //! back (3 years for weekly). This balances storage costs against analytical
 //! utility - higher-frequency data is most relevant for recent periods.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum Timeframe {
+    #[serde(rename = "15m")]
     FifteenMin,
+    #[serde(rename = "1h")]
     OneHour,
+    #[serde(rename = "1d")]
     OneDay,
+    #[serde(rename = "1w")]
     OneWeek,
 }
 
@@ -31,6 +37,21 @@ impl Timeframe {
             Self::OneDay => "1d",
             Self::OneWeek => "1w",
         }
+    }
+
+    /// Default 6-field cron expression (sec min hour day-of-month month day-of-week)
+    /// for scheduled ingestion of this candle interval.
+    pub(crate) fn ingestion_cron_expression(self) -> &'static str {
+        match self {
+            Self::FifteenMin => "0 */15 * * * *",
+            Self::OneHour => "0 0 * * * *",
+            Self::OneDay => "0 0 0 * * *",
+            Self::OneWeek => "0 0 0 * * 1",
+        }
+    }
+
+    pub(crate) fn all() -> [Self; 4] {
+        [Self::FifteenMin, Self::OneHour, Self::OneDay, Self::OneWeek]
     }
 
     /// Duration covered by a window of `max_entries` candles for this timeframe.

--- a/src/timeframe.rs
+++ b/src/timeframe.rs
@@ -5,18 +5,29 @@
 //! back (3 years for weekly). This balances storage costs against analytical
 //! utility - higher-frequency data is most relevant for recent periods.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Timeframe {
-    #[serde(rename = "15m")]
     FifteenMin,
-    #[serde(rename = "1h")]
     OneHour,
-    #[serde(rename = "1d")]
     OneDay,
-    #[serde(rename = "1w")]
     OneWeek,
+}
+
+impl Serialize for Timeframe {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.interval_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Timeframe {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let interval = String::deserialize(deserializer)?;
+        Self::from_interval_string(&interval).ok_or_else(|| {
+            serde::de::Error::custom(format!("unknown timeframe interval: {interval}"))
+        })
+    }
 }
 
 impl Timeframe {
@@ -234,16 +245,20 @@ mod tests {
 
     #[test]
     fn interval_string_roundtrips() {
-        for timeframe in [
-            Timeframe::FifteenMin,
-            Timeframe::OneHour,
-            Timeframe::OneDay,
-            Timeframe::OneWeek,
-        ] {
+        for timeframe in Timeframe::all() {
             assert_eq!(
                 Timeframe::from_interval_string(timeframe.interval_string()),
                 Some(timeframe)
             );
+        }
+    }
+
+    #[test]
+    fn serde_uses_interval_strings() {
+        for timeframe in Timeframe::all() {
+            let json = serde_json::to_string(&timeframe).unwrap();
+            assert_eq!(json, format!("\"{}\"", timeframe.interval_string()));
+            assert_eq!(serde_json::from_str::<Timeframe>(&json).unwrap(), timeframe);
         }
     }
 

--- a/stories/0x023.switch-event-sourcing-wrapper.md
+++ b/stories/0x023.switch-event-sourcing-wrapper.md
@@ -21,7 +21,8 @@ job queue, and each queued job carries the run ID it is responsible for.
 
 ## Acceptance Criteria
 
-- [x] `POST /ingest` creates an `ingestion_runs` row before queueing work.
+- [x] Scheduled ingestion runs are enqueued by built-in apalis-cron workers
+      before the job executes.
 - [x] `IngestionJob` carries a typed run ID and updates that run to `completed`
       or `failed`.
 - [x] Backend startup marks leftover `running` rows as `failed`, making crashed

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -125,6 +125,14 @@ impl TestApp {
 }
 
 async fn spawn_test_app(mock_server: &MockServer, data_dir: &TempDir) -> TestApp {
+    spawn_test_app_with_retries(mock_server, data_dir, 2).await
+}
+
+async fn spawn_test_app_with_retries(
+    mock_server: &MockServer,
+    data_dir: &TempDir,
+    max_retries: usize,
+) -> TestApp {
     let database_path = data_dir.path().join("moneymentum-test.db");
     let toml_str = format!(
         r#"
@@ -134,7 +142,7 @@ async fn spawn_test_app(mock_server: &MockServer, data_dir: &TempDir) -> TestApp
         hyperliquid_base_url = "{}"
         log_level = "debug"
         max_concurrent_requests = 3
-        max_retries = 2
+        max_retries = {max_retries}
         "#,
         data_dir.path().display(),
         database_path.display(),
@@ -248,10 +256,14 @@ async fn status_advances_after_failed_scheduled_run() {
     mount_failing_ingestion_mocks(&mock_server).await;
 
     let data_dir = TempDir::new().unwrap();
-    let app = spawn_test_app(&mock_server, &data_dir).await;
+    let app = spawn_test_app_with_retries(&mock_server, &data_dir, 0).await;
 
-    let failed = poll_for_status(&app, "Failed", 60, 200).await;
-    assert!(failed, "first scheduled ingestion should fail");
+    let failed = poll_for_status(&app, "Failed", 40, 100).await;
+    assert!(
+        failed,
+        "first scheduled ingestion should fail, last status: {}",
+        ingestion_status_body(&app).await
+    );
 
     mock_server.reset().await;
     mount_successful_ingestion_mocks(&mock_server).await;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -63,6 +63,30 @@ async fn mount_funding_mock(server: &MockServer) {
         .await;
 }
 
+async fn mount_failing_candle_mock(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/info"))
+        .and(body_partial_json(json!({"type": "candleSnapshot"})))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(server)
+        .await;
+}
+
+async fn mount_failing_funding_mock(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/info"))
+        .and(body_partial_json(json!({"type": "fundingHistory"})))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(server)
+        .await;
+}
+
+async fn mount_failing_ingestion_mocks(server: &MockServer) {
+    mount_meta_mock(server).await;
+    mount_failing_candle_mock(server).await;
+    mount_failing_funding_mock(server).await;
+}
+
 async fn mount_successful_ingestion_mocks(server: &MockServer) {
     mount_meta_mock(server).await;
     mount_candle_mock(server).await;
@@ -221,13 +245,7 @@ async fn scheduled_ingestion_completes_and_candles_are_queryable() {
 #[tokio::test(flavor = "multi_thread")]
 async fn status_advances_after_failed_scheduled_run() {
     let mock_server = MockServer::start().await;
-    mount_meta_mock(&mock_server).await;
-    Mock::given(method("POST"))
-        .and(path("/info"))
-        .and(body_partial_json(json!({"type": "candleSnapshot"})))
-        .respond_with(ResponseTemplate::new(500))
-        .mount(&mock_server)
-        .await;
+    mount_failing_ingestion_mocks(&mock_server).await;
 
     let data_dir = TempDir::new().unwrap();
     let app = spawn_test_app(&mock_server, &data_dir).await;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -9,6 +9,7 @@
 )]
 
 use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
 
 use moneymentum::{Config, app};
 use reqwest::StatusCode;
@@ -62,11 +63,18 @@ async fn mount_funding_mock(server: &MockServer) {
         .await;
 }
 
+async fn mount_successful_ingestion_mocks(server: &MockServer) {
+    mount_meta_mock(server).await;
+    mount_candle_mock(server).await;
+    mount_funding_mock(server).await;
+}
+
 /// A moneymentum backend bound to an ephemeral port, exercised end-to-end over
 /// real HTTP exactly as an external consumer would.
 struct TestApp {
     base_url: String,
     http: reqwest::Client,
+    server: tokio::task::JoinHandle<()>,
 }
 
 impl TestApp {
@@ -85,6 +93,11 @@ impl TestApp {
             .await
             .unwrap()
     }
+
+    async fn shutdown(self) {
+        self.server.abort();
+        let _ = self.server.await;
+    }
 }
 
 async fn spawn_test_app(mock_server: &MockServer, data_dir: &TempDir) -> TestApp {
@@ -98,7 +111,6 @@ async fn spawn_test_app(mock_server: &MockServer, data_dir: &TempDir) -> TestApp
         log_level = "debug"
         max_concurrent_requests = 3
         max_retries = 2
-        ingestion_schedule = "0 0 * * * *"
         "#,
         data_dir.path().display(),
         database_path.display(),
@@ -111,48 +123,71 @@ async fn spawn_test_app(mock_server: &MockServer, data_dir: &TempDir) -> TestApp
         .await
         .unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
-    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
 
     TestApp {
         base_url,
         http: reqwest::Client::new(),
+        server,
     }
+}
+
+async fn ingestion_status_body(app: &TestApp) -> String {
+    app.get("/ingestion/status").await.text().await.unwrap()
 }
 
 async fn poll_for_status(app: &TestApp, status: &str, max_polls: usize, interval_ms: u64) -> bool {
     for _ in 0..max_polls {
-        let body = app.get("/ingestion/status").await.text().await.unwrap();
-        if body.contains(status) {
+        if ingestion_status_body(app).await.contains(status) {
             return true;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(interval_ms)).await;
+        tokio::time::sleep(Duration::from_millis(interval_ms)).await;
     }
     false
 }
 
-// Temporarily skipped: fails due to OneWeek timeframe overflow when using a
-// 5000-entry window; see https://github.com/dataclique/moneymentum/issues/64.
-#[ignore = "OneWeek timeframe window overflows when requesting 5000 candles (see issue #64)"]
 #[tokio::test(flavor = "multi_thread")]
-async fn ingest_and_query_candles() {
+async fn ingestion_status_is_idle_on_fresh_start() {
     let mock_server = MockServer::start().await;
     mount_meta_mock(&mock_server).await;
-    mount_candle_mock(&mock_server).await;
-    mount_funding_mock(&mock_server).await;
 
     let data_dir = TempDir::new().unwrap();
     let app = spawn_test_app(&mock_server, &data_dir).await;
 
-    let ingest_response = app.post("/ingest").await;
-    assert_eq!(ingest_response.status(), StatusCode::ACCEPTED);
+    let response = app.get("/ingestion/status").await;
+    assert!(response.status().is_success());
 
-    let completed = poll_for_status(&app, "Completed", 100, 50).await;
+    let body = response.text().await.unwrap();
+    assert_eq!(body, "null");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn manual_ingest_endpoint_is_not_exposed() {
+    let mock_server = MockServer::start().await;
+    mount_meta_mock(&mock_server).await;
+
+    let data_dir = TempDir::new().unwrap();
+    let app = spawn_test_app(&mock_server, &data_dir).await;
+
+    let response = app.post("/ingest").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scheduled_ingestion_completes_and_candles_are_queryable() {
+    let mock_server = MockServer::start().await;
+    mount_successful_ingestion_mocks(&mock_server).await;
+
+    let data_dir = TempDir::new().unwrap();
+    let app = spawn_test_app(&mock_server, &data_dir).await;
+
+    let completed = poll_for_status(&app, "Completed", 60, 200).await;
     if !completed {
-        let body = app.get("/ingestion/status").await.text().await.unwrap();
+        let body = ingestion_status_body(&app).await;
         if body.contains("Failed") {
-            panic!("ingestion failed: {body}");
+            panic!("scheduled ingestion failed: {body}");
         }
-        panic!("ingestion did not complete within timeout, last status: {body}");
+        panic!("scheduled ingestion did not complete within timeout, last status: {body}");
     }
 
     let candles_response = app.get("/candles/1h").await;
@@ -181,13 +216,11 @@ async fn ingest_and_query_candles() {
     );
 }
 
-/// After a previous failed ingestion, restarting should show "Running" status,
-/// not the old "Failed" status.
+/// After a failed scheduled run, the next scheduler tick must surface `Running`
+/// (or `Completed`) rather than leaving the latest status stuck on `Failed`.
 #[tokio::test(flavor = "multi_thread")]
-async fn status_shows_running_after_restart_from_failed() {
+async fn status_advances_after_failed_scheduled_run() {
     let mock_server = MockServer::start().await;
-
-    // First run: mock returns error to cause failure
     mount_meta_mock(&mock_server).await;
     Mock::given(method("POST"))
         .and(path("/info"))
@@ -199,18 +232,27 @@ async fn status_shows_running_after_restart_from_failed() {
     let data_dir = TempDir::new().unwrap();
     let app = spawn_test_app(&mock_server, &data_dir).await;
 
-    // Trigger first ingestion (will fail)
-    app.post("/ingest").await;
+    let failed = poll_for_status(&app, "Failed", 60, 200).await;
+    assert!(failed, "first scheduled ingestion should fail");
 
-    // Wait for failure (retries take ~12s with exponential backoff)
-    let failed = poll_for_status(&app, "Failed", 200, 100).await;
-    assert!(failed, "first ingestion should fail");
-
-    // Set up successful mock for second run
     mock_server.reset().await;
-    mount_meta_mock(&mock_server).await;
+    mount_successful_ingestion_mocks(&mock_server).await;
 
-    // Make candle fetch slow so we can check Running status
+    let advanced = poll_for_status(&app, "Running", 60, 200).await
+        || poll_for_status(&app, "Completed", 60, 200).await;
+
+    assert!(
+        advanced,
+        "status should advance after a failed run, last status: {}",
+        ingestion_status_body(&app).await
+    );
+}
+
+/// A backend restart abandons any in-flight run so schedulers can enqueue again.
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_abandons_running_ingestion_and_scheduler_recovers() {
+    let mock_server = MockServer::start().await;
+    mount_meta_mock(&mock_server).await;
     Mock::given(method("POST"))
         .and(path("/info"))
         .and(body_partial_json(json!({"type": "candleSnapshot"})))
@@ -228,22 +270,29 @@ async fn status_shows_running_after_restart_from_failed() {
                     "v": "1000.0",
                     "n": 500
                 }]))
-                .set_delay(std::time::Duration::from_millis(500)),
+                .set_delay(Duration::from_secs(30)),
         )
         .mount(&mock_server)
         .await;
     mount_funding_mock(&mock_server).await;
 
-    // Trigger second ingestion
-    let ingest_response = app.post("/ingest").await;
-    assert_eq!(ingest_response.status(), StatusCode::ACCEPTED);
+    let data_dir = TempDir::new().unwrap();
+    let app = spawn_test_app(&mock_server, &data_dir).await;
 
-    // Poll for Running or Completed status
-    let saw_running = poll_for_status(&app, "Running", 50, 100).await
-        || poll_for_status(&app, "Completed", 50, 100).await;
+    let running = poll_for_status(&app, "Running", 60, 200).await;
+    assert!(running, "scheduler should enqueue a run");
 
+    app.shutdown().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    mock_server.reset().await;
+    mount_successful_ingestion_mocks(&mock_server).await;
+
+    let restarted = spawn_test_app(&mock_server, &data_dir).await;
+    let completed = poll_for_status(&restarted, "Completed", 60, 200).await;
     assert!(
-        saw_running,
-        "status should transition to Running (or Completed) after restart from Failed"
+        completed,
+        "restarted backend should complete ingestion after abandoning the wedged run, last status: {}",
+        ingestion_status_body(&restarted).await
     );
 }


### PR DESCRIPTION
Decouple scheduled ingestion into scoped work units (one candle timeframe or funding per run) with built-in cron cadences per interval, while operator-triggered `/ingest` still runs a full sweep.

Closes #411.

## Motivation

A single hourly ingestion tick refreshes every candle timeframe and funding together, so 15m data cannot update every fifteen minutes without also re-fetching daily and weekly series on the same cadence. Each interval needs its own schedule aligned to how often that data actually moves.

## Solution

Introduce `IngestionWork` (`Full`, `Funding`, `Candles(Timeframe)`) and thread it through run commands, job enqueue, and the worker so a scheduled tick only executes the work it enqueues. Replace the one `ingestion_schedule` cron with five apalis-cron workers -- one per candle interval plus funding -- using default expressions derived from each timeframe (15m every fifteen minutes, 1h on the hour, 1d at midnight, 1w on Monday, funding hourly). `POST /ingest` continues to enqueue `Full` for manual backfills. Stacked on #410 (`chore/ingestion-submodules`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingestion now runs on multiple automatic schedules instead of one shared schedule.
  * Scheduled work is split between funding updates and candle updates by timeframe.
  * Manual ingestion via the API was removed.

* **Bug Fixes**
  * Improved recovery after failures or restarts so scheduled ingestion can continue normally.
  * Fixed status reporting so failed runs don’t leave the app stuck showing outdated state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->