### PR TITLE
restore the applied migration #407 rewrote so the binary starts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,6 +136,8 @@ the next user-facing priority; it runs in parallel to the Dev track above.
       ([#395](https://github.com/dataclique/moneymentum/pull/395))
 - [x] [Bridge the stale per-service binary through deploy activation](https://github.com/dataclique/moneymentum/issues/421)
       ([#423](https://github.com/dataclique/moneymentum/pull/423))
+- [x] [Restore the applied migration #407 rewrote so the binary starts](https://github.com/dataclique/moneymentum/issues/426)
+      ([#427](https://github.com/dataclique/moneymentum/pull/427))
 - [ ] [Remove the markets_refresh_token deploy bridge from service configs](https://github.com/dataclique/moneymentum/issues/425)
 - [ ] [Deploy the service binary, unit, and config atomically](https://github.com/dataclique/moneymentum/issues/422)
 - [x] [Address #377 review follow-ups](https://github.com/dataclique/moneymentum/issues/392)

--- a/migrations/20260618052212_reconcile_event_store_for_event_sorcery.sql
+++ b/migrations/20260618052212_reconcile_event_store_for_event_sorcery.sql
@@ -1,16 +1,46 @@
 -- Reconcile the event store with event-sorcery's canonical schema.
 --
 -- The `events`, `snapshots`, and `ingestion_view` tables were created by
--- earlier migrations for a cqrs-es Ingestion aggregate that issue #339 removed,
--- so they are empty. event-sorcery now owns the event store:
+-- earlier migrations for a cqrs-es Ingestion aggregate that issue #339 removed.
+-- event-sorcery now owns the event store:
 --
 --   * `events` already matches event-sorcery's canonical layout -- left as is.
---   * `snapshots` lacked the `snapshot_version` column event-sorcery's schema
---     reconciler reads; add it in place so existing snapshot rows survive upgrade.
+--   * `snapshots` is missing the `snapshot_version` column event-sorcery's
+--     schema reconciler reads. We rebuild the table with the canonical columns
+--     and copy every existing row forward (defaulting `snapshot_version` to 0)
+--     rather than dropping it, so a database that still holds snapshot rows
+--     keeps its event-store state instead of silently losing it.
 --   * `ingestion_view` is dead: ingestion uses the `ingestion_runs` ledger, and
 --     event-sorcery creates per-aggregate view tables itself, so the orphan is
 --     dropped to avoid confusion with future projection tables.
 
 DROP TABLE IF EXISTS ingestion_view;
 
-ALTER TABLE snapshots ADD COLUMN snapshot_version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE snapshots RENAME TO snapshots_legacy;
+
+CREATE TABLE snapshots (
+    aggregate_type TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    last_sequence BIGINT NOT NULL,
+    snapshot_version BIGINT NOT NULL DEFAULT 0,
+    payload JSON NOT NULL,
+    timestamp TEXT NOT NULL,
+    PRIMARY KEY (aggregate_type, aggregate_id)
+);
+
+INSERT INTO snapshots (
+    aggregate_type,
+    aggregate_id,
+    last_sequence,
+    payload,
+    timestamp
+)
+SELECT
+    aggregate_type,
+    aggregate_id,
+    last_sequence,
+    payload,
+    timestamp
+FROM snapshots_legacy;
+
+DROP TABLE snapshots_legacy;


### PR DESCRIPTION
## Motivation

The first deploy to pass activation (after #423) still left the backend serving 502s: #407 rewrote the already-applied `20260618052212_reconcile_event_store_for_event_sorcery` migration in place, so sqlx's startup migration validation fails the checksum against the databases that applied the original on 2026-06-30, and the service crash-loops on prod and staging.

Closes #426.

## Solution

Restore the migration file byte-for-byte to the content the databases actually applied (`b5a0f384`). Both versions converge on the same schema — the rewrite only simplified the snapshots rebuild into an `ALTER TABLE` — so the deployed databases already match what the binary expects and only the checksum record diverged; restoring the bytes fixes startup with no host surgery, and fresh databases migrate identically (verified by the e2e suite).

No automated test beyond the existing e2e migration path: the failure requires a database that applied the pre-#407 file, which is host state; verified by matching the restored bytes against `b5a0f384` and running the e2e suite on fresh databases.
