### PR TITLE
make the running-slot migration apply to populated databases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -162,6 +162,8 @@ the next user-facing priority; it runs in parallel to the Dev track above.
       ([#423](https://github.com/dataclique/moneymentum/pull/423))
 - [x] [Restore the applied migration #407 rewrote so the binary starts](https://github.com/dataclique/moneymentum/issues/426)
       ([#427](https://github.com/dataclique/moneymentum/pull/427))
+- [x] [running-slot migration cannot apply to a populated database, crash-looping the deployed backend](https://github.com/dataclique/moneymentum/issues/443)
+      ([#444](https://github.com/dataclique/moneymentum/pull/444))
 - [x] [frontend markets requests 404: GET /hyperliquid/markets no longer exists](https://github.com/dataclique/moneymentum/issues/429)
       ([#433](https://github.com/dataclique/moneymentum/pull/433))
 - [x] [systemd moneymentum-ingest timer curls the removed POST /ingest every six hours](https://github.com/dataclique/moneymentum/issues/430)

--- a/migrations/20260618073806_per_work_ingestion_running_slot.sql
+++ b/migrations/20260618073806_per_work_ingestion_running_slot.sql
@@ -3,9 +3,14 @@
 
 DROP INDEX IF EXISTS one_running_ingestion_run;
 
+-- VIRTUAL, not STORED: SQLite rejects ALTER TABLE ADD COLUMN of a STORED
+-- generated column on a table that already has rows, so a STORED column here
+-- applies on fresh databases but fails on any database with recorded runs
+-- (which took prod down). The column only backs the partial unique index
+-- below, and indexes on virtual generated columns are enforced identically.
 ALTER TABLE ingestion_run_view ADD COLUMN schedule_key TEXT GENERATED ALWAYS AS (
     json_extract(payload, '$.Live.schedule_key')
-) STORED;
+) VIRTUAL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS one_running_ingestion_run_per_schedule_key
     ON ingestion_run_view(schedule_key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1855,9 +1855,14 @@ mod tests {
         status: &str,
         schedule_key: &str,
     ) -> Result<sqlx::sqlite::SqliteQueryResult, sqlx::Error> {
-        let payload = format!(
-            r#"{{"Live":{{"status":"{status}","started_at":"2026-07-01T00:00:00Z","schedule_key":"{schedule_key}"}}}}"#
-        );
+        let payload = serde_json::json!({
+            "Live": {
+                "status": status,
+                "started_at": "2026-07-01T00:00:00Z",
+                "schedule_key": schedule_key,
+            }
+        })
+        .to_string();
         sqlx::query("INSERT INTO ingestion_run_view (view_id, version, payload) VALUES (?1, 1, ?2)")
             .bind(view_id.to_string())
             .bind(payload)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1846,6 +1846,75 @@ mod tests {
         assert_eq!(snapshot_version, 0);
     }
 
+    /// Version of `migrations/20260618073806_per_work_ingestion_running_slot.sql`.
+    const RUNNING_SLOT_MIGRATION_VERSION: i64 = 20_260_618_073_806;
+
+    async fn insert_ingestion_run_row(
+        pool: &SqlitePool,
+        view_id: &str,
+        status: &str,
+        schedule_key: &str,
+    ) -> Result<sqlx::sqlite::SqliteQueryResult, sqlx::Error> {
+        let payload = format!(
+            r#"{{"Live":{{"status":"{status}","started_at":"2026-07-01T00:00:00Z","schedule_key":"{schedule_key}"}}}}"#
+        );
+        sqlx::query("INSERT INTO ingestion_run_view (view_id, version, payload) VALUES (?1, 1, ?2)")
+            .bind(view_id.to_string())
+            .bind(payload)
+            .execute(pool)
+            .await
+    }
+
+    /// Prod regression: SQLite refuses `ALTER TABLE ... ADD COLUMN ... STORED`
+    /// on a table that already has rows, so a migration adding a stored
+    /// generated column passes on every fresh database (CI, dev) and crashes
+    /// the binary on any database with recorded ingestion runs. Reproduces the
+    /// prod path: migrate to the pre-existing state, record a run, then apply
+    /// the remaining migrations.
+    #[tokio::test]
+    async fn running_slot_migration_applies_to_a_populated_database() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        let mut up_to_previous = sqlx::migrate!("./migrations");
+        up_to_previous.migrations = up_to_previous
+            .migrations
+            .iter()
+            .filter(|migration| migration.version < RUNNING_SLOT_MIGRATION_VERSION)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into();
+        up_to_previous.run(&pool).await.unwrap();
+
+        insert_ingestion_run_row(&pool, "ingestion-1", "Completed", "1h")
+            .await
+            .unwrap();
+
+        let migrated = sqlx::migrate!("./migrations").run(&pool).await;
+        assert!(
+            migrated.is_ok(),
+            "migrations must apply to a database with recorded runs: {migrated:?}"
+        );
+
+        // The rescoped index must still admit one Running row per schedule key.
+        insert_ingestion_run_row(&pool, "ingestion-2", "Running", "15m")
+            .await
+            .unwrap();
+        insert_ingestion_run_row(&pool, "ingestion-3", "Running", "1h")
+            .await
+            .unwrap();
+
+        let second_running_for_key =
+            insert_ingestion_run_row(&pool, "ingestion-4", "Running", "15m").await;
+        assert!(
+            second_running_for_key.is_err(),
+            "a second Running row for the same schedule key must violate the unique index"
+        );
+    }
+
     /// Serves a fixed universe, standing in for one Hyperliquid deployment.
     struct StubHyperliquid {
         universe: Vec<market_metadata::MarketMetadata>,


### PR DESCRIPTION
## Motivation

Prod deploys have failed since July 9 and the prod backend is crash-looping: migration `20260618073806` adds a STORED generated column via `ALTER TABLE`, which SQLite rejects on tables that already have rows (`cannot add a STORED column`). Every fresh test database applies it fine, so CI stayed green while prod's populated `ingestion_run_view` kills the binary ~30ms into startup, and each failed unit then wedges the next deploy's system activation.

Closes #443

## Solution

- Switch the generated column to VIRTUAL, which SQLite adds regardless of existing rows; the partial unique index on it enforces the same one-Running-per-schedule-key invariant.
- Regression test reproduces the prod path: migrate to the pre-existing state, record a run, apply the rest, and assert the rescoped index still holds.
- Local dev databases that applied the STORED variant will hit a checksum mismatch and need their sqlite file recreated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration compatibility so existing ingestion data can be kept without breaking the upgrade.
  * Ensured only one ingestion run can be in the “Running” state per schedule.
* **Tests**
  * Added regression coverage for running-slot migration behavior when the database already contains prior ingestion runs.
  * Added validation that duplicate “Running” ingestion attempts for the same schedule are rejected.
* **Documentation**
  * Updated the production deployment checklist with a note about the running-slot migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->