### PR TITLE
deploy every backend pr to staging and gate production behind it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,12 @@ jobs:
       - name: Clippy
         run: nix build -L --log-format raw .#moneymentum-clippy
 
+      # The exact derivation the deploy activates, release-profile tests
+      # included. Green CI therefore guarantees the deploy's build phase, and
+      # cachix turns the deploy build into a cache pull instead of a rebuild.
+      - name: Build the deploy artifact
+        run: nix build -L --log-format raw .#moneymentum
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -83,8 +83,12 @@ jobs:
           bun install --frozen-lockfile
           bun run build
 
-      - name: Deploy system and backend
-        run: nix run .#deployServer
+      # Staged rollout: system profile, then staging, then a health-and-markets
+      # gate against staging -- production only deploys after staging proves
+      # the new binary. A staging failure leaves production on its previous
+      # generation.
+      - name: Deploy staged (system, staging, gate, production)
+        run: nix run .#deployStaged
 
       - name: Deploy frontend
         run: nix run .#deployFrontend

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -136,6 +136,8 @@ jobs:
         env:
           FRONTEND_URL: ${{ vars.DEPLOY_FRONTEND_URL }}
           HEALTH_URL: ${{ vars.DEPLOY_HEALTH_URL }}
+          STAGING_HEALTH_URL: ${{ vars.DEPLOY_STAGING_HEALTH_URL }}
+          MARKETS_URL: ${{ vars.DEPLOY_MARKETS_URL }}
           SMOKE_HOST: ${{ vars.DEPLOY_SMOKE_HOST }}
           SMOKE_INSECURE: ${{ vars.DEPLOY_SMOKE_INSECURE }}
         run: |
@@ -148,6 +150,8 @@ jobs:
 
           frontend_url="${FRONTEND_URL:-http://$host_ip/}"
           health_url="${HEALTH_URL:-http://$host_ip/api/health}"
+          staging_health_url="${STAGING_HEALTH_URL:-http://$host_ip:8080/api/health}"
+          markets_url="${MARKETS_URL:-http://$host_ip/api/hyperliquid/markets?network=mainnet}"
 
           health_response_ok() {
             response_file="$1"
@@ -228,6 +232,13 @@ jobs:
 
           retry_url "$frontend_url" "" true
           retry_url "$health_url"
+          # Staging runs the same binary against its own database; a crash loop
+          # there wedges the next deploy's system activation, so catch it here.
+          retry_url "$staging_health_url"
+          # The Portfolio page's symbol universe and rebalancing both depend on
+          # this endpoint; a deploy that leaves it failing bricks the frontend
+          # even while /api/health stays green.
+          retry_url "$markets_url"
 
       - name: Cleanup SSH
         if: always()

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -1,0 +1,94 @@
+# Deploys the PR's backend to the staging instance and verifies it (health +
+# markets endpoint), so a reviewer knows the change survives a real deploy --
+# migrations against a real database included -- BEFORE hitting merge.
+#
+# Only the staging service profile is deployed: an unmerged PR must not reshape
+# shared host config. System-level changes are verified by the staged rollout
+# on master. Staging afterwards keeps running the PR's binary until the next
+# deploy touches it; it is a proving ground, not an environment with uptime
+# guarantees.
+
+name: Staging
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "crates/**"
+      - "migrations/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "config/**"
+      - "*.nix"
+      - "flake.lock"
+      - ".github/workflows/staging.yaml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+# Serialize against master deploys and other PRs -- staging is one shared
+# instance and deployServer/deployStaged touch it too.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy-and-verify-staging:
+    # Fork PRs have no SSH_KEY secret; only same-repo branches deploy.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+        with:
+          nix_version: "2.31.2"
+          nix_conf: |
+            accept-flake-config = true
+            fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+        with:
+          name: data-cartel-public
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ runner.os }}-deploy-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-deploy-
+          gc-max-store-size-linux: 5G
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Resolve host IP
+        run: |
+          host_ip=$(nix run .#resolveIp)
+          echo "::add-mask::$host_ip"
+
+          # The host key is pinned in keys.nix, not fetched from the target host.
+          host_key=$(nix eval --raw --file keys.nix keys.host)
+          if [ -z "$host_key" ]; then
+            echo "Host key is empty" >&2
+            exit 1
+          fi
+
+          echo "$host_ip $host_key" > ~/.ssh/known_hosts
+
+      - name: Deploy this revision to staging and verify
+        run: nix run .#deployStagingVerify
+
+      - name: Cleanup SSH
+        if: always()
+        run: rm -rf ~/.ssh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,6 +166,8 @@ the next user-facing priority; it runs in parallel to the Dev track above.
       ([#444](https://github.com/dataclique/moneymentum/pull/444))
 - [x] [a race-loser ingestion run poisons the newest view row and breaks the status endpoint](https://github.com/dataclique/moneymentum/issues/445)
       ([#446](https://github.com/dataclique/moneymentum/pull/446))
+- [x] [green PRs produce failing deploys: CI never builds the deploy artifact and the smoke test misses staging and the markets endpoint](https://github.com/dataclique/moneymentum/issues/447)
+      ([#448](https://github.com/dataclique/moneymentum/pull/448))
 - [x] [frontend markets requests 404: GET /hyperliquid/markets no longer exists](https://github.com/dataclique/moneymentum/issues/429)
       ([#433](https://github.com/dataclique/moneymentum/pull/433))
 - [x] [systemd moneymentum-ingest timer curls the removed POST /ingest every six hours](https://github.com/dataclique/moneymentum/issues/430)

--- a/deploy.nix
+++ b/deploy.nix
@@ -101,6 +101,38 @@ in
         map (name: "systemctl reset-failed ${name} || true") enabledServices
       );
 
+      # Remote preflight plus the local logind poll, shared by deployServer and
+      # deployStaged. Runs on the remote host via heredoc so nested quotes do
+      # not break shellcheck or the generated scripts (SC2026).
+      preflightScript = ''
+        ssh -i "$identity" "root@$host_ip" bash -s <<'REMOTE_PREFLIGHT'
+        set -eu
+        systemctl stop 'nixos-rebuild-switch-to-configuration*' 2>/dev/null || true
+        pkill -9 -f '[s]witch-to-configuration' || true
+        rm -f /run/nixos/switch-to-configuration.lock
+        systemctl stop moneymentum-markets-refresh.timer staging-markets-refresh.timer 2>/dev/null || true
+        systemctl disable moneymentum-markets-refresh.timer staging-markets-refresh.timer 2>/dev/null || true
+        ${serviceResetLines}
+        systemd-run --on-active=3s --collect --unit=moneymentum-deploy-dbus-heal \
+          /bin/sh -c 'systemctl reset-failed dbus-broker systemd-logind || true; systemctl restart dbus-broker; systemctl restart systemd-logind' \
+          || true
+        REMOTE_PREFLIGHT
+
+        # dbus heal is scheduled for +3s after preflight SSH closes; poll logind
+        # before deploy-rs activation so wedged logind fails fast instead of timing
+        # out for the full activation window (nixpkgs#527469).
+        for ((attempt = 1; attempt <= 15; attempt++)); do
+          if ssh -i "$identity" "root@$host_ip" loginctl list-users >/dev/null 2>&1; then
+            break
+          fi
+          if [ "$attempt" -eq 15 ]; then
+            echo "ERROR: logind still unhealthy after deploy preflight" >&2
+            exit 1
+          fi
+          sleep 2
+        done
+      '';
+
     in
     {
       deployNixos = pkgs.writeShellApplication {
@@ -128,37 +160,53 @@ in
         runtimeInputs = deployInputs ++ [ pkgs.openssh ];
         text = ''
           ${deployPreamble}
+          ${preflightScript}
+          deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} "$@" .#moneymentum
+        '';
+      };
 
-          # Preflight runs on the remote host via heredoc so nested quotes do not
-          # break shellcheck or the generated deploy-server script (SC2026).
-          ssh -i "$identity" "root@$host_ip" bash -s <<'REMOTE_PREFLIGHT'
-          set -eu
-          systemctl stop 'nixos-rebuild-switch-to-configuration*' 2>/dev/null || true
-          pkill -9 -f '[s]witch-to-configuration' || true
-          rm -f /run/nixos/switch-to-configuration.lock
-          systemctl stop moneymentum-markets-refresh.timer staging-markets-refresh.timer 2>/dev/null || true
-          systemctl disable moneymentum-markets-refresh.timer staging-markets-refresh.timer 2>/dev/null || true
-          ${serviceResetLines}
-          systemd-run --on-active=3s --collect --unit=moneymentum-deploy-dbus-heal \
-            /bin/sh -c 'systemctl reset-failed dbus-broker systemd-logind || true; systemctl restart dbus-broker; systemctl restart systemd-logind' \
-            || true
-          REMOTE_PREFLIGHT
+      # Staged rollout: the new binary must prove itself on staging before
+      # production is touched. System profile first (shared host config), then
+      # staging, then a health-and-markets gate against staging, and only then
+      # the production service. A staging failure aborts with production still
+      # on its previous generation.
+      #
+      # Residual risk: the system profile is shared, so unit or host config
+      # changes still reach production units before the gate (#422).
+      deployStaged = pkgs.writeShellApplication {
+        name = "deploy-staged";
+        runtimeInputs = deployInputs ++ [
+          pkgs.openssh
+          pkgs.curl
+        ];
+        text = ''
+          ${deployPreamble}
+          ${preflightScript}
 
-          # dbus heal is scheduled for +3s after preflight SSH closes; poll logind
-          # before deploy-rs activation so wedged logind fails fast instead of timing
-          # out for the full activation window (nixpkgs#527469).
-          for ((attempt = 1; attempt <= 15; attempt++)); do
-            if ssh -i "$identity" "root@$host_ip" loginctl list-users >/dev/null 2>&1; then
+          echo "==> Deploying the system profile"
+          deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} .#moneymentum.system
+
+          echo "==> Deploying staging"
+          deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} .#moneymentum.staging
+
+          echo "==> Verifying staging before touching production"
+          staging_ok=""
+          for delay in 2 4 8 16 32 32; do
+            if curl -sSf --max-time 20 "http://$host_ip:8080/api/health" >/dev/null &&
+              curl -sSf --max-time 30 "http://$host_ip:8080/api/hyperliquid/markets?network=mainnet" >/dev/null; then
+              staging_ok=1
               break
             fi
-            if [ "$attempt" -eq 15 ]; then
-              echo "ERROR: logind still unhealthy after deploy preflight" >&2
-              exit 1
-            fi
-            sleep 2
+            echo "staging not healthy yet; retrying in ''${delay}s"
+            sleep "$delay"
           done
+          if [ -z "$staging_ok" ]; then
+            echo "ERROR: staging failed verification -- production deploy aborted" >&2
+            exit 1
+          fi
 
-          deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} "$@" .#moneymentum
+          echo "==> Staging verified; deploying production"
+          deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} .#moneymentum.moneymentum
         '';
       };
 

--- a/deploy.nix
+++ b/deploy.nix
@@ -133,6 +133,27 @@ in
         done
       '';
 
+      # Health-and-markets verification against the freshly deployed staging
+      # instance: migrations applied to a real database, the binary serving, and
+      # the live Hyperliquid fetch working from the host's IP.
+      stagingGateScript = ''
+        echo "==> Verifying staging"
+        staging_ok=""
+        for delay in 2 4 8 16 32 32; do
+          if curl -sSf --max-time 20 "http://$host_ip:8080/api/health" >/dev/null &&
+            curl -sSf --max-time 30 "http://$host_ip:8080/api/hyperliquid/markets?network=mainnet" >/dev/null; then
+            staging_ok=1
+            break
+          fi
+          echo "staging not healthy yet; retrying in ''${delay}s"
+          sleep "$delay"
+        done
+        if [ -z "$staging_ok" ]; then
+          echo "ERROR: staging failed verification" >&2
+          exit 1
+        fi
+      '';
+
     in
     {
       deployNixos = pkgs.writeShellApplication {
@@ -189,24 +210,35 @@ in
           echo "==> Deploying staging"
           deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} .#moneymentum.staging
 
-          echo "==> Verifying staging before touching production"
-          staging_ok=""
-          for delay in 2 4 8 16 32 32; do
-            if curl -sSf --max-time 20 "http://$host_ip:8080/api/health" >/dev/null &&
-              curl -sSf --max-time 30 "http://$host_ip:8080/api/hyperliquid/markets?network=mainnet" >/dev/null; then
-              staging_ok=1
-              break
-            fi
-            echo "staging not healthy yet; retrying in ''${delay}s"
-            sleep "$delay"
-          done
-          if [ -z "$staging_ok" ]; then
-            echo "ERROR: staging failed verification -- production deploy aborted" >&2
-            exit 1
-          fi
+          ${stagingGateScript}
 
           echo "==> Staging verified; deploying production"
           deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} .#moneymentum.moneymentum
+        '';
+      };
+
+      # Pull-request gate: deploy the PR's binary to staging and verify it, so
+      # a reviewer knows the change survives a real deploy BEFORE merging. Only
+      # the staging service profile is deployed -- an unmerged PR must not
+      # reshape shared host config, so the system profile stays whatever master
+      # last activated and system-level changes are verified by deployStaged at
+      # merge time.
+      deployStagingVerify = pkgs.writeShellApplication {
+        name = "deploy-staging-verify";
+        runtimeInputs = deployInputs ++ [
+          pkgs.openssh
+          pkgs.curl
+        ];
+        text = ''
+          ${deployPreamble}
+          ${preflightScript}
+
+          echo "==> Deploying this revision to staging"
+          deploy ${deployFlags} --hostname "$host_ip" ''${ssh_flag:+"$ssh_flag"} .#moneymentum.staging
+
+          ${stagingGateScript}
+
+          echo "==> Staging verified"
         '';
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -302,6 +302,7 @@
             deployNixos
             deployService
             deployServer
+            deployStaged
             deployFrontend
             ;
 

--- a/flake.nix
+++ b/flake.nix
@@ -303,6 +303,7 @@
             deployService
             deployServer
             deployStaged
+            deployStagingVerify
             deployFrontend
             ;
 


### PR DESCRIPTION
## Motivation

Three deploys failed or half-failed this week after fully green PR checks, and staging protected nothing: it received the new binary in the same activation pass as production, and nothing verified deployability before merge. Whether a change survives a real deploy must be a PR check, not a post-merge discovery.

Closes #447

## Solution

- Every backend-touching PR deploys its binary to the staging service and must pass a health-and-markets verification gate (new `Staging` workflow + `deployStagingVerify`) -- a migration that cannot apply to a real database or a binary that cannot serve fails the PR before merge. Runs serialize with master deploys via the shared concurrency group; fork PRs are excluded (no secrets).
- The master deploy becomes a staged rollout (`deployStaged`): system profile, staging, the same gate, and only then production -- a staging failure aborts with production untouched.
- CI builds `.#moneymentum`, the exact derivation deploys activate, release-profile tests included, so a green PR proves the deploy's build phase and cachix turns the deploy build into a cache pull.
- The post-deploy smoke test additionally verifies staging health and `GET /hyperliquid/markets` on prod.
- Residual risks, tracked in #422: the system profile is shared host config and reaches production units before the gate; a PR whose migrations change after deploying to staging can leave staging's database with a stale checksum (staging's DB is resettable by design).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated staging deployments and verification for pull requests.
  * Production releases now use a staged rollout, promoting changes only after staging health and markets checks pass.
  * Expanded deployment smoke tests to cover frontend, API health, staging health, and markets endpoints.

* **Bug Fixes**
  * Improved deployment reliability by ensuring required release artifacts are built and cached before deployment.

* **Documentation**
  * Updated the production deployment roadmap to reflect improved staging and smoke-test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->