### PR TITLE
fix systemd ExecStart after markets-refresh token removal

### DIFF
--- a/os.nix
+++ b/os.nix
@@ -12,38 +12,11 @@ let
 
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
 
-  mkMarketsRefreshService =
-    {
-      description,
-      readyMarker,
-      port,
-      runtimeTokenPath,
-    }:
-    {
-      inherit description;
-      unitConfig.ConditionPathExists = [
-        readyMarker
-        runtimeTokenPath
-      ];
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        LoadCredential = "markets_refresh_token:${runtimeTokenPath}";
-        ExecStart = pkgs.writeShellScript "markets-refresh-${builtins.baseNameOf runtimeTokenPath}" ''
-          ${pkgs.curl}/bin/curl -sSf --max-time 120 -X POST \
-            -H "X-Markets-Refresh-Token: $(<"$CREDENTIALS_DIRECTORY/markets_refresh_token")" \
-            http://127.0.0.1:${toString port}/hyperliquid/markets/refresh
-        '';
-      };
-    };
-
   mkService =
     name: cfg:
     let
       path = "/nix/var/nix/profiles/per-service/${name}/bin/${cfg.bin}";
       configFile = ./config/${name}.toml;
-      runtimeDir = "/run/moneymentum/${name}";
-      runtimeTokenPath = "${runtimeDir}/markets-refresh-token";
     in
     {
       description = "moneymentum ${cfg.bin} (${name})";
@@ -61,13 +34,10 @@ let
       serviceConfig = {
         User = "moneymentum";
         Group = "warehouse";
-        ExecStart = "${path} --config ${configFile} --markets-refresh-token-publish-path ${runtimeTokenPath}";
+        ExecStart = "${path} --config ${configFile}";
         Restart = "always";
         RestartSec = 5;
-        ReadWritePaths = [
-          cfg.dataDir
-          runtimeDir
-        ];
+        ReadWritePaths = [ cfg.dataDir ];
       };
     };
 
@@ -252,20 +222,6 @@ in
         ExecStart = "${pkgs.curl}/bin/curl -sSf --max-time 300 -X POST http://127.0.0.1:8000/ingest";
       };
     };
-
-    moneymentum-markets-refresh = mkMarketsRefreshService {
-      description = "Refresh Hyperliquid markets metadata";
-      readyMarker = "/run/moneymentum/moneymentum.ready";
-      port = 8000;
-      runtimeTokenPath = "/run/moneymentum/moneymentum/markets-refresh-token";
-    };
-
-    staging-markets-refresh = mkMarketsRefreshService {
-      description = "Refresh Hyperliquid markets metadata (staging)";
-      readyMarker = "/run/moneymentum/staging.ready";
-      port = 8001;
-      runtimeTokenPath = "/run/moneymentum/staging/markets-refresh-token";
-    };
   };
 
   systemd.timers.moneymentum-ingest = {
@@ -277,31 +233,11 @@ in
     };
   };
 
-  systemd.timers.moneymentum-markets-refresh = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnCalendar = "*-*-* 00:00:00 UTC";
-      Persistent = true;
-    };
-  };
-
-  systemd.timers.staging-markets-refresh = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnCalendar = "*-*-* 00:00:00 UTC";
-      Persistent = true;
-    };
-  };
-
   systemd.tmpfiles.rules =
     let
       dataDirs = lib.mapAttrsToList (_: cfg: cfg.dataDir) enabledServices;
-      runtimeDirs = lib.mapAttrsToList (
-        name: _: "d /run/moneymentum/${name} 0770 moneymentum warehouse -"
-      ) enabledServices;
     in
     map (dir: "d ${dir} 0770 moneymentum warehouse -") dataDirs
-    ++ runtimeDirs
     ++ [ "d /var/lib/moneymentum/frontend 0755 root root -" ];
 
   system.activationScripts.moneymentum-init.text = "mkdir -p /run/moneymentum";


### PR DESCRIPTION
## Motivation

The deployment systemd unit still passes `--markets-refresh-token-publish-path`, which the application no longer accepts after markets-refresh was removed. The service fails on start.

## Solution

Drop the dead CLI flag from `ExecStart` and remove the obsolete markets-refresh systemd units, timers, and runtime directories from `os.nix`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified service startup for enabled services, improving consistency when launching with configuration files.
  * Reduced writable filesystem access for services to only the needed data directories.
  * Removed scheduled market refresh jobs and their related runtime setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->