### PR TITLE
make CLI tool to call ingest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ uuid = { version = "1.23.3", features = ["v4", "serde"] }
 [lints]
 workspace = true
 
+[[bin]]
+name = "moneymentum-ingest"
+path = "src/bin/moneymentum_ingest.rs"
+
 [features]
 # Forwards event-sorcery's test-support (TestHarness, FailureInjector, and the
 # 4-argument `work` job handler). The ingestion worker registers a

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Moneymentum makes those exposures legible and adjustable.
 - **Backend** (active development): Rust + Axum API, Polars analytics,
   SQLite-backed ingestion runs and job queue. Ingests Hyperliquid
   open-high-low-close-volume (OHLCV) and funding rates on a built-in schedule
-  (and on demand via `POST /ingest`); computes rolling beta to BTC and serves
-  per-asset factor scores via `GET /factors/<timeframe>`.
+  (and on demand via
+  `cargo run --bin moneymentum-ingest -- --config
+  config.toml`); computes
+  rolling beta to BTC and serves per-asset factor scores via
+  `GET /factors/<timeframe>`.
 - **Vault program** (planned): Anchor program on Solana for non-custodial
   managed deposits with two-phase withdrawal.
 
@@ -71,7 +74,9 @@ cargo test -q       # tests
 cargo clippy        # lints (pedantic + nursery, panic-free)
 cargo fmt           # format
 
-cargo run -- --help # see CLI options
+cargo run -- --config config.toml
+# on-demand candle + funding pull (no HTTP server):
+cargo run --bin moneymentum-ingest -- --config config.toml
 ```
 
 Configuration is loaded from a TOML file modeled on

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Moneymentum makes those exposures legible and adjustable.
 - **Frontend prototype** at `/prototype`: design reference for the target UI.
 - **Backend** (active development): Rust + Axum API, Polars analytics,
   SQLite-backed ingestion runs and job queue. Ingests Hyperliquid
-  open-high-low-close-volume (OHLCV) and funding rates; computes rolling beta to
-  BTC and serves per-asset factor scores via `GET /factors/<timeframe>`.
+  open-high-low-close-volume (OHLCV) and funding rates on a built-in schedule
+  (and on demand via `POST /ingest`); computes rolling beta to BTC and serves
+  per-asset factor scores via `GET /factors/<timeframe>`.
 - **Vault program** (planned): Anchor program on Solana for non-custodial
   managed deposits with two-phase withdrawal.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -170,9 +170,9 @@ the next user-facing priority; it runs in parallel to the Dev track above.
       ([#433](https://github.com/dataclique/moneymentum/pull/433))
 - [x] [systemd moneymentum-ingest timer curls the removed POST /ingest every six hours](https://github.com/dataclique/moneymentum/issues/430)
       ([#434](https://github.com/dataclique/moneymentum/pull/434))
-- [ ] cannot trigger a full on-demand ingestion after POST /ingest was removed
-      -- [#449](https://github.com/dataclique/moneymentum/issues/449) /
-      [#451](https://github.com/dataclique/moneymentum/pull/451)
+- [x] cannot trigger a full on-demand ingestion after POST /ingest was removed
+      -- local `moneymentum-ingest` CLI instead of restoring the HTTP endpoint
+      ([#449](https://github.com/dataclique/moneymentum/issues/449))
 - [ ] candle parquet backups stay a manual Telegram upload with no integrity
       check against prior dumps --
       [#450](https://github.com/dataclique/moneymentum/issues/450)
@@ -321,7 +321,7 @@ to DigitalOcean via NixOS + deploy-rs.
 - [x] Rolling beta calculation (`POST /beta`)
 - [x] Candle API (`GET /candles/<timeframe>`)
 - [x] Ingestion status API (`GET /ingestion/status`)
-- [x] Manual ingestion trigger (`POST /ingest`)
+- [x] On-demand ingestion CLI (`moneymentum-ingest`)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,7 +171,8 @@ the next user-facing priority; it runs in parallel to the Dev track above.
 - [x] [systemd moneymentum-ingest timer curls the removed POST /ingest every six hours](https://github.com/dataclique/moneymentum/issues/430)
       ([#434](https://github.com/dataclique/moneymentum/pull/434))
 - [ ] cannot trigger a full on-demand ingestion after POST /ingest was removed
-      -- [#449](https://github.com/dataclique/moneymentum/issues/449)
+      -- [#449](https://github.com/dataclique/moneymentum/issues/449) /
+      [#451](https://github.com/dataclique/moneymentum/pull/451)
 - [ ] candle parquet backups stay a manual Telegram upload with no integrity
       check against prior dumps --
       [#450](https://github.com/dataclique/moneymentum/issues/450)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -170,6 +170,11 @@ the next user-facing priority; it runs in parallel to the Dev track above.
       ([#433](https://github.com/dataclique/moneymentum/pull/433))
 - [x] [systemd moneymentum-ingest timer curls the removed POST /ingest every six hours](https://github.com/dataclique/moneymentum/issues/430)
       ([#434](https://github.com/dataclique/moneymentum/pull/434))
+- [ ] cannot trigger a full on-demand ingestion after POST /ingest was removed
+      -- [#449](https://github.com/dataclique/moneymentum/issues/449)
+- [ ] candle parquet backups stay a manual Telegram upload with no integrity
+      check against prior dumps --
+      [#450](https://github.com/dataclique/moneymentum/issues/450)
 - [ ] [Remove the markets_refresh_token deploy bridge from service configs](https://github.com/dataclique/moneymentum/issues/425)
 - [ ] [Deploy the service binary, unit, and config atomically](https://github.com/dataclique/moneymentum/issues/422)
 - [x] [Address #377 review follow-ups](https://github.com/dataclique/moneymentum/issues/392)
@@ -312,6 +317,7 @@ to DigitalOcean via NixOS + deploy-rs.
 - [x] Rolling beta calculation (`POST /beta`)
 - [x] Candle API (`GET /candles/<timeframe>`)
 - [x] Ingestion status API (`GET /ingestion/status`)
+- [x] Manual ingestion trigger (`POST /ingest`)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -176,6 +176,9 @@ the next user-facing priority; it runs in parallel to the Dev track above.
 - [ ] candle parquet backups stay a manual Telegram upload with no integrity
       check against prior dumps --
       [#450](https://github.com/dataclique/moneymentum/issues/450)
+- [ ] scheduled candle ingestion re-fetches the full Hyperliquid history window
+      on every tick --
+      [#452](https://github.com/dataclique/moneymentum/issues/452)
 - [ ] [Remove the markets_refresh_token deploy bridge from service configs](https://github.com/dataclique/moneymentum/issues/425)
 - [ ] [Deploy the service binary, unit, and config atomically](https://github.com/dataclique/moneymentum/issues/422)
 - [x] [Address #377 review follow-ups](https://github.com/dataclique/moneymentum/issues/392)

--- a/src/bin/moneymentum_ingest.rs
+++ b/src/bin/moneymentum_ingest.rs
@@ -1,0 +1,16 @@
+use clap::Parser;
+use moneymentum::{Config, run_local_ingest};
+
+#[derive(Parser)]
+struct Env {
+    #[arg(long = "config", env)]
+    config_path: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let env = Env::parse();
+    let config = Config::load(&env.config_path)?;
+    run_local_ingest(config).await?;
+    Ok(())
+}

--- a/src/hyperliquid.rs
+++ b/src/hyperliquid.rs
@@ -363,8 +363,10 @@ impl<H: ?Sized + Hyperliquid> CandleIngester<H> {
         // To always fetch the maximum available history per symbol, we ignore
         // existing data for the start time and request a 5000-candle window
         // ending at "now". Any overlap with existing data is handled by
-        // merge_and_deduplicate.
-        let start_for_all_markets = Utc::now() - timeframe.window_duration(MAX_HISTORY_ENTRIES);
+        // merge_and_deduplicate. Weekly windows of 5000 bars predate the Unix
+        // epoch, and the candle API takes startTime as u64 ms, so clamp there.
+        let start_for_all_markets = (Utc::now() - timeframe.window_duration(MAX_HISTORY_ENTRIES))
+            .max(DateTime::<Utc>::UNIX_EPOCH);
 
         let market_starts: Vec<(Market, DateTime<Utc>)> = markets
             .iter()
@@ -588,6 +590,60 @@ mod tests {
             self.fetch_funding_calls.fetch_add(1, Ordering::Relaxed);
             Ok(self.funding_rates.clone())
         }
+    }
+
+    struct StartCapturingHyperliquid {
+        captured_start_millis: std::sync::Mutex<Option<i64>>,
+    }
+
+    #[async_trait]
+    impl Hyperliquid for StartCapturingHyperliquid {
+        async fn fetch_market_metadata(&self) -> Result<Vec<MarketMetadata>, HyperliquidError> {
+            Ok(vec![])
+        }
+
+        async fn fetch_candles(
+            &self,
+            _market: &Market,
+            _timeframe: Timeframe,
+            start: DateTime<Utc>,
+        ) -> Result<Vec<Candle>, HyperliquidError> {
+            *self.captured_start_millis.lock().unwrap() = Some(start.timestamp_millis());
+            Ok(vec![])
+        }
+
+        async fn fetch_funding_rates(
+            &self,
+            _market: &Market,
+            _start: DateTime<Utc>,
+        ) -> Result<Vec<FundingRate>, HyperliquidError> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn weekly_candle_ingest_clamps_pre_epoch_window_to_unix_epoch() {
+        let data_dir = TempDir::new().unwrap();
+        let mock = Arc::new(StartCapturingHyperliquid {
+            captured_start_millis: std::sync::Mutex::new(None),
+        });
+        let ingester = CandleIngester::new(Arc::clone(&mock), 1);
+
+        ingester
+            .ingest_with_markets(Timeframe::OneWeek, data_dir.path(), &btc_markets())
+            .await
+            .unwrap();
+
+        let start_millis = mock
+            .captured_start_millis
+            .lock()
+            .unwrap()
+            .expect("weekly ingest must call fetch_candles");
+        assert!(
+            start_millis >= 0,
+            "weekly window must be clamped to unix epoch so start_ms fits u64, got {start_millis}"
+        );
+        assert_eq!(start_millis, DateTime::<Utc>::UNIX_EPOCH.timestamp_millis());
     }
 
     #[traced_test]

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -6,7 +6,8 @@
 //! schedule-key invariant is enforced by the per-work projection check plus a
 //! partial unique index; an unconditional startup reconciler abandons every
 //! still-running stream before schedulers start, so a crash can never wedge a slot.
-//! Operators can also trigger the same work units on demand via `POST /ingest`.
+//! Operators trigger the same work units on demand with the `moneymentum-ingest`
+//! CLI (`cargo run --bin moneymentum-ingest -- --config config.toml`).
 //!
 //! Organized by concern:
 //! - [`run_id`]: opaque run identity and wire parsing.
@@ -30,6 +31,7 @@ pub(crate) use orchestration::{
     create_runs_for_active_units, default_ingestion_schedules, latest_status,
     recover_abandoned_runs, trigger_scheduled_ingestion,
 };
-pub(crate) use run::{IngestionRun, IngestionRunStatus};
+pub(crate) use run::{IngestionRun, IngestionRunStatus, running_runs};
+pub(crate) use run_id::IngestionRunId;
 pub(crate) use services::IngestionServices;
 pub(crate) use work::IngestionWork;

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -6,6 +6,7 @@
 //! schedule-key invariant is enforced by the per-work projection check plus a
 //! partial unique index; an unconditional startup reconciler abandons every
 //! still-running stream before schedulers start, so a crash can never wedge a slot.
+//! Operators can also trigger the same work units on demand via `POST /ingest`.
 //!
 //! Organized by concern:
 //! - [`run_id`]: opaque run identity and wire parsing.
@@ -26,7 +27,8 @@ pub(crate) mod fixtures;
 
 pub(crate) use job::{IngestionJob, IngestionJobContext};
 pub(crate) use orchestration::{
-    default_ingestion_schedules, latest_status, recover_abandoned_runs, trigger_scheduled_ingestion,
+    create_runs_for_active_units, default_ingestion_schedules, latest_status,
+    recover_abandoned_runs, trigger_scheduled_ingestion,
 };
 pub(crate) use run::{IngestionRun, IngestionRunStatus};
 pub(crate) use services::IngestionServices;

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -83,26 +83,58 @@ pub(crate) fn default_ingestion_schedules()
         .collect()
 }
 
+/// Outcome of opening runs across every active work unit in one pass.
+///
+/// `AlreadyRunning` never populates [`Self::error`]. Callers distinguish:
+/// - clean pass: `error` is `None` (possibly with an empty `enqueued` when every
+///   unit was already busy)
+/// - mixed success: `enqueued` is non-empty and `error` is `Some`
+/// - wholly failed: `enqueued` is empty and `error` is `Some`
+#[derive(Debug)]
+pub(crate) struct ActiveUnitsEnqueue {
+    pub enqueued: Vec<IngestionRunId>,
+    pub error: Option<IngestionError>,
+}
+
 /// Opens a run for every active work unit that is idle.
 ///
-/// Returns the run ids that were enqueued. `AlreadyRunning` for an individual
-/// unit is skipped so a partial busy set still starts the idle ones; only a
-/// genuine send/projection failure aborts the pass.
+/// Continues through the full active set after genuine send/projection failures
+/// so earlier successes are not discarded. `AlreadyRunning` for an individual
+/// unit is skipped. The first genuine failure is retained in
+/// [`ActiveUnitsEnqueue::error`] alongside any run ids that were enqueued.
 pub(crate) async fn create_runs_for_active_units(
     store: &Store<IngestionRun>,
     projection: &Projection<IngestionRun>,
-) -> Result<Vec<IngestionRunId>, IngestionError> {
+) -> ActiveUnitsEnqueue {
+    enqueue_active_units(|work| create_run(store, projection, work)).await
+}
+
+async fn enqueue_active_units<Create, CreateFuture>(mut create: Create) -> ActiveUnitsEnqueue
+where
+    Create: FnMut(IngestionWork) -> CreateFuture,
+    CreateFuture: std::future::Future<Output = Result<IngestionRunId, IngestionError>>,
+{
     let mut enqueued = Vec::new();
+    let mut error = None;
 
     for work in active_ingestion_units() {
-        match create_run(store, projection, work).await {
+        match create(work).await {
             Ok(run_id) => enqueued.push(run_id),
             Err(IngestionError::AlreadyRunning) => {}
-            Err(err) => return Err(err),
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    work = work.schedule_key(),
+                    "failed to enqueue ingestion run for active unit"
+                );
+                if error.is_none() {
+                    error = Some(err);
+                }
+            }
         }
     }
 
-    Ok(enqueued)
+    ActiveUnitsEnqueue { enqueued, error }
 }
 
 /// Opens a new ingestion run and enqueues its job atomically with the
@@ -324,7 +356,7 @@ mod tests {
 
     use super::{
         IngestionError, active_ingestion_units, create_run, create_runs_for_active_units,
-        latest_status, recover_abandoned_runs, trigger_scheduled_ingestion,
+        enqueue_active_units, latest_status, recover_abandoned_runs, trigger_scheduled_ingestion,
     };
     use crate::ingestion::fixtures::{ingestion_store, instant};
     use crate::ingestion::run::{
@@ -614,11 +646,10 @@ mod tests {
     async fn create_runs_for_active_units_enqueues_every_idle_unit() {
         let (store, projection, _pool) = ingestion_store().await;
 
-        let enqueued = create_runs_for_active_units(&store, &projection)
-            .await
-            .unwrap();
+        let outcome = create_runs_for_active_units(&store, &projection).await;
 
-        assert_eq!(enqueued.len(), active_ingestion_units().len());
+        assert!(outcome.error.is_none());
+        assert_eq!(outcome.enqueued.len(), active_ingestion_units().len());
         assert_eq!(
             running_runs(&projection).await.unwrap().len(),
             active_ingestion_units().len()
@@ -635,11 +666,10 @@ mod tests {
 
         create_run(&store, &projection, first).await.unwrap();
 
-        let enqueued = create_runs_for_active_units(&store, &projection)
-            .await
-            .unwrap();
+        let outcome = create_runs_for_active_units(&store, &projection).await;
 
-        assert_eq!(enqueued.len(), units.len() - 1);
+        assert!(outcome.error.is_none());
+        assert_eq!(outcome.enqueued.len(), units.len() - 1);
         assert_eq!(running_runs(&projection).await.unwrap().len(), units.len());
         assert!(logs_contain_at(Level::DEBUG, &["ingestion run created"]));
     }
@@ -647,15 +677,59 @@ mod tests {
     #[tokio::test]
     async fn create_runs_for_active_units_reports_zero_when_every_unit_is_busy() {
         let (store, projection, _pool) = ingestion_store().await;
-        create_runs_for_active_units(&store, &projection)
-            .await
-            .unwrap();
+        let first_pass = create_runs_for_active_units(&store, &projection).await;
+        assert!(first_pass.error.is_none());
+        assert!(!first_pass.enqueued.is_empty());
 
-        let enqueued = create_runs_for_active_units(&store, &projection)
-            .await
-            .unwrap();
+        let outcome = create_runs_for_active_units(&store, &projection).await;
 
-        assert!(enqueued.is_empty());
+        assert!(outcome.error.is_none());
+        assert!(outcome.enqueued.is_empty());
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn create_runs_for_active_units_keeps_successes_when_a_later_unit_fails() {
+        let units = active_ingestion_units();
+        assert!(
+            units.len() >= 2,
+            "need at least two active units to cover mixed success"
+        );
+
+        let (store, projection, pool) = ingestion_store().await;
+        let call_index = Arc::new(AtomicU32::new(0));
+
+        let outcome = enqueue_active_units(|work| {
+            let store = Arc::clone(&store);
+            let projection = Arc::clone(&projection);
+            let pool = pool.clone();
+            let call_index = Arc::clone(&call_index);
+            async move {
+                let index = call_index.fetch_add(1, Ordering::Relaxed);
+                if index == 0 {
+                    let run_id = create_run(&store, &projection, work).await?;
+                    pool.close().await;
+                    Ok(run_id)
+                } else {
+                    create_run(&store, &projection, work).await
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(
+            outcome.enqueued.len(),
+            1,
+            "the successful enqueue before the failure must be retained"
+        );
+        assert!(
+            outcome.error.is_some(),
+            "a later genuine failure must be reported alongside retained run ids"
+        );
+        assert!(logs_contain_at(
+            Level::WARN,
+            &["failed to enqueue ingestion run for active unit"]
+        ));
     }
 
     #[traced_test]

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -53,23 +53,56 @@ fn validate_production_schedule_definitions() -> Result<(), IngestionScheduleErr
     Ok(())
 }
 
+/// Work units that schedulers and `POST /ingest` enqueue in this build.
+///
+/// Production runs every candle timeframe plus funding. The `test-support`
+/// feature narrows that set so e2e tests avoid the OneWeek lookback overflow
+/// (issue #64) while still exercising the same enqueue path.
+pub(crate) fn active_ingestion_units() -> Vec<IngestionWork> {
+    #[cfg(feature = "test-support")]
+    {
+        IngestionWork::test_e2e_scheduled_units().into()
+    }
+    #[cfg(not(feature = "test-support"))]
+    {
+        IngestionWork::scheduled_units()
+    }
+}
+
 /// Built-in apalis-cron schedules for each candle timeframe and funding refresh.
 pub(crate) fn default_ingestion_schedules()
 -> Result<Vec<(IngestionWork, Schedule)>, IngestionScheduleError> {
     validate_production_schedule_definitions()?;
 
-    #[cfg(feature = "test-support")]
-    let units: Vec<IngestionWork> = IngestionWork::test_e2e_scheduled_units().into();
-    #[cfg(not(feature = "test-support"))]
-    let units = IngestionWork::scheduled_units();
-
-    units
+    active_ingestion_units()
         .into_iter()
         .map(|work| {
             let expression = work.default_cron_expression();
             Ok((work, Schedule::from_str(expression)?))
         })
         .collect()
+}
+
+/// Opens a run for every active work unit that is idle.
+///
+/// Returns how many runs were enqueued. `AlreadyRunning` for an individual unit
+/// is skipped so a partial busy set still starts the idle ones; only a genuine
+/// send/projection failure aborts the pass.
+pub(crate) async fn create_runs_for_active_units(
+    store: &Store<IngestionRun>,
+    projection: &Projection<IngestionRun>,
+) -> Result<usize, IngestionError> {
+    let mut enqueued = 0usize;
+
+    for work in active_ingestion_units() {
+        match create_run(store, projection, work).await {
+            Ok(_) => enqueued += 1,
+            Err(IngestionError::AlreadyRunning) => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok(enqueued)
 }
 
 /// Opens a new ingestion run and enqueues its job atomically with the
@@ -290,8 +323,8 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        IngestionError, create_run, latest_status, recover_abandoned_runs,
-        trigger_scheduled_ingestion,
+        IngestionError, active_ingestion_units, create_run, create_runs_for_active_units,
+        latest_status, recover_abandoned_runs, trigger_scheduled_ingestion,
     };
     use crate::ingestion::fixtures::{ingestion_store, instant};
     use crate::ingestion::run::{
@@ -574,6 +607,55 @@ mod tests {
 
         assert!(hourly.is_ok() && funding.is_ok());
         assert_eq!(running_runs(&projection).await.unwrap().len(), 2);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn create_runs_for_active_units_enqueues_every_idle_unit() {
+        let (store, projection, _pool) = ingestion_store().await;
+
+        let enqueued = create_runs_for_active_units(&store, &projection)
+            .await
+            .unwrap();
+
+        assert_eq!(enqueued, active_ingestion_units().len());
+        assert_eq!(
+            running_runs(&projection).await.unwrap().len(),
+            active_ingestion_units().len()
+        );
+        assert!(logs_contain_at(Level::DEBUG, &["ingestion run created"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn create_runs_for_active_units_skips_busy_units_and_starts_idle_ones() {
+        let (store, projection, _pool) = ingestion_store().await;
+        let units = active_ingestion_units();
+        let first = *units.first().expect("at least one active ingestion unit");
+
+        create_run(&store, &projection, first).await.unwrap();
+
+        let enqueued = create_runs_for_active_units(&store, &projection)
+            .await
+            .unwrap();
+
+        assert_eq!(enqueued, units.len() - 1);
+        assert_eq!(running_runs(&projection).await.unwrap().len(), units.len());
+        assert!(logs_contain_at(Level::DEBUG, &["ingestion run created"]));
+    }
+
+    #[tokio::test]
+    async fn create_runs_for_active_units_reports_zero_when_every_unit_is_busy() {
+        let (store, projection, _pool) = ingestion_store().await;
+        create_runs_for_active_units(&store, &projection)
+            .await
+            .unwrap();
+
+        let enqueued = create_runs_for_active_units(&store, &projection)
+            .await
+            .unwrap();
+
+        assert_eq!(enqueued, 0);
     }
 
     #[traced_test]

--- a/src/ingestion/orchestration.rs
+++ b/src/ingestion/orchestration.rs
@@ -53,7 +53,7 @@ fn validate_production_schedule_definitions() -> Result<(), IngestionScheduleErr
     Ok(())
 }
 
-/// Work units that schedulers and `POST /ingest` enqueue in this build.
+/// Work units that schedulers and the local ingest CLI enqueue in this build.
 ///
 /// Production runs every candle timeframe plus funding. The `test-support`
 /// feature narrows that set so e2e tests avoid the OneWeek lookback overflow
@@ -85,18 +85,18 @@ pub(crate) fn default_ingestion_schedules()
 
 /// Opens a run for every active work unit that is idle.
 ///
-/// Returns how many runs were enqueued. `AlreadyRunning` for an individual unit
-/// is skipped so a partial busy set still starts the idle ones; only a genuine
-/// send/projection failure aborts the pass.
+/// Returns the run ids that were enqueued. `AlreadyRunning` for an individual
+/// unit is skipped so a partial busy set still starts the idle ones; only a
+/// genuine send/projection failure aborts the pass.
 pub(crate) async fn create_runs_for_active_units(
     store: &Store<IngestionRun>,
     projection: &Projection<IngestionRun>,
-) -> Result<usize, IngestionError> {
-    let mut enqueued = 0usize;
+) -> Result<Vec<IngestionRunId>, IngestionError> {
+    let mut enqueued = Vec::new();
 
     for work in active_ingestion_units() {
         match create_run(store, projection, work).await {
-            Ok(_) => enqueued += 1,
+            Ok(run_id) => enqueued.push(run_id),
             Err(IngestionError::AlreadyRunning) => {}
             Err(err) => return Err(err),
         }
@@ -618,7 +618,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(enqueued, active_ingestion_units().len());
+        assert_eq!(enqueued.len(), active_ingestion_units().len());
         assert_eq!(
             running_runs(&projection).await.unwrap().len(),
             active_ingestion_units().len()
@@ -639,7 +639,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(enqueued, units.len() - 1);
+        assert_eq!(enqueued.len(), units.len() - 1);
         assert_eq!(running_runs(&projection).await.unwrap().len(), units.len());
         assert!(logs_contain_at(Level::DEBUG, &["ingestion run created"]));
     }
@@ -655,7 +655,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(enqueued, 0);
+        assert!(enqueued.is_empty());
     }
 
     #[traced_test]

--- a/src/ingestion/run.rs
+++ b/src/ingestion/run.rs
@@ -27,7 +27,7 @@ pub(crate) enum IngestionRunStatus {
 /// revive a finished run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct IngestionRun {
-    pub(super) status: IngestionRunStatus,
+    pub(crate) status: IngestionRunStatus,
     pub(super) started_at: DateTime<Utc>,
     pub(super) schedule_key: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ use crate::hyperliquid::{Hyperliquid, HyperliquidClients, HyperliquidNetwork};
 use finance::Symbol;
 use ingestion::{
     IngestionJob, IngestionJobContext, IngestionRun, IngestionRunStatus, IngestionServices,
-    IngestionWork, default_ingestion_schedules, trigger_scheduled_ingestion,
+    IngestionWork, create_runs_for_active_units, default_ingestion_schedules,
+    trigger_scheduled_ingestion,
 };
 use market_catalog::MarketCatalog;
 use market_enablement::{
@@ -127,6 +128,8 @@ pub(crate) struct AppState {
     hyperliquid_clients: HyperliquidClients,
     portfolio_store: Arc<Store<Portfolio>>,
     portfolio_projection: Arc<Projection<Portfolio>>,
+    ingestion_store: Arc<Store<IngestionRun>>,
+    ingestion_projection: Arc<Projection<IngestionRun>>,
     market_enablement: Arc<Store<MarketEnablement>>,
     market_enablement_projection: Arc<Projection<MarketEnablement>>,
     market_catalog_projection: Arc<Projection<MarketCatalog>>,
@@ -200,6 +203,24 @@ async fn post_screener(
         Err(err) => {
             error!(error = %err, "failed to screen perps");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+/// Starts an on-demand ingestion pass for every idle active work unit.
+///
+/// Returns `202 Accepted` when at least one run was enqueued, `409 Conflict`
+/// when every unit already has a running run, and `500` on unexpected failures.
+async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
+    match create_runs_for_active_units(&state.ingestion_store, &state.ingestion_projection).await {
+        Ok(0) => StatusCode::CONFLICT,
+        Ok(enqueued) => {
+            debug!(enqueued, "manual ingestion runs enqueued");
+            StatusCode::ACCEPTED
+        }
+        Err(err) => {
+            error!(error = %err, "failed to start ingestion runs");
+            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 }
@@ -909,6 +930,8 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
         hyperliquid_clients,
         portfolio_store,
         portfolio_projection,
+        ingestion_store,
+        ingestion_projection,
         market_enablement,
         market_enablement_projection,
         market_catalog_projection,
@@ -924,6 +947,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/candles/{timeframe}", get(get_candles))
         .route("/factors/{timeframe}", get(get_factors))
         .route("/screener/{timeframe}", post(post_screener))
+        .route("/ingest", post(start_ingestion))
         .route("/ingestion/status", get(get_ingestion_status))
         .route(
             "/portfolio",
@@ -1053,7 +1077,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let (_ingestion_store, _ingestion_projection) =
+        let (ingestion_store, ingestion_projection) =
             StoreBuilder::<IngestionRun>::new(pool.clone())
                 .build()
                 .await
@@ -1075,6 +1099,8 @@ mod tests {
             hyperliquid_clients,
             portfolio_store,
             portfolio_projection,
+            ingestion_store,
+            ingestion_projection,
             market_enablement,
             market_enablement_projection,
             market_catalog_projection,
@@ -1497,6 +1523,23 @@ mod tests {
             payload.get("version").and_then(serde_json::Value::as_str),
             Some(env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn post_ingest_accepts_then_conflicts_while_runs_are_active() {
+        let data_dir = TempDir::new().unwrap();
+        let router = test_router(data_dir.path()).await;
+
+        let accepted = router.clone().oneshot(post_empty("/ingest")).await.unwrap();
+        assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+        assert!(logs_contain_at(
+            tracing::Level::DEBUG,
+            &["manual ingestion runs enqueued"]
+        ));
+
+        let conflicted = router.oneshot(post_empty("/ingest")).await.unwrap();
+        assert_eq!(conflicted.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod finance;
 mod funding;
 mod hyperliquid;
 mod ingestion;
+mod local_ingest;
 mod market_catalog;
 mod market_enablement;
 mod market_metadata;
@@ -13,6 +14,8 @@ mod readonly_portfolio;
 mod screener;
 mod timeframe;
 mod venue;
+
+pub use local_ingest::{LocalIngestError, run_local_ingest};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -45,8 +48,7 @@ use crate::hyperliquid::{Hyperliquid, HyperliquidClients, HyperliquidNetwork};
 use finance::Symbol;
 use ingestion::{
     IngestionJob, IngestionJobContext, IngestionRun, IngestionRunStatus, IngestionServices,
-    IngestionWork, create_runs_for_active_units, default_ingestion_schedules,
-    trigger_scheduled_ingestion,
+    IngestionWork, default_ingestion_schedules, trigger_scheduled_ingestion,
 };
 use market_catalog::MarketCatalog;
 use market_enablement::{
@@ -128,8 +130,6 @@ pub(crate) struct AppState {
     hyperliquid_clients: HyperliquidClients,
     portfolio_store: Arc<Store<Portfolio>>,
     portfolio_projection: Arc<Projection<Portfolio>>,
-    ingestion_store: Arc<Store<IngestionRun>>,
-    ingestion_projection: Arc<Projection<IngestionRun>>,
     market_enablement: Arc<Store<MarketEnablement>>,
     market_enablement_projection: Arc<Projection<MarketEnablement>>,
     market_catalog_projection: Arc<Projection<MarketCatalog>>,
@@ -203,24 +203,6 @@ async fn post_screener(
         Err(err) => {
             error!(error = %err, "failed to screen perps");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
-}
-
-/// Starts an on-demand ingestion pass for every idle active work unit.
-///
-/// Returns `202 Accepted` when at least one run was enqueued, `409 Conflict`
-/// when every unit already has a running run, and `500` on unexpected failures.
-async fn start_ingestion(State(state): State<Arc<AppState>>) -> StatusCode {
-    match create_runs_for_active_units(&state.ingestion_store, &state.ingestion_projection).await {
-        Ok(0) => StatusCode::CONFLICT,
-        Ok(enqueued) => {
-            debug!(enqueued, "manual ingestion runs enqueued");
-            StatusCode::ACCEPTED
-        }
-        Err(err) => {
-            error!(error = %err, "failed to start ingestion runs");
-            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 }
@@ -758,7 +740,7 @@ fn classify_enablement_error(error: &SendError<MarketEnablement>, operation: &st
 /// library's shared retry/backoff/circuit-breaker policy: retries are exhausted
 /// before a terminal failure trips the breaker and stops the worker for a human
 /// to inspect.
-fn spawn_ingestion_worker(
+pub(crate) fn spawn_ingestion_worker(
     apalis_pool: apalis_sqlite::SqlitePool,
     context: Arc<IngestionJobContext>,
 ) {
@@ -930,8 +912,6 @@ pub async fn app(config: Config) -> Result<Router, Box<dyn std::error::Error + S
         hyperliquid_clients,
         portfolio_store,
         portfolio_projection,
-        ingestion_store,
-        ingestion_projection,
         market_enablement,
         market_enablement_projection,
         market_catalog_projection,
@@ -947,7 +927,6 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/candles/{timeframe}", get(get_candles))
         .route("/factors/{timeframe}", get(get_factors))
         .route("/screener/{timeframe}", post(post_screener))
-        .route("/ingest", post(start_ingestion))
         .route("/ingestion/status", get(get_ingestion_status))
         .route(
             "/portfolio",
@@ -980,9 +959,11 @@ fn build_router(state: Arc<AppState>) -> Router {
 #[error(
     "in-memory SQLite database_url is unsupported: the event store and the apalis worker open separate pools, and an in-memory URL gives each its own private database; use a file-backed database_url"
 )]
-struct InMemoryDatabaseUnsupported;
+pub(crate) struct InMemoryDatabaseUnsupported;
 
-fn ensure_shared_database(database_url: &str) -> Result<(), InMemoryDatabaseUnsupported> {
+pub(crate) fn ensure_shared_database(
+    database_url: &str,
+) -> Result<(), InMemoryDatabaseUnsupported> {
     let normalized = database_url.to_ascii_lowercase();
     if normalized.contains(":memory:") || normalized.contains("mode=memory") {
         return Err(InMemoryDatabaseUnsupported);
@@ -1077,11 +1058,6 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let (ingestion_store, ingestion_projection) =
-            StoreBuilder::<IngestionRun>::new(pool.clone())
-                .build()
-                .await
-                .unwrap();
         let (market_catalog, market_catalog_projection) =
             StoreBuilder::<MarketCatalog>::new(pool.clone())
                 .build()
@@ -1099,8 +1075,6 @@ mod tests {
             hyperliquid_clients,
             portfolio_store,
             portfolio_projection,
-            ingestion_store,
-            ingestion_projection,
             market_enablement,
             market_enablement_projection,
             market_catalog_projection,
@@ -1523,23 +1497,6 @@ mod tests {
             payload.get("version").and_then(serde_json::Value::as_str),
             Some(env!("CARGO_PKG_VERSION"))
         );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn post_ingest_accepts_then_conflicts_while_runs_are_active() {
-        let data_dir = TempDir::new().unwrap();
-        let router = test_router(data_dir.path()).await;
-
-        let accepted = router.clone().oneshot(post_empty("/ingest")).await.unwrap();
-        assert_eq!(accepted.status(), StatusCode::ACCEPTED);
-        assert!(logs_contain_at(
-            tracing::Level::DEBUG,
-            &["manual ingestion runs enqueued"]
-        ));
-
-        let conflicted = router.oneshot(post_empty("/ingest")).await.unwrap();
-        assert_eq!(conflicted.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2071,6 +2071,7 @@ mod tests {
         assert_eq!(body["tickers"], serde_json::json!(["BTC/USDC:USDC"]));
         assert_eq!(body["leverageLimits"][0]["maxLeverage"], 50);
         assert_eq!(body["leverageLimits"][0]["assetIndex"], 0);
+        assert_eq!(body["leverageLimits"][0]["onlyIsolated"], false);
         assert!(
             logs_contain_at(
                 tracing::Level::DEBUG,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod screener;
 mod timeframe;
 mod venue;
 
-pub use local_ingest::{LocalIngestError, run_local_ingest};
+pub use local_ingest::run_local_ingest;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/local_ingest.rs
+++ b/src/local_ingest.rs
@@ -1,0 +1,199 @@
+//! Standalone on-demand ingestion for the `moneymentum-ingest` CLI.
+//!
+//! Runs without the HTTP API or cron schedulers: boots its own stores and
+//! ingestion worker, enqueues every idle work unit, waits for completion, then
+//! exits. Intended for local operator use from a terminal when the main server
+//! is not running.
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use event_sorcery::{Projection, Store, StoreBuilder};
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+use thiserror::Error;
+use tracing::{debug, info};
+use tracing_subscriber::EnvFilter;
+
+use crate::Config;
+use crate::hyperliquid::HyperliquidClients;
+use crate::ingestion::{
+    IngestionJobContext, IngestionRun, IngestionRunId, IngestionRunStatus, IngestionServices,
+    create_runs_for_active_units, recover_abandoned_runs, running_runs,
+};
+use crate::market_catalog::MarketCatalog;
+use crate::market_enablement::MarketEnablement;
+use crate::{ensure_shared_database, spawn_ingestion_worker};
+
+/// Why a local on-demand ingestion pass fails.
+#[derive(Debug, Error)]
+pub enum LocalIngestError {
+    #[error("no idle ingestion units available; every unit already has a running run")]
+    NothingEnqueued,
+    #[error("ingestion run {run_id} finished with status {status}, expected Completed")]
+    RunNotCompleted { run_id: String, status: String },
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+fn local_ingest_err(
+    error: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+) -> LocalIngestError {
+    LocalIngestError::Other(error.into())
+}
+
+struct LocalIngestRuntime {
+    ingestion_store: Arc<Store<IngestionRun>>,
+    ingestion_projection: Arc<Projection<IngestionRun>>,
+}
+
+async fn bootstrap_local_ingest(config: &Config) -> Result<LocalIngestRuntime, LocalIngestError> {
+    let filter = EnvFilter::new(format!("moneymentum={}", config.log_level.as_str()));
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+
+    ensure_shared_database(&config.database_url).map_err(local_ingest_err)?;
+
+    let database_options = SqliteConnectOptions::from_str(&config.database_url)
+        .map_err(local_ingest_err)?
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(5));
+    let pool = SqlitePool::connect_with(database_options)
+        .await
+        .map_err(local_ingest_err)?;
+    debug!("database connected");
+
+    let mut migrations = sqlx::migrate!("./migrations");
+    migrations
+        .set_ignore_missing(true)
+        .run(&pool)
+        .await
+        .map_err(local_ingest_err)?;
+    debug!(count = migrations.iter().count(), "migrations applied");
+
+    let (ingestion_store, ingestion_projection) = StoreBuilder::<IngestionRun>::new(pool.clone())
+        .build()
+        .await
+        .map_err(local_ingest_err)?;
+    let (market_catalog, market_catalog_projection) =
+        StoreBuilder::<MarketCatalog>::new(pool.clone())
+            .build()
+            .await
+            .map_err(local_ingest_err)?;
+    let (_market_enablement, market_enablement_projection) =
+        StoreBuilder::<MarketEnablement>::new(pool)
+            .build()
+            .await
+            .map_err(local_ingest_err)?;
+    debug!("event-sourced stores ready");
+
+    recover_abandoned_runs(&ingestion_store, &ingestion_projection)
+        .await
+        .map_err(local_ingest_err)?;
+
+    let apalis_options = apalis_sqlite::SqliteConnectOptions::from_str(&config.database_url)
+        .map_err(local_ingest_err)?
+        .busy_timeout(Duration::from_secs(5));
+    let apalis_pool = apalis_sqlite::SqlitePool::connect_with(apalis_options)
+        .await
+        .map_err(local_ingest_err)?;
+    debug!("apalis storage pool connected");
+
+    let hyperliquid_clients = HyperliquidClients::from_config(
+        config.hyperliquid_base_url.as_ref(),
+        config.hyperliquid_testnet_base_url.as_ref(),
+        config.max_retries,
+    )
+    .await
+    .map_err(local_ingest_err)?;
+    let services = IngestionServices {
+        hyperliquid: Arc::clone(&hyperliquid_clients.mainnet),
+        data_dir: config.data_dir.clone(),
+        max_concurrent_requests: config.max_concurrent_requests,
+        market_catalog: Arc::clone(&market_catalog),
+        market_catalog_projection: Arc::clone(&market_catalog_projection),
+        market_enablement_projection: Arc::clone(&market_enablement_projection),
+    };
+    spawn_ingestion_worker(
+        apalis_pool,
+        Arc::new(IngestionJobContext {
+            run_store: Arc::clone(&ingestion_store),
+            run_projection: Arc::clone(&ingestion_projection),
+            services,
+        }),
+    );
+    debug!("ingestion worker started");
+
+    Ok(LocalIngestRuntime {
+        ingestion_store,
+        ingestion_projection,
+    })
+}
+
+async fn wait_for_local_ingest_completion(
+    runtime: &LocalIngestRuntime,
+    started_run_ids: &[IngestionRunId],
+) -> Result<(), LocalIngestError> {
+    loop {
+        let running = running_runs(&runtime.ingestion_projection)
+            .await
+            .map_err(local_ingest_err)?;
+        if running.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    for run_id in started_run_ids {
+        let run = runtime
+            .ingestion_store
+            .load(run_id)
+            .await
+            .map_err(local_ingest_err)?;
+        let status = run.as_ref().map(|loaded| loaded.status);
+        if status != Some(IngestionRunStatus::Completed) {
+            return Err(LocalIngestError::RunNotCompleted {
+                run_id: run_id.to_string(),
+                status: format!("{status:?}"),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Runs a full on-demand ingestion pass for every idle active work unit and
+/// waits until those runs finish.
+///
+/// Boots stores and an ingestion worker only -- no HTTP server, no cron. For the
+/// `moneymentum-ingest` CLI when the main backend is not running.
+///
+/// # Errors
+///
+/// Returns [`LocalIngestError`] when bootstrap fails, every unit is already
+/// busy, or a started run does not complete successfully.
+pub async fn run_local_ingest(config: Config) -> Result<(), LocalIngestError> {
+    let runtime = bootstrap_local_ingest(&config).await?;
+
+    let started_run_ids =
+        create_runs_for_active_units(&runtime.ingestion_store, &runtime.ingestion_projection)
+            .await
+            .map_err(local_ingest_err)?;
+
+    if started_run_ids.is_empty() {
+        return Err(LocalIngestError::NothingEnqueued);
+    }
+
+    info!(
+        enqueued = started_run_ids.len(),
+        "local ingestion runs enqueued; waiting for completion"
+    );
+
+    wait_for_local_ingest_completion(&runtime, &started_run_ids).await?;
+
+    info!(
+        completed = started_run_ids.len(),
+        "local ingestion finished"
+    );
+    Ok(())
+}

--- a/src/local_ingest.rs
+++ b/src/local_ingest.rs
@@ -28,13 +28,32 @@ use crate::{ensure_shared_database, spawn_ingestion_worker};
 
 /// Why a local on-demand ingestion pass fails.
 #[derive(Debug, Error)]
-pub enum LocalIngestError {
+pub(crate) enum LocalIngestError {
     #[error("no idle ingestion units available; every unit already has a running run")]
     NothingEnqueued,
-    #[error("ingestion run {run_id} finished with status {status}, expected Completed")]
-    RunNotCompleted { run_id: String, status: String },
+    #[error("ingestion run {run_id} finished with status {status:?}, expected Completed")]
+    RunNotCompleted {
+        run_id: IngestionRunId,
+        status: Option<IngestionRunStatus>,
+    },
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Runs a full on-demand ingestion pass for every idle active work unit and
+/// waits until those runs finish.
+///
+/// Boots stores and an ingestion worker only -- no HTTP server, no cron. For the
+/// `moneymentum-ingest` CLI when the main backend is not running.
+///
+/// # Errors
+///
+/// Returns an error when bootstrap fails, every unit is already busy, or a
+/// started run does not complete successfully.
+pub async fn run_local_ingest(
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    run_local_ingest_inner(config).await.map_err(Into::into)
 }
 
 fn local_ingest_err(
@@ -153,8 +172,8 @@ async fn wait_for_local_ingest_completion(
         let status = run.as_ref().map(|loaded| loaded.status);
         if status != Some(IngestionRunStatus::Completed) {
             return Err(LocalIngestError::RunNotCompleted {
-                run_id: run_id.to_string(),
-                status: format!("{status:?}"),
+                run_id: run_id.clone(),
+                status,
             });
         }
     }
@@ -162,17 +181,7 @@ async fn wait_for_local_ingest_completion(
     Ok(())
 }
 
-/// Runs a full on-demand ingestion pass for every idle active work unit and
-/// waits until those runs finish.
-///
-/// Boots stores and an ingestion worker only -- no HTTP server, no cron. For the
-/// `moneymentum-ingest` CLI when the main backend is not running.
-///
-/// # Errors
-///
-/// Returns [`LocalIngestError`] when bootstrap fails, every unit is already
-/// busy, or a started run does not complete successfully.
-pub async fn run_local_ingest(config: Config) -> Result<(), LocalIngestError> {
+async fn run_local_ingest_inner(config: Config) -> Result<(), LocalIngestError> {
     let runtime = bootstrap_local_ingest(&config).await?;
 
     let outcome =

--- a/src/local_ingest.rs
+++ b/src/local_ingest.rs
@@ -175,24 +175,28 @@ async fn wait_for_local_ingest_completion(
 pub async fn run_local_ingest(config: Config) -> Result<(), LocalIngestError> {
     let runtime = bootstrap_local_ingest(&config).await?;
 
-    let started_run_ids =
-        create_runs_for_active_units(&runtime.ingestion_store, &runtime.ingestion_projection)
-            .await
-            .map_err(local_ingest_err)?;
+    let outcome =
+        create_runs_for_active_units(&runtime.ingestion_store, &runtime.ingestion_projection).await;
 
-    if started_run_ids.is_empty() {
-        return Err(LocalIngestError::NothingEnqueued);
+    if outcome.enqueued.is_empty() {
+        return Err(outcome
+            .error
+            .map_or_else(|| LocalIngestError::NothingEnqueued, local_ingest_err));
     }
 
     info!(
-        enqueued = started_run_ids.len(),
+        enqueued = outcome.enqueued.len(),
         "local ingestion runs enqueued; waiting for completion"
     );
 
-    wait_for_local_ingest_completion(&runtime, &started_run_ids).await?;
+    wait_for_local_ingest_completion(&runtime, &outcome.enqueued).await?;
+
+    if let Some(err) = outcome.error {
+        return Err(local_ingest_err(err));
+    }
 
     info!(
-        completed = started_run_ids.len(),
+        completed = outcome.enqueued.len(),
         "local ingestion finished"
     );
     Ok(())

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -113,6 +113,11 @@ pub(crate) enum RefreshError {
 
 /// Refreshes the Hyperliquid universe from the live exchange and returns the
 /// tradable markets: every listed market the operator has not disabled.
+///
+/// Returned [`Market`] values keep the exchange-native coin casing from the
+/// live fetch. Hyperliquid's candle and funding endpoints are case-sensitive
+/// (`kPEPE` succeeds; `KPEPE` returns HTTP 500), while [`Symbol`] uppercases
+/// for identity joins with operator disable decisions.
 pub(crate) async fn refresh_markets(
     client: &dyn Hyperliquid,
     catalog: &Store<MarketCatalog>,
@@ -140,12 +145,20 @@ pub(crate) async fn refresh_markets(
         )
         .await?;
 
-    let tradable = tradable_markets(
-        VenueRef::Hyperliquid,
-        catalog_projection,
-        enablement_projection,
-    )
-    .await?;
+    let disabled: BTreeSet<Symbol> = enablement_projection
+        .filter(ENABLEMENT_STATUS, &MarketStatus::Disabled)
+        .await?
+        .into_iter()
+        .filter(|(id, _)| id.venue() == VenueRef::Hyperliquid)
+        .map(|(id, _): (MarketId, MarketEnablement)| id.into_symbol())
+        .collect();
+
+    let tradable: Vec<Market> = fetched
+        .iter()
+        .filter(|market| !disabled.contains(&Symbol::from_raw(market.symbol.as_str())))
+        .map(|market| market.symbol.clone())
+        .collect();
+
     let observed_at = catalog_projection
         .load(&VenueRef::Hyperliquid)
         .await?
@@ -299,6 +312,35 @@ mod tests {
 
     fn symbols(markets: &[Market]) -> Vec<&str> {
         markets.iter().map(Market::as_str).collect()
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn refresh_preserves_exchange_native_market_casing() {
+        let (catalog, catalog_projection, _enablement, enablement_projection) =
+            market_stores().await;
+        let client = StubClient {
+            metadata: vec![
+                metadata("BTC", 50, 0),
+                metadata("kPEPE", 10, 1),
+                metadata("kSHIB", 5, 2),
+            ],
+        };
+
+        let tradable = refresh_markets(
+            &client,
+            &catalog,
+            &catalog_projection,
+            &enablement_projection,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(symbols(&tradable), vec!["BTC", "kPEPE", "kSHIB"]);
+        assert!(crate::logs_contain_at(
+            Level::INFO,
+            &["markets metadata refreshed"]
+        ));
     }
 
     #[traced_test]

--- a/src/market_metadata.rs
+++ b/src/market_metadata.rs
@@ -57,6 +57,9 @@ pub(crate) struct LeverageLimitEntry {
     pub(crate) symbol: CcxtSymbol,
     pub(crate) max_leverage: u32,
     pub(crate) asset_index: u32,
+    /// `true` when Hyperliquid forbids cross margin for this asset. Always a
+    /// boolean -- the frontend trading client treats it as required.
+    pub(crate) only_isolated: bool,
 }
 
 /// The `GET /hyperliquid/markets` response: the perp universe in the exact
@@ -82,6 +85,7 @@ pub(crate) fn markets_api_response(
             symbol: finance::hyperliquid_swap_ccxt_symbol(market.symbol.as_str()),
             max_leverage: market.max_leverage,
             asset_index: market.asset_index,
+            only_isolated: market.only_isolated,
         })
         .collect();
     leverage_limits.sort_unstable_by(|left, right| left.symbol.cmp(&right.symbol));
@@ -569,6 +573,7 @@ mod tests {
         assert_eq!(response.leverage_limits[0].symbol.as_str(), "BTC/USDC:USDC");
         assert_eq!(response.leverage_limits[0].max_leverage, 50);
         assert_eq!(response.leverage_limits[0].asset_index, 0);
+        assert!(!response.leverage_limits[0].only_isolated);
         assert_eq!(
             response.leverage_limits[2].symbol.as_str(),
             "KPEPE/USDC:USDC"
@@ -580,13 +585,22 @@ mod tests {
     #[test]
     fn markets_api_response_serializes_with_camel_case_fields() {
         let refreshed_at = Utc.with_ymd_and_hms(2026, 7, 11, 12, 0, 0).unwrap();
-        let response = markets_api_response(&[metadata("BTC", 50, 7)], refreshed_at);
+        let response = markets_api_response(
+            &[MarketMetadata {
+                symbol: Market::new("BANANA".to_string()),
+                max_leverage: 5,
+                asset_index: 7,
+                only_isolated: true,
+            }],
+            refreshed_at,
+        );
 
         let json = serde_json::to_value(&response).unwrap();
-        assert_eq!(json["tickers"][0], "BTC/USDC:USDC");
-        assert_eq!(json["leverageLimits"][0]["symbol"], "BTC/USDC:USDC");
-        assert_eq!(json["leverageLimits"][0]["maxLeverage"], 50);
+        assert_eq!(json["tickers"][0], "BANANA/USDC:USDC");
+        assert_eq!(json["leverageLimits"][0]["symbol"], "BANANA/USDC:USDC");
+        assert_eq!(json["leverageLimits"][0]["maxLeverage"], 5);
         assert_eq!(json["leverageLimits"][0]["assetIndex"], 7);
+        assert_eq!(json["leverageLimits"][0]["onlyIsolated"], true);
         assert_eq!(json["refreshedAt"], "2026-07-11T12:00:00Z");
     }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -205,15 +205,42 @@ async fn ingestion_status_is_idle_on_fresh_start() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn manual_ingest_endpoint_is_not_exposed() {
+async fn manual_ingest_enqueues_and_completes() {
     let mock_server = MockServer::start().await;
-    mount_meta_mock(&mock_server).await;
+    mount_successful_ingestion_mocks(&mock_server).await;
 
     let data_dir = TempDir::new().unwrap();
     let app = spawn_test_app(&mock_server, &data_dir).await;
 
-    let response = app.post("/ingest").await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let ingest_response = app.post("/ingest").await;
+    assert_eq!(ingest_response.status(), StatusCode::ACCEPTED);
+
+    let completed = poll_for_status(&app, "Completed", 60, 200).await;
+    if !completed {
+        let body = ingestion_status_body(&app).await;
+        if body.contains("Failed") {
+            panic!("manual ingestion failed: {body}");
+        }
+        panic!("manual ingestion did not complete within timeout, last status: {body}");
+    }
+
+    let candles_response = app.get("/candles/1h").await;
+    assert_eq!(candles_response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn manual_ingest_conflicts_when_every_unit_is_already_running() {
+    let mock_server = MockServer::start().await;
+    mount_successful_ingestion_mocks(&mock_server).await;
+
+    let data_dir = TempDir::new().unwrap();
+    let app = spawn_test_app(&mock_server, &data_dir).await;
+
+    let first = app.post("/ingest").await;
+    assert_eq!(first.status(), StatusCode::ACCEPTED);
+
+    let second = app.post("/ingest").await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -385,7 +385,8 @@ async fn hyperliquid_markets_serves_the_universe_in_ccxt_format() {
         json!([
             {"name": "ETH", "szDecimals": 4, "maxLeverage": 25},
             {"name": "DELISTED", "szDecimals": 2, "maxLeverage": 3, "isDelisted": true},
-            {"name": "BTC", "szDecimals": 8, "maxLeverage": 50}
+            {"name": "BTC", "szDecimals": 8, "maxLeverage": 50},
+            {"name": "BANANA", "szDecimals": 0, "maxLeverage": 5, "onlyIsolated": true}
         ]),
     )
     .await;
@@ -399,16 +400,32 @@ async fn hyperliquid_markets_serves_the_universe_in_ccxt_format() {
     let body: serde_json::Value = response.json().await.unwrap();
     assert_eq!(
         body["tickers"],
-        json!(["BTC/USDC:USDC", "ETH/USDC:USDC"]),
+        json!(["BANANA/USDC:USDC", "BTC/USDC:USDC", "ETH/USDC:USDC"]),
         "tickers should be sorted ccxt symbols excluding delisted assets: {body}"
     );
     assert_eq!(
         body["leverageLimits"],
         json!([
-            {"symbol": "BTC/USDC:USDC", "maxLeverage": 50, "assetIndex": 2},
-            {"symbol": "ETH/USDC:USDC", "maxLeverage": 25, "assetIndex": 0}
+            {
+                "symbol": "BANANA/USDC:USDC",
+                "maxLeverage": 5,
+                "assetIndex": 3,
+                "onlyIsolated": true
+            },
+            {
+                "symbol": "BTC/USDC:USDC",
+                "maxLeverage": 50,
+                "assetIndex": 2,
+                "onlyIsolated": false
+            },
+            {
+                "symbol": "ETH/USDC:USDC",
+                "maxLeverage": 25,
+                "assetIndex": 0,
+                "onlyIsolated": false
+            }
         ]),
-        "leverage limits should keep positional asset indexes: {body}"
+        "leverage limits should keep positional asset indexes and onlyIsolated: {body}"
     );
     assert!(
         body["refreshedAt"].is_string(),

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -110,14 +110,6 @@ impl TestApp {
             .unwrap()
     }
 
-    async fn post(&self, path: &str) -> reqwest::Response {
-        self.http
-            .post(format!("{}{path}", self.base_url))
-            .send()
-            .await
-            .unwrap()
-    }
-
     async fn shutdown(self) {
         self.server.abort();
         let _ = self.server.await;
@@ -205,42 +197,36 @@ async fn ingestion_status_is_idle_on_fresh_start() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn manual_ingest_enqueues_and_completes() {
+async fn local_ingest_writes_candles() {
     let mock_server = MockServer::start().await;
     mount_successful_ingestion_mocks(&mock_server).await;
 
     let data_dir = TempDir::new().unwrap();
-    let app = spawn_test_app(&mock_server, &data_dir).await;
+    let database_path = data_dir.path().join("moneymentum-test.db");
+    let toml_str = format!(
+        r#"
+        port = 0
+        data_dir = "{}"
+        database_url = "sqlite://{}?mode=rwc"
+        hyperliquid_base_url = "{}"
+        hyperliquid_testnet_base_url = "{}"
+        log_level = "debug"
+        max_concurrent_requests = 3
+        max_retries = 2
+        "#,
+        data_dir.path().display(),
+        database_path.display(),
+        mock_server.uri(),
+        mock_server.uri()
+    );
+    let config: Config = toml::from_str(&toml_str).unwrap();
+    moneymentum::run_local_ingest(config).await.unwrap();
 
-    let ingest_response = app.post("/ingest").await;
-    assert_eq!(ingest_response.status(), StatusCode::ACCEPTED);
-
-    let completed = poll_for_status(&app, "Completed", 60, 200).await;
-    if !completed {
-        let body = ingestion_status_body(&app).await;
-        if body.contains("Failed") {
-            panic!("manual ingestion failed: {body}");
-        }
-        panic!("manual ingestion did not complete within timeout, last status: {body}");
-    }
-
-    let candles_response = app.get("/candles/1h").await;
-    assert_eq!(candles_response.status(), StatusCode::OK);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn manual_ingest_conflicts_when_every_unit_is_already_running() {
-    let mock_server = MockServer::start().await;
-    mount_successful_ingestion_mocks(&mock_server).await;
-
-    let data_dir = TempDir::new().unwrap();
-    let app = spawn_test_app(&mock_server, &data_dir).await;
-
-    let first = app.post("/ingest").await;
-    assert_eq!(first.status(), StatusCode::ACCEPTED);
-
-    let second = app.post("/ingest").await;
-    assert_eq!(second.status(), StatusCode::CONFLICT);
+    let candles_path = data_dir.path().join("ohlcv_1h.csv");
+    assert!(
+        candles_path.exists(),
+        "local ingest should write the 1h candle csv"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -206,8 +206,8 @@ async fn local_ingest_writes_candles() {
     let toml_str = format!(
         r#"
         port = 0
-        data_dir = "{}"
-        database_url = "sqlite://{}?mode=rwc"
+        data_dir = '{}'
+        database_url = 'sqlite://{}?mode=rwc'
         hyperliquid_base_url = "{}"
         hyperliquid_testnet_base_url = "{}"
         log_level = "debug"


### PR DESCRIPTION
## Why

Scheduled ingestion alone cannot support local operator workflows that need a complete, on-demand candle and funding refresh -- for example before taking a Monday ground-truth backup. After the manual endpoint was removed, there was no HTTP way to start those pulls when needed.

## How

Re-expose `POST /ingest` so it enqueues every idle active work unit the built-in schedulers already run. The handler returns 202 when at least one run starts and 409 when every unit is already busy, keeping the per-schedule-key running-slot invariant.

Closes #449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `moneymentum-ingest` CLI for running on-demand/local ingestion from a config file.
  * Market API leverage details now expose isolated-margin capability (`onlyIsolated`) per asset.
* **Bug Fixes**
  * Weekly candle ingestion now clamps the computed start timestamp to avoid pre-epoch millisecond values.
* **Documentation**
  * Updated README and roadmap to reflect scheduled vs on-demand ingestion behavior and current production deployment notes.
* **Tests**
  * Added coverage for the pre-epoch clamp and local ingestion output generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->