### PR TITLE
name the failing market in ingestion fetch errors

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,6 +43,11 @@ Design: [adrs/0001](./adrs/0001-event-sorcery-persistence-foundation.md).
 - [x] Schedule candle and funding ingestion on independent cadences --
       [#411](https://github.com/dataclique/moneymentum/issues/411) /
       [#412](https://github.com/dataclique/moneymentum/pull/412)
+- [x] Name the failing market in ingestion fetch errors --
+      [#431](https://github.com/dataclique/moneymentum/issues/431) /
+      [#435](https://github.com/dataclique/moneymentum/pull/435)
+- [ ] A single market's failed fetch aborts the whole ingestion run and discards
+      its data -- [#432](https://github.com/dataclique/moneymentum/issues/432)
 
 ---
 

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -35,6 +35,10 @@ pub(crate) const MAX_HISTORY_ENTRIES: i64 = 5000;
 
 #[derive(Debug, Error)]
 pub(crate) enum HyperliquidError {
+    #[error("candle fetch for {} failed: {source}", market.as_str())]
+    CandleFetch { market: Market, source: Box<Self> },
+    #[error("funding rate fetch for {} failed: {source}", market.as_str())]
+    FundingFetch { market: Market, source: Box<Self> },
     #[error(transparent)]
     Candle(#[from] CandleError),
     #[error(transparent)]
@@ -376,7 +380,13 @@ impl<H: ?Sized + Hyperliquid> CandleIngester<H> {
                 let client = Arc::clone(&self.client);
                 async move {
                     debug!(market = market.as_str(), "fetching candles");
-                    let candles = client.fetch_candles(&market, timeframe, start).await?;
+                    let candles = client
+                        .fetch_candles(&market, timeframe, start)
+                        .await
+                        .map_err(|source| HyperliquidError::CandleFetch {
+                            market: market.clone(),
+                            source: Box::new(source),
+                        })?;
                     debug!(
                         market = market.as_str(),
                         count = candles.len(),
@@ -460,7 +470,14 @@ impl<H: ?Sized + Hyperliquid> FundingRateIngester<H> {
                 let client = Arc::clone(&self.client);
                 async move {
                     debug!(market = market.as_str(), "fetching funding rates");
-                    let rates = client.fetch_funding_rates(&market, start).await?;
+                    let rates =
+                        client
+                            .fetch_funding_rates(&market, start)
+                            .await
+                            .map_err(|source| HyperliquidError::FundingFetch {
+                                market: market.clone(),
+                                source: Box::new(source),
+                            })?;
                     debug!(
                         market = market.as_str(),
                         count = rates.len(),
@@ -520,6 +537,7 @@ mod tests {
         market_metadata: Vec<MarketMetadata>,
         candles: Vec<Candle>,
         funding_rates: Vec<FundingRate>,
+        failing_market: Option<Market>,
         fetch_candles_calls: AtomicUsize,
         fetch_funding_calls: AtomicUsize,
     }
@@ -552,6 +570,7 @@ mod tests {
                     rate: dec!(0.0001),
                     symbol: Symbol::from_raw("BTC"),
                 }],
+                failing_market: None,
                 fetch_candles_calls: AtomicUsize::new(0),
                 fetch_funding_calls: AtomicUsize::new(0),
             }
@@ -561,6 +580,15 @@ mod tests {
             self.candles = vec![];
             self.funding_rates = vec![];
             self
+        }
+
+        fn failing_for(mut self, market: &str) -> Self {
+            self.failing_market = Some(Market::new(market.to_string()));
+            self
+        }
+
+        fn upstream_error() -> HyperliquidError {
+            HyperliquidError::IntConversion(u32::try_from(u64::MAX).unwrap_err())
         }
     }
 
@@ -572,20 +600,26 @@ mod tests {
 
         async fn fetch_candles(
             &self,
-            _market: &Market,
+            market: &Market,
             _timeframe: Timeframe,
             _start: DateTime<Utc>,
         ) -> Result<Vec<Candle>, HyperliquidError> {
             self.fetch_candles_calls.fetch_add(1, Ordering::Relaxed);
+            if self.failing_market.as_ref() == Some(market) {
+                return Err(Self::upstream_error());
+            }
             Ok(self.candles.clone())
         }
 
         async fn fetch_funding_rates(
             &self,
-            _market: &Market,
+            market: &Market,
             _start: DateTime<Utc>,
         ) -> Result<Vec<FundingRate>, HyperliquidError> {
             self.fetch_funding_calls.fetch_add(1, Ordering::Relaxed);
+            if self.failing_market.as_ref() == Some(market) {
+                return Err(Self::upstream_error());
+            }
             Ok(self.funding_rates.clone())
         }
     }
@@ -713,6 +747,56 @@ mod tests {
             call_count.fetch_funding_calls.load(Ordering::Relaxed),
             2,
             "should fetch funding rates for each market"
+        );
+    }
+
+    #[tokio::test]
+    async fn candle_ingester_error_names_the_failing_market() {
+        let data_dir = TempDir::new().unwrap();
+        let markets = vec![
+            Market::new("BTC".to_string()),
+            Market::new("ETH".to_string()),
+        ];
+        let mock = Arc::new(MockHyperliquid::new().failing_for("ETH"));
+        let ingester = CandleIngester::new(mock, 10);
+
+        let error = ingester
+            .ingest_with_markets(Timeframe::OneHour, data_dir.path(), &markets)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("ETH"),
+            "the ingestion error should name the failing market: {error}"
+        );
+        assert!(
+            matches!(error, HyperliquidError::CandleFetch { ref market, .. } if market.as_str() == "ETH"),
+            "expected CandleFetch for ETH, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn funding_ingester_error_names_the_failing_market() {
+        let data_dir = TempDir::new().unwrap();
+        let markets = vec![
+            Market::new("BTC".to_string()),
+            Market::new("ETH".to_string()),
+        ];
+        let mock = Arc::new(MockHyperliquid::new().failing_for("ETH"));
+        let ingester = FundingRateIngester::new(mock, 10);
+
+        let error = ingester
+            .ingest_with_markets(data_dir.path(), &markets)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("ETH"),
+            "the ingestion error should name the failing market: {error}"
+        );
+        assert!(
+            matches!(error, HyperliquidError::FundingFetch { ref market, .. } if market.as_str() == "ETH"),
+            "expected FundingFetch for ETH, got: {error:?}"
         );
     }
 

--- a/src/ingestion/fixtures.rs
+++ b/src/ingestion/fixtures.rs
@@ -99,6 +99,56 @@ impl Hyperliquid for MockHyperliquid {
     }
 }
 
+/// Serves a two-market universe but fails every candle fetch for one of them,
+/// mirroring a prod run where a single market's fetch exhausts its retries.
+pub(crate) struct MarketFailingMockHyperliquid {
+    pub(crate) failing_market: &'static str,
+}
+
+#[async_trait]
+impl Hyperliquid for MarketFailingMockHyperliquid {
+    async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+        Ok(vec![
+            MarketMetadata {
+                symbol: Market::new("BTC".into()),
+                max_leverage: 50,
+                asset_index: 0,
+                only_isolated: false,
+            },
+            MarketMetadata {
+                symbol: Market::new(self.failing_market.into()),
+                max_leverage: 25,
+                asset_index: 1,
+                only_isolated: false,
+            },
+        ])
+    }
+
+    async fn fetch_candles(
+        &self,
+        market: &Market,
+        timeframe: Timeframe,
+        start: DateTime<Utc>,
+    ) -> Result<Vec<Candle>, HyperliquidError> {
+        if market.as_str() == self.failing_market {
+            return Err(HyperliquidError::Url(url::ParseError::EmptyHost));
+        }
+        MockHyperliquid::without_call_counter()
+            .fetch_candles(market, timeframe, start)
+            .await
+    }
+
+    async fn fetch_funding_rates(
+        &self,
+        market: &Market,
+        start: DateTime<Utc>,
+    ) -> Result<Vec<FundingRate>, HyperliquidError> {
+        MockHyperliquid::without_call_counter()
+            .fetch_funding_rates(market, start)
+            .await
+    }
+}
+
 #[async_trait]
 impl Hyperliquid for FailingMockHyperliquid {
     async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {

--- a/src/ingestion/job.rs
+++ b/src/ingestion/job.rs
@@ -228,8 +228,8 @@ mod tests {
 
     use super::IngestionJob;
     use crate::ingestion::fixtures::{
-        FailingMockHyperliquid, MockHyperliquid, ingestion_store, instant, job_context,
-        test_services, test_services_with_hyperliquid,
+        FailingMockHyperliquid, MarketFailingMockHyperliquid, MockHyperliquid, ingestion_store,
+        instant, job_context, test_services, test_services_with_hyperliquid,
     };
     use crate::ingestion::orchestration::{create_run, latest_status, recover_abandoned_runs};
     use crate::ingestion::run::{IngestionRunCommand, IngestionRunStatus, running_runs};
@@ -333,6 +333,35 @@ mod tests {
             Level::ERROR,
             &["ingestion failed", run_id.as_str()]
         ));
+    }
+
+    /// When one market of the universe fails its fetch, the run's failure must
+    /// name it: the market is the first thing an operator needs from the logs.
+    #[traced_test]
+    #[tokio::test]
+    async fn failed_run_names_the_failing_market() {
+        let (store, projection, pool) = ingestion_store().await;
+        let work = IngestionWork::candles(Timeframe::OneHour);
+        let run_id = create_run(&store, &projection, work).await.unwrap();
+        let services = test_services_with_hyperliquid(Arc::new(MarketFailingMockHyperliquid {
+            failing_market: "ETH",
+        }))
+        .await;
+        let context = job_context(&store, &projection, services);
+
+        IngestionJob::new(run_id, work)
+            .perform(&context)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            latest_status(&pool).await.unwrap(),
+            Some(IngestionRunStatus::Failed)
+        );
+        assert!(
+            logs_contain_at(Level::ERROR, &["ingestion failed", "candle fetch", "ETH"]),
+            "the failure log must name the failing market"
+        );
     }
 
     #[traced_test]


### PR DESCRIPTION
## Motivation

A failed ingestion run records and logs only the bare upstream error (e.g. `Server error: status code: 500`) with no hint which of the ~180 markets caused it, so prod failures cannot be diagnosed from the logs or the status API.

Closes #431

## Solution

- Wrap each per-market candle and funding fetch failure in an error variant carrying the market, so the run's failure reason and the `ingestion failed` log line name the culprit.
- Follow-up on the run-level semantics (one failed market discards the whole run's data) is tracked in #432.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #460
- <kbd>&nbsp;1&nbsp;</kbd> #435 👈 
<!-- GitButler Footer Boundary Bottom -->