### PR TITLE
bridge the stale per-service binary through deploy activation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,6 +136,7 @@ the next user-facing priority; it runs in parallel to the Dev track above.
       ([#395](https://github.com/dataclique/moneymentum/pull/395))
 - [x] [Bridge the stale per-service binary through deploy activation](https://github.com/dataclique/moneymentum/issues/421)
       ([#423](https://github.com/dataclique/moneymentum/pull/423))
+- [ ] [Remove the markets_refresh_token deploy bridge from service configs](https://github.com/dataclique/moneymentum/issues/425)
 - [ ] [Deploy the service binary, unit, and config atomically](https://github.com/dataclique/moneymentum/issues/422)
 - [x] [Address #377 review follow-ups](https://github.com/dataclique/moneymentum/issues/392)
       ([#393](https://github.com/dataclique/moneymentum/pull/393))

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,6 +134,9 @@ the next user-facing priority; it runs in parallel to the Dev track above.
 - [ ] [Serve The App From A Domain](./stories/0x009.serve-app-from-domain.md)
 - [x] [Clear stale switch-to-configuration lock blocking deploys](https://github.com/dataclique/moneymentum/issues/394)
       ([#395](https://github.com/dataclique/moneymentum/pull/395))
+- [x] [Bridge the stale per-service binary through deploy activation](https://github.com/dataclique/moneymentum/issues/421)
+      ([#423](https://github.com/dataclique/moneymentum/pull/423))
+- [ ] [Deploy the service binary, unit, and config atomically](https://github.com/dataclique/moneymentum/issues/422)
 - [x] [Address #377 review follow-ups](https://github.com/dataclique/moneymentum/issues/392)
       ([#393](https://github.com/dataclique/moneymentum/pull/393))
 

--- a/config/moneymentum.toml
+++ b/config/moneymentum.toml
@@ -4,3 +4,10 @@ database_url = "sqlite:///mnt/data/prod/moneymentum.db?mode=rwc"
 log_level = "info"
 max_concurrent_requests = 3
 max_retries = 5
+
+# Deploy bridge: the per-service profile still runs the pre-#417 binary during
+# system activation, and that binary refuses to start unless the token is set
+# here (its --markets-refresh-token-publish-path flag no longer exists in the
+# new unit). The current binary ignores this key. Remove once the per-service
+# profiles have picked up a post-markets-refresh-removal binary.
+markets_refresh_token = "deploy-bridge-token-unused-by-current-binary"

--- a/config/moneymentum.toml
+++ b/config/moneymentum.toml
@@ -8,6 +8,8 @@ max_retries = 5
 # Deploy bridge: the per-service profile still runs the pre-#417 binary during
 # system activation, and that binary refuses to start unless the token is set
 # here (its --markets-refresh-token-publish-path flag no longer exists in the
-# new unit). The current binary ignores this key. Remove once the per-service
-# profiles have picked up a post-markets-refresh-removal binary.
-markets_refresh_token = "deploy-bridge-token-unused-by-current-binary"
+# new unit). The current binary ignores this key. On the stale binary the
+# value authenticates POST /hyperliquid/markets/refresh, so it is random
+# rather than guessable. Removal after the first green deploy is tracked in
+# https://github.com/dataclique/moneymentum/issues/425.
+markets_refresh_token = "159751662c02956417382903adf492b0a8af10c04f9e6fb6"

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -4,3 +4,10 @@ database_url = "sqlite:///mnt/data/staging/moneymentum.db?mode=rwc"
 log_level = "debug"
 max_concurrent_requests = 3
 max_retries = 5
+
+# Deploy bridge: the per-service profile still runs the pre-#417 binary during
+# system activation, and that binary refuses to start unless the token is set
+# here (its --markets-refresh-token-publish-path flag no longer exists in the
+# new unit). The current binary ignores this key. Remove once the per-service
+# profiles have picked up a post-markets-refresh-removal binary.
+markets_refresh_token = "deploy-bridge-token-unused-by-current-binary"

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -8,6 +8,8 @@ max_retries = 5
 # Deploy bridge: the per-service profile still runs the pre-#417 binary during
 # system activation, and that binary refuses to start unless the token is set
 # here (its --markets-refresh-token-publish-path flag no longer exists in the
-# new unit). The current binary ignores this key. Remove once the per-service
-# profiles have picked up a post-markets-refresh-removal binary.
-markets_refresh_token = "deploy-bridge-token-unused-by-current-binary"
+# new unit). The current binary ignores this key. On the stale binary the
+# value authenticates POST /hyperliquid/markets/refresh, so it is random
+# rather than guessable. Removal after the first green deploy is tracked in
+# https://github.com/dataclique/moneymentum/issues/425.
+markets_refresh_token = "a540f5cb56e342d9b969efc38a532931db04b178eff6cc0b"


### PR DESCRIPTION
## Motivation

Every master deploy fails at NixOS activation and rolls back, even with #420 merged. The system profile activates first and restarts `moneymentum.service` and `staging.service` under the new generation's unit, which no longer passes `--markets-refresh-token-publish-path` -- but the per-service profiles still hold a pre-#417 binary that cannot start without that flag or a `markets_refresh_token` config key. The failed units abort activation, deploy-rs rolls back, and the new binary never reaches the host, so every deploy hits the same wall.

Closes #421.

## Solution

Set a `markets_refresh_token` in both service configs: the stale binary accepts the token from config and starts under the flag-less unit, activation converges, and the per-service profiles then deliver the current binary, which ignores the unknown key. The values are random because on the stale binary they authenticate the nginx-proxied markets-refresh endpoint during the skew window. Removing the bridge after the first green deploy is tracked in #425; the underlying skew class (binary and unit/config deploying through separate profiles) in #422.

No automated test: the failure mode depends on the live host's per-service profile predating #417, which nothing in-repo can reproduce. Verified instead by reading both config loaders — the stale binary's (`b5a0f384:src/lib.rs`, token-in-config path) and master's (unknown keys tolerated, all required fields present).
