### PR TITLE
feat: keyboard navigation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -252,6 +252,8 @@ result before sending trades.
       [#274](https://github.com/dataclique/moneymentum/pull/274)); frontend
       filter integration pending
 - [ ] [Simulate Staged Portfolio Metrics](./stories/0x01d.simulate-staged-portfolio-metrics.md)
+- [ ] [Navigate Portfolio With Keyboard](./stories/0x025.navigate-portfolio-with-keyboard.md)
+      -- [#457](https://github.com/dataclique/moneymentum/issues/457)
 
 ---
 

--- a/frontend/src/pages/Portfolio/components/AllSymbolsPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/AllSymbolsPanel.tsx
@@ -60,7 +60,11 @@ export const AllSymbolsPanel = (props: AllSymbolsPanelProps): JSX.Element => {
   }
 
   return (
-    <div class="flex h-full min-h-0 w-full min-w-0 flex-col">
+    <div
+      class="flex h-full min-h-0 w-full min-w-0 flex-col outline-none"
+      tabIndex={0}
+      data-portfolio-panel="allSymbols"
+    >
       <div class="min-h-0 flex-1">
         <AllSymbolsDataTable
           data={allSymbolRows}

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/AllSymbolsRow.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/AllSymbolsRow.tsx
@@ -27,6 +27,8 @@ export const AllSymbolsRow = (props: {
   fundingIsLoading: boolean
   factorsIsLoading: boolean
   onSymbolClick: (symbol: string) => void
+  isSelected?: boolean
+  onSelect?: () => void
 }): JSX.Element => {
   const metricSkeleton = () => (
     <Skeleton class="inline-block h-3 w-10 align-middle" />
@@ -134,6 +136,7 @@ export const AllSymbolsRow = (props: {
   }
 
   const handleActivate = () => {
+    props.onSelect?.()
     props.onSymbolClick(props.row.symbol)
   }
 
@@ -164,8 +167,11 @@ export const AllSymbolsRow = (props: {
       class={cn(
         "group border-b border-border/20 cursor-pointer transition-colors",
         rowClassName(),
+        props.isSelected && "bg-primary/15",
       )}
       onClick={handleActivate}
+      aria-selected={props.isSelected === true}
+      data-all-symbols-row={props.row.symbol}
     >
       <td class={allSymbolBodyCellClass("asset")}>
         <button

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/LeverageInlineEditor.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/LeverageInlineEditor.tsx
@@ -42,18 +42,19 @@ export const LeverageEditorTrigger = (
     props.leverageLimitsIsLoading || props.maxLeverage === undefined
 
   // Intentional imperative keyboard listener:
-  // the inline editor needs to close on `Escape`, so we subscribe while it is
-  // open and remove the handler via `onCleanup`.
+  // the inline editor needs to close on Escape/Enter, so we subscribe while it
+  // is open and remove the handler via onCleanup.
   createEffect(() => {
     if (props.isOpen) {
-      const handleEsc = (event: KeyboardEvent) => {
-        if (event.key === "Escape") {
+      const handleCloseKey = (event: KeyboardEvent) => {
+        if (event.key === "Escape" || event.key === "Enter") {
+          event.preventDefault()
           props.onClose()
         }
       }
-      window.addEventListener("keydown", handleEsc)
+      window.addEventListener("keydown", handleCloseKey)
       onCleanup(() => {
-        window.removeEventListener("keydown", handleEsc)
+        window.removeEventListener("keydown", handleCloseKey)
       })
     }
   })

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanel.tsx
@@ -30,11 +30,12 @@ import {
 } from "./portfolioMetricVisibility"
 import { PositionsDataTable } from "./positions-data-table"
 import type { PositionsTableMeta } from "./positions-data-table"
+import {
+  CROSS_ACCOUNT_LEVERAGE_MAX,
+  CROSS_ACCOUNT_LEVERAGE_MIN,
+  CROSS_ACCOUNT_LEVERAGE_STEP,
+} from "./crossAccountLeverage"
 import { ReadonlyBtcPanel } from "./ReadonlyBtcPanel"
-
-const LEVERAGE_MIN = 0.001
-const LEVERAGE_MAX = 5
-const LEVERAGE_STEP = 0.1
 
 interface PositionsPanelProps {
   hasTotalWeightExceeded: boolean
@@ -168,7 +169,10 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
     }
     const value = parseFloat(raw)
     if (!Number.isNaN(value)) {
-      const clamped = Math.max(LEVERAGE_MIN, Math.min(LEVERAGE_MAX, value))
+      const clamped = Math.max(
+        CROSS_ACCOUNT_LEVERAGE_MIN,
+        Math.min(CROSS_ACCOUNT_LEVERAGE_MAX, value),
+      )
       props.onCrossAccountLeverageChange(clamped)
     }
   }
@@ -197,7 +201,11 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
   )
 
   return (
-    <div class="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col">
+    <div
+      class="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col outline-none"
+      tabIndex={0}
+      data-portfolio-panel="portfolio"
+    >
       <div class="flex min-h-0 flex-1 flex-col">
         <Show
           when={!props.isLoading}
@@ -256,7 +264,7 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
         currentPortfolio={props.currentPortfolio}
       />
 
-      <div class="shrink-0 border-t border-border bg-background/80 backdrop-blur">
+      <div class="shrink-0 border-t border-border bg-background/80 backdrop-blur px-3 pb-3">
         <div class="flex items-center pt-3 text-[12px]">
           <div class="flex flex-1 items-center gap-3">
             <span class="whitespace-nowrap font-semibold text-muted-foreground">
@@ -271,9 +279,9 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
                 onChange={([selectedLeverage]) => {
                   props.onCrossAccountLeverageChange(selectedLeverage)
                 }}
-                minValue={LEVERAGE_MIN}
-                maxValue={LEVERAGE_MAX}
-                step={LEVERAGE_STEP}
+                minValue={CROSS_ACCOUNT_LEVERAGE_MIN}
+                maxValue={CROSS_ACCOUNT_LEVERAGE_MAX}
+                step={CROSS_ACCOUNT_LEVERAGE_STEP}
                 class="flex-1"
               />
               <input
@@ -289,9 +297,9 @@ export const PositionsPanel = (props: PositionsPanelProps): JSX.Element => {
                     leverageInputChangeEvent.currentTarget.value,
                   )
                 }}
-                min={LEVERAGE_MIN}
-                max={LEVERAGE_MAX}
-                step={LEVERAGE_STEP}
+                min={CROSS_ACCOUNT_LEVERAGE_MIN}
+                max={CROSS_ACCOUNT_LEVERAGE_MAX}
+                step={CROSS_ACCOUNT_LEVERAGE_STEP}
                 class="w-16 rounded-md border border-border bg-transparent px-2 py-1 text-center font-medium [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               />
               <span class="text-sm font-medium">x</span>

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanelRow.test.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanelRow.test.tsx
@@ -22,7 +22,7 @@ const defaultRowMetrics = {
 }
 
 describe("PositionsPanelRow", () => {
-  it("replaces side through visible metric columns with a compact leverage editor", async () => {
+  it("replaces side, weight, and notional with a compact leverage editor", async () => {
     const user = userEvent.setup()
 
     render(() => (
@@ -75,7 +75,7 @@ describe("PositionsPanelRow", () => {
     if (sliderCell === null) {
       throw new Error("slider cell not found")
     }
-    expect(sliderCell).toHaveAttribute("colspan", "4")
+    expect(sliderCell).toHaveAttribute("colspan", "3")
 
     await user.click(document.body)
 
@@ -211,7 +211,7 @@ describe("PositionsPanelRow", () => {
     if (sliderCell === null) {
       throw new Error("slider cell not found")
     }
-    expect(sliderCell).toHaveAttribute("colspan", "4")
+    expect(sliderCell).toHaveAttribute("colspan", "3")
 
     await user.keyboard("{Escape}")
 

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanelRow.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/PositionsPanelRow.tsx
@@ -49,6 +49,10 @@ import {
   type PortfolioMetricColumnId,
 } from "./portfolioMetricVisibility"
 import { positionCellInputProps } from "./positionCellInput"
+import {
+  PORTFOLIO_CELL_ATTR,
+  PORTFOLIO_SYMBOL_ATTR,
+} from "../../keyboard/portfolioCellFocus"
 
 export interface PositionRowMetrics {
   signedFundingRate: number | null
@@ -90,6 +94,10 @@ export const PositionsPanelRow = (props: {
   symbolsDeltaBelowMinimum: string[]
   symbolDelta: number
   rebalanceError?: string
+  isSelected?: boolean
+  leverageEditorRequested?: boolean
+  onSelect?: () => void
+  onLeverageEditorClosed?: () => void
 }): JSX.Element => {
   const notional = () => props.position().notional
   const weight = createMemo(() => {
@@ -135,10 +143,18 @@ export const PositionsPanelRow = (props: {
   const stickyErrorBackgroundClass = () =>
     rebalanceError() && !isClosing() && positionStickyErrorBackground
 
-  const stickyCellStyle = () =>
-    rebalanceError() && !isClosing()
+  const stickyCellStyle = () => {
+    if (props.isSelected) {
+      return {
+        "background-color":
+          "color-mix(in oklch, var(--primary) 14%, var(--background))",
+      }
+    }
+
+    return rebalanceError() && !isClosing()
       ? positionStickyErrorBackgroundStyle
       : positionStickyRowBackgroundStyle(props.status)
+  }
 
   const metricSkeleton = () => (
     <Skeleton class="ml-auto h-3 w-[3rem] inline-block align-middle" />
@@ -271,6 +287,9 @@ export const PositionsPanelRow = (props: {
     leverageKeyboardEntry = ""
   }
 
+  let rowElement: HTMLTableRowElement | undefined
+  let openedByKeyboardRequest = false
+
   const openLeverageEditor = () => {
     clearLeverageEditorTimers()
     resetLeverageKeyboardEntry()
@@ -286,7 +305,44 @@ export const PositionsPanelRow = (props: {
     resetLeverageKeyboardEntry()
     setIsLeverageEditorExpanded(false)
     setIsLeverageEditorMounted(false)
+    openedByKeyboardRequest = false
+    props.onLeverageEditorClosed?.()
   }
+
+  // createEffect: open/close leverage editor from keyboard controller request
+  createEffect(() => {
+    if (props.leverageEditorRequested) {
+      openedByKeyboardRequest = true
+      if (!isLeverageEditorMounted()) {
+        openLeverageEditor()
+      }
+      return
+    }
+
+    if (openedByKeyboardRequest && isLeverageEditorMounted()) {
+      openedByKeyboardRequest = false
+      clearLeverageEditorTimers()
+      resetLeverageKeyboardEntry()
+      setIsLeverageEditorExpanded(false)
+      setIsLeverageEditorMounted(false)
+    }
+  })
+
+  // createEffect: scroll selected row into view
+  createEffect(() => {
+    if (!props.isSelected) {
+      return
+    }
+    rowElement?.scrollIntoView({ block: "nearest" })
+  })
+
+  const showRowHints = () => props.isSelected === true
+
+  const rowHintClass = () =>
+    cn(
+      "inline-flex w-3 shrink-0 justify-center font-mono text-[8px] text-muted-foreground",
+      showRowHints() ? "opacity-60" : "opacity-0",
+    )
 
   const applyLeverageKeyboardEntry = (digit: string) => {
     const maxLeverage = Math.floor(props.maxLeverage ?? 1)
@@ -378,13 +434,25 @@ export const PositionsPanelRow = (props: {
   return (
     <>
       <tr
+        ref={element => {
+          rowElement = element
+        }}
+        onClick={() => {
+          props.onSelect?.()
+        }}
         class={cn(
-          "border-b border-border/30 position-row h-7 transition-[height,opacity] duration-200 ease-out",
+          "border-b border-border/30 position-row h-7 transition-[height,opacity,background-color] duration-200 ease-out",
           isLeverageEditorExpanded() && "h-14",
-          isClosing() && "bg-red-500/5",
-          isNew() && "bg-green-500/5",
-          rebalanceError() && !isClosing() && "bg-destructive/5",
+          isClosing() && !props.isSelected && "bg-red-500/5",
+          isNew() && !props.isSelected && "bg-green-500/5",
+          rebalanceError() &&
+            !isClosing() &&
+            !props.isSelected &&
+            "bg-destructive/5",
+          props.isSelected && "bg-primary/15",
         )}
+        data-portfolio-row={props.symbol}
+        aria-selected={props.isSelected === true}
       >
         <td
           class={cn(
@@ -418,6 +486,7 @@ export const PositionsPanelRow = (props: {
               >
                 {baseSymbol()}
               </span>
+              <kbd class={rowHintClass()}>l</kbd>
               <LeverageEditorTrigger
                 isOpen={isLeverageEditorMounted()}
                 onOpen={openLeverageEditor}
@@ -437,6 +506,7 @@ export const PositionsPanelRow = (props: {
             <>
               <td class={positionBodyCellClass("side")}>
                 <div class={positionBodyCellInnerClass}>
+                  <kbd class={rowHintClass()}>t</kbd>
                   <button
                     type="button"
                     disabled={isClosing()}
@@ -465,9 +535,14 @@ export const PositionsPanelRow = (props: {
                       <span class="text-rose-500 text-[10px]">→ 0%</span>
                     }
                   >
+                    <kbd class={rowHintClass()}>w</kbd>
                     <input
                       type="number"
                       {...positionCellInputProps}
+                      {...{
+                        [PORTFOLIO_CELL_ATTR]: "weight",
+                        [PORTFOLIO_SYMBOL_ATTR]: props.symbol,
+                      }}
                       value={weightInput()}
                       onFocus={() => {
                         setIsWeightFocused(true)
@@ -502,10 +577,15 @@ export const PositionsPanelRow = (props: {
               </td>
               <td class={positionBodyCellClass("notional")}>
                 <div class={positionBodyCellInnerClass}>
+                  <kbd class={rowHintClass()}>n</kbd>
                   <span class="text-muted-foreground text-[10px]">$</span>
                   <input
                     type="number"
                     {...positionCellInputProps}
+                    {...{
+                      [PORTFOLIO_CELL_ATTR]: "notional",
+                      [PORTFOLIO_SYMBOL_ATTR]: props.symbol,
+                    }}
                     value={notionalInput()}
                     onFocus={() => {
                       setIsNotionalFocused(true)
@@ -570,6 +650,7 @@ export const PositionsPanelRow = (props: {
                 style={stickyCellStyle()}
               >
                 <div class={positionBodyCellInnerClass}>
+                  <kbd class={rowHintClass()}>d</kbd>
                   <Button
                     variant="ghost"
                     size="icon"
@@ -612,34 +693,51 @@ export const PositionsPanelRow = (props: {
             )}
           >
             <Show when={isLeverageEditorExpanded()}>
-              <LeverageSliderEditor
-                symbol={props.position().symbol}
-                leverage={props.position().leverage}
-                maxLeverage={props.maxLeverage}
-                onLeverageChange={props.onLeverageChange}
-              />
+              <div class="w-full max-w-[13.875rem]">
+                <LeverageSliderEditor
+                  symbol={props.position().symbol}
+                  leverage={props.position().leverage}
+                  maxLeverage={props.maxLeverage}
+                  onLeverageChange={props.onLeverageChange}
+                />
+              </div>
             </Show>
           </td>
+          <For each={props.visibleMetricColumns}>
+            {columnId => (
+              <td class={positionBodyCellClass(columnId)} aria-hidden="true" />
+            )}
+          </For>
           <td
             class={cn(
               positionStickyLeverageCloseClass(props.status),
               stickyErrorBackgroundClass(),
-              "transition-[padding] duration-200 ease-out",
+              "w-auto min-w-9 transition-[padding] duration-200 ease-out",
               isLeverageEditorExpanded() ? "py-2" : "py-0",
             )}
             style={stickyCellStyle()}
           >
-            <Button
-              variant="ghost"
-              size="icon"
-              class="h-6 w-6"
-              aria-label={`Close leverage editor for ${props.position().symbol}`}
-              onClick={() => {
-                closeLeverageEditor()
-              }}
-            >
-              <X class="h-3 w-3" />
-            </Button>
+            <div class="flex items-center justify-end gap-0.5">
+              <kbd
+                class={cn(
+                  "inline-flex shrink-0 justify-center font-mono text-[8px] text-muted-foreground",
+                  isLeverageEditorExpanded() ? "opacity-60" : "opacity-0",
+                )}
+              >
+                esc
+              </kbd>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-6 w-6"
+                aria-label={`Close leverage editor for ${props.position().symbol}`}
+                onClick={() => {
+                  closeLeverageEditor()
+                }}
+              >
+                <X class="h-3 w-3" />
+              </Button>
+            </div>
           </td>
         </Show>
       </tr>

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/all-symbols-data-table.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/all-symbols-data-table.tsx
@@ -12,6 +12,7 @@ import {
   Show,
   createMemo,
   createRenderEffect,
+  createEffect,
   createSignal,
   splitProps,
   type Accessor,
@@ -22,6 +23,10 @@ import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/cn"
 
 import type { PortfolioInterface } from "../../hooks/usePortfolioState"
+import {
+  ALL_SYMBOLS_SEARCH_ATTR,
+  tryUsePortfolioKeyboardContext,
+} from "../../keyboard"
 
 import { AllSymbolsRow } from "./AllSymbolsRow"
 import type { AllSymbolRowData } from "./allSymbolRowModel"
@@ -54,6 +59,8 @@ interface AllSymbolsVirtualRowProps {
   fundingIsLoading: boolean
   factorsIsLoading: boolean
   onSymbolClick: (symbol: string) => void
+  isSelected: boolean
+  onSelect: () => void
 }
 
 const AllSymbolsVirtualRow = (
@@ -78,6 +85,8 @@ const AllSymbolsVirtualRow = (
           fundingIsLoading={props.fundingIsLoading}
           factorsIsLoading={props.factorsIsLoading}
           onSymbolClick={props.onSymbolClick}
+          isSelected={props.isSelected}
+          onSelect={props.onSelect}
         />
       )}
     </Show>
@@ -113,6 +122,7 @@ export const AllSymbolsDataTable = (
   ])
   const [searchQuery, setSearchQuery] = createSignal("")
   let tableContainerRef!: HTMLDivElement
+  const keyboard = tryUsePortfolioKeyboardContext()
 
   const filteredData = createMemo(() =>
     filterAllSymbolRows(local.data(), searchQuery()),
@@ -196,7 +206,52 @@ export const AllSymbolsDataTable = (
     rowVirtualizer.scrollToOffset(0)
   })
 
+  // createEffect: keep keyboard order in sync with filtered/sorted rows
+  createEffect(() => {
+    const symbols = rows().map(row => row.original.symbol)
+    keyboard?.setAllSymbolOrder(symbols)
+    if (
+      keyboard?.focusedPanel() === "allSymbols" &&
+      keyboard.selectedAllSymbolsIndex() === null &&
+      symbols.length > 0
+    ) {
+      keyboard.setSelectedAllSymbolsIndex(0)
+    }
+  })
+
+  // createEffect: scroll selected virtual row into view
+  createEffect(() => {
+    if (keyboard?.focusedPanel() !== "allSymbols") {
+      return
+    }
+    const index = keyboard.selectedAllSymbolsIndex()
+    if (index === null) {
+      return
+    }
+    rowVirtualizer.scrollToIndex(index, { align: "auto" })
+  })
+
   const totalSize = () => rowVirtualizer.getTotalSize()
+
+  const isSymbolSelected = (symbol: string): boolean => {
+    if (keyboard?.focusedPanel() !== "allSymbols") {
+      return false
+    }
+    const index = keyboard.selectedAllSymbolsIndex()
+    if (index === null) {
+      return false
+    }
+    return rows()[index]?.original.symbol === symbol
+  }
+
+  const selectSymbol = (symbol: string) => {
+    const index = rows().findIndex(row => row.original.symbol === symbol)
+    if (index < 0) {
+      return
+    }
+    keyboard?.setSelectedAllSymbolsIndex(index)
+    keyboard?.setFocusedPanel("allSymbols")
+  }
 
   const paddingTop = () => {
     const items = virtualRows()
@@ -222,9 +277,13 @@ export const AllSymbolsDataTable = (
             onInput={event => {
               setSearchQuery(event.currentTarget.value)
             }}
-            class="h-7 pl-7 text-[11px]"
+            class="h-7 pl-7 pr-8 text-[11px]"
             aria-label="Search symbols"
+            {...{ [ALL_SYMBOLS_SEARCH_ATTR]: "" }}
           />
+          <kbd class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+            s
+          </kbd>
         </div>
       </div>
       <div
@@ -302,6 +361,10 @@ export const AllSymbolsDataTable = (
                     fundingIsLoading={local.fundingIsLoading}
                     factorsIsLoading={local.factorsIsLoading}
                     onSymbolClick={local.onSymbolClick}
+                    isSelected={isSymbolSelected(symbol)}
+                    onSelect={() => {
+                      selectSymbol(symbol)
+                    }}
                   />
                 )}
               </For>

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/crossAccountLeverage.test.ts
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/crossAccountLeverage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CROSS_ACCOUNT_LEVERAGE_MAX,
+  CROSS_ACCOUNT_LEVERAGE_MIN,
+  steppedCrossAccountLeverage,
+} from "./crossAccountLeverage"
+
+describe("steppedCrossAccountLeverage", () => {
+  it("steps by 0.1 and clamps to the account range", () => {
+    expect(steppedCrossAccountLeverage(1, 1)).toBe(1.1)
+    expect(steppedCrossAccountLeverage(1.1, -1)).toBe(1)
+    expect(steppedCrossAccountLeverage(CROSS_ACCOUNT_LEVERAGE_MAX, 1)).toBe(
+      CROSS_ACCOUNT_LEVERAGE_MAX,
+    )
+    expect(steppedCrossAccountLeverage(CROSS_ACCOUNT_LEVERAGE_MIN, -1)).toBe(
+      CROSS_ACCOUNT_LEVERAGE_MIN,
+    )
+  })
+})

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/crossAccountLeverage.ts
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/crossAccountLeverage.ts
@@ -1,0 +1,20 @@
+export const CROSS_ACCOUNT_LEVERAGE_MIN = 0.001
+export const CROSS_ACCOUNT_LEVERAGE_MAX = 5
+export const CROSS_ACCOUNT_LEVERAGE_STEP = 0.1
+
+/** Step account leverage by `deltaSteps` * STEP, clamped and rounded to the step grid. */
+export const steppedCrossAccountLeverage = (
+  current: number,
+  deltaSteps: number,
+): number => {
+  const unclamped =
+    Math.round(
+      (current + deltaSteps * CROSS_ACCOUNT_LEVERAGE_STEP) /
+        CROSS_ACCOUNT_LEVERAGE_STEP,
+    ) * CROSS_ACCOUNT_LEVERAGE_STEP
+
+  return Math.min(
+    CROSS_ACCOUNT_LEVERAGE_MAX,
+    Math.max(CROSS_ACCOUNT_LEVERAGE_MIN, unclamped),
+  )
+}

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/portfolioMetricVisibility.ts
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/portfolioMetricVisibility.ts
@@ -112,5 +112,5 @@ export const visiblePortfolioMetricColumns = (
   PORTFOLIO_METRIC_COLUMN_ORDER.filter(columnId => visibility[columnId])
 
 export const leverageEditorColumnSpan = (
-  visibleMetricColumns: PortfolioMetricColumnId[],
-): number => 3 + visibleMetricColumns.length
+  _visibleMetricColumns: PortfolioMetricColumnId[],
+): number => 3

--- a/frontend/src/pages/Portfolio/components/PositionsPanel/positions-data-table.tsx
+++ b/frontend/src/pages/Portfolio/components/PositionsPanel/positions-data-table.tsx
@@ -10,6 +10,7 @@ import {
   Show,
   createMemo,
   createSignal,
+  createEffect,
   splitProps,
   type Accessor,
   type JSX,
@@ -34,6 +35,7 @@ import {
   isPortfolioMetricColumnId,
   type PortfolioMetricColumnId,
 } from "./portfolioMetricVisibility"
+import { tryUsePortfolioKeyboardContext } from "../../keyboard"
 
 export interface PositionsTableMeta {
   currentPortfolio: Record<string, PortfolioInterface | undefined>
@@ -87,6 +89,14 @@ const PositionsTableBodyRow = (
   props: PositionsTableBodyRowProps,
 ): JSX.Element => {
   const row = createMemo(() => props.rowDataBySymbol().get(props.symbol))
+  const keyboard = tryUsePortfolioKeyboardContext()
+
+  const isSelected = () =>
+    keyboard?.focusedPanel() === "portfolio" &&
+    keyboard.selectedPortfolioSymbol() === props.symbol
+
+  const leverageEditorRequested = () =>
+    keyboard?.leverageEditorSymbol() === props.symbol
 
   return (
     <Show when={row()}>
@@ -130,6 +140,17 @@ const PositionsTableBodyRow = (
           symbolsDeltaBelowMinimum={props.meta.symbolsDeltaBelowMinimum}
           symbolDelta={resolvedRow().symbolDelta}
           rebalanceError={props.meta.errorsBySymbol[props.symbol]}
+          isSelected={isSelected()}
+          leverageEditorRequested={leverageEditorRequested()}
+          onSelect={() => {
+            keyboard?.setSelectedPortfolioSymbol(props.symbol)
+            keyboard?.setFocusedPanel("portfolio")
+          }}
+          onLeverageEditorClosed={() => {
+            if (keyboard?.leverageEditorSymbol() === props.symbol) {
+              keyboard.setLeverageEditorSymbol(null)
+            }
+          }}
         />
       )}
     </Show>
@@ -231,6 +252,21 @@ export const PositionsDataTable = (
     positionTableColumnIds(local.visibleMetricColumns)
   const rowSymbols = (): string[] =>
     displayRows().map(row => row.original.symbol)
+
+  const keyboard = tryUsePortfolioKeyboardContext()
+
+  // createEffect: keep keyboard navigation order in sync with displayed rows
+  createEffect(() => {
+    const symbols = rowSymbols()
+    keyboard?.setPortfolioSymbolOrder(symbols)
+    if (
+      keyboard?.focusedPanel() === "portfolio" &&
+      keyboard.selectedPortfolioSymbol() === null &&
+      symbols.length > 0
+    ) {
+      keyboard.setSelectedPortfolioSymbol(symbols[0] ?? null)
+    }
+  })
 
   return (
     <div class={cn("w-full", local.class)}>

--- a/frontend/src/pages/Portfolio/components/StagedChangesPanel.tsx
+++ b/frontend/src/pages/Portfolio/components/StagedChangesPanel.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createSignal } from "solid-js"
+import { For, Show, createSignal, createEffect, onCleanup } from "solid-js"
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import { cn } from "@/lib/cn"
@@ -14,6 +14,11 @@ import {
   normalizeWalletPinInput,
   WALLET_PIN_LENGTH,
 } from "@/services/walletCredentialCrypto"
+import {
+  PORTFOLIO_PANEL_ATTR,
+  STAGED_PIN_ATTR,
+  tryUsePortfolioKeyboardContext,
+} from "@/pages/Portfolio/keyboard"
 
 /** Mutually exclusive wallet/agent readiness for the staged-changes primary action. */
 export type StagedConnectionState =
@@ -60,6 +65,7 @@ export const StagedChangesPanel = (props: StagedChangesPanelProps) => {
   const [unlockError, setUnlockError] = createSignal<string | null>(null)
   const [isUnlocking, setIsUnlocking] = createSignal(false)
   let unlockPinInput: HTMLInputElement | undefined
+  const keyboard = tryUsePortfolioKeyboardContext()
 
   const stagedTrades = () => props.stagedTrades
   const hasStaged = () => stagedTrades().length > 0
@@ -69,6 +75,33 @@ export const StagedChangesPanel = (props: StagedChangesPanelProps) => {
   const connectionState = () => props.connectionState
 
   const showUnlockPinField = () => connectionState() === "agentLocked"
+
+  // createEffect: focus PIN when staged panel activates while agent is locked
+  createEffect(() => {
+    if (keyboard?.focusedPanel() !== "staged") {
+      return
+    }
+    if (!showUnlockPinField()) {
+      return
+    }
+    queueMicrotask(() => {
+      unlockPinInput?.focus()
+      unlockPinInput?.select()
+    })
+  })
+
+  // createEffect: register unlock submit for Cmd/Ctrl+Enter while agent locked
+  createEffect(() => {
+    if (!keyboard) {
+      return
+    }
+    keyboard.registerStagedUnlockSubmit(() => {
+      void submitUnlockPin()
+    })
+    onCleanup(() => {
+      keyboard.registerStagedUnlockSubmit(null)
+    })
+  })
 
   const primaryLabel = () => {
     if (isRebalancing()) {
@@ -161,7 +194,11 @@ export const StagedChangesPanel = (props: StagedChangesPanelProps) => {
   }
 
   return (
-    <div class="flex h-full min-h-0 w-full min-w-0 flex-col">
+    <div
+      class="flex h-full min-h-0 w-full min-w-0 flex-col outline-none"
+      tabIndex={0}
+      {...{ [PORTFOLIO_PANEL_ATTR]: "staged" }}
+    >
       <Show when={hasStaged() && props.onClearAll}>
         <div class="flex shrink-0 items-center justify-end border-b border-border/40 px-2 py-1">
           <button
@@ -342,6 +379,7 @@ export const StagedChangesPanel = (props: StagedChangesPanelProps) => {
                 unlockError() !== null ? UNLOCK_PIN_ERROR_ID : undefined
               }
               class="h-8 font-mono text-[11px] tracking-[0.25em] placeholder:tracking-normal placeholder:font-sans"
+              {...{ [STAGED_PIN_ATTR]: "" }}
               onAnimationEnd={event => {
                 event.currentTarget.classList.remove(PIN_SHAKE_CLASS)
               }}

--- a/frontend/src/pages/Portfolio/index.tsx
+++ b/frontend/src/pages/Portfolio/index.tsx
@@ -59,6 +59,21 @@ import {
   readPortfolioDockviewLayout,
   writePortfolioDockviewLayout,
 } from "./portfolioLayoutStorage"
+import {
+  PANEL_DIGIT_BY_ID,
+  PortfolioHotkeyBar,
+  PortfolioKeyboardContext,
+  PortfolioKeyboardProvider,
+  tryUsePortfolioKeyboardContext,
+  type KeyboardPanelId,
+  type PortfolioKeyboardActions,
+  usePortfolioKeyboardContext,
+} from "./keyboard"
+import { positionStatus } from "./components/PositionsPanel/positionRowModel"
+import {
+  allSymbolPortfolioState,
+  resolveAllSymbolClick,
+} from "./components/PositionsPanel/allSymbolRowModel"
 import "./portfolio-dockview.css"
 
 type PortfolioPanelId =
@@ -99,7 +114,7 @@ const panelCatalog: PanelCatalogEntry[] = [
     id: "allSymbols",
     title: "ALL SYMBOLS",
     component: "allSymbols",
-    tabComponent: "lockedTab",
+    tabComponent: "allSymbolsTab",
     closable: false,
   },
   {
@@ -113,7 +128,7 @@ const panelCatalog: PanelCatalogEntry[] = [
     id: "staged",
     title: "STAGED CHANGES",
     component: "staged",
-    tabComponent: "lockedTab",
+    tabComponent: "stagedTab",
     closable: false,
   },
   {
@@ -177,9 +192,47 @@ const useDockviewPanelTitle = (props: IDockviewPanelHeaderProps) => {
   return title
 }
 
-const LockedTab = (props: IDockviewPanelHeaderProps) => (
-  <DockviewDefaultTab {...props} hideClose />
-)
+const LockedTab = (props: IDockviewPanelHeaderProps) => {
+  const digit = () => {
+    const panelId = props.api.id
+    if (
+      panelId === "portfolio" ||
+      panelId === "allSymbols" ||
+      panelId === "staged"
+    ) {
+      return PANEL_DIGIT_BY_ID[panelId]
+    }
+    return undefined
+  }
+
+  return (
+    <Show when={digit()} fallback={<DockviewDefaultTab {...props} hideClose />}>
+      {resolvedDigit => (
+        <LockedTabWithDigit {...props} digit={resolvedDigit()} />
+      )}
+    </Show>
+  )
+}
+
+const LockedTabWithDigit = (
+  props: IDockviewPanelHeaderProps & { digit: string },
+) => {
+  const title = useDockviewPanelTitle(props)
+
+  return (
+    <div
+      data-testid="dockview-dv-default-tab"
+      class="dv-default-tab portfolio-dockview-tab"
+    >
+      <span class="dv-default-tab-content portfolio-dockview-tab-title">
+        {title()}
+      </span>
+      <kbd class="ml-1 rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+        {props.digit}
+      </kbd>
+    </div>
+  )
+}
 
 const ClosableTab = (props: IDockviewPanelHeaderProps) => (
   <DockviewDefaultTab {...props} />
@@ -280,12 +333,6 @@ const AddPanelMenu = (props: IDockviewHeaderActionsProps) => {
 }
 
 const PortfolioPage = () => {
-  const portfolioOwner = getOwner()
-  bindDockviewSolidOwner(portfolioOwner)
-  onCleanup(() => {
-    bindDockviewSolidOwner(null)
-  })
-
   const { isNetworkSwitching } = useNetwork()
   const { hasStoredSession, isLocked, canTrade, isConnected } = useWallet()
   const DockviewProviders = useDockviewPanelProviders()
@@ -407,15 +454,38 @@ const PortfolioPage = () => {
     })
   })
 
+  const KeyboardAwareDockviewProviders = (props: {
+    children: import("solid-js").JSX.Element
+  }) => {
+    const keyboard = tryUsePortfolioKeyboardContext()
+    return (
+      <DockviewProviders>
+        {keyboard ? (
+          <PortfolioKeyboardContext.Provider value={keyboard}>
+            {props.children}
+          </PortfolioKeyboardContext.Provider>
+        ) : (
+          props.children
+        )}
+      </DockviewProviders>
+    )
+  }
+
   const PortfolioTab = (props: IDockviewPanelHeaderProps) => {
     const title = useDockviewPanelTitle(props)
 
     return (
-      <DockviewProviders>
-        <div class="dv-default-tab portfolio-dockview-tab">
+      <KeyboardAwareDockviewProviders>
+        <div
+          data-testid="dockview-dv-default-tab"
+          class="dv-default-tab portfolio-dockview-tab"
+        >
           <span class="dv-default-tab-content portfolio-dockview-tab-title">
             {title()}
           </span>
+          <kbd class="ml-1 rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+            {PANEL_DIGIT_BY_ID.portfolio}
+          </kbd>
           <PortfolioSettingsMenu
             isPrecise={portfolio.isPrecise}
             onPreciseChange={value => {
@@ -429,13 +499,25 @@ const PortfolioPage = () => {
             onMetricVisibilityChange={setMetricColumnVisible}
           />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     )
   }
 
+  const AllSymbolsTab = (props: IDockviewPanelHeaderProps) => (
+    <KeyboardAwareDockviewProviders>
+      <LockedTabWithDigit {...props} digit={PANEL_DIGIT_BY_ID.allSymbols} />
+    </KeyboardAwareDockviewProviders>
+  )
+
+  const StagedTab = (props: IDockviewPanelHeaderProps) => (
+    <KeyboardAwareDockviewProviders>
+      <LockedTabWithDigit {...props} digit={PANEL_DIGIT_BY_ID.staged} />
+    </KeyboardAwareDockviewProviders>
+  )
+
   const panelComponents = {
     portfolio: (_props: IDockviewPanelProps) => (
-      <DockviewProviders>
+      <KeyboardAwareDockviewProviders>
         <div class="portfolio-dockview-panel-body">
           <PositionsPanel
             currentPortfolio={portfolio.currentPortfolio}
@@ -477,10 +559,10 @@ const PortfolioPage = () => {
             }
           />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     ),
     allSymbols: (_props: IDockviewPanelProps) => (
-      <DockviewProviders>
+      <KeyboardAwareDockviewProviders>
         <div class="portfolio-dockview-panel-body">
           <AllSymbolsPanel
             screenerSymbols={screenerSymbols}
@@ -494,17 +576,17 @@ const PortfolioPage = () => {
             onAddSymbol={portfolio.handleAddToken}
           />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     ),
     performance: (_props: IDockviewPanelProps) => (
-      <DockviewProviders>
+      <KeyboardAwareDockviewProviders>
         <div class="portfolio-dockview-panel-body">
           <PerformancePanel />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     ),
     staged: (_props: IDockviewPanelProps) => (
-      <DockviewProviders>
+      <KeyboardAwareDockviewProviders>
         <div class="portfolio-dockview-panel-body">
           <StagedChangesPanel
             stagedTrades={portfolio.stagedTrades}
@@ -520,10 +602,10 @@ const PortfolioPage = () => {
             onClearAll={portfolio.handleResetToCurrent}
           />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     ),
     factors: (_props: IDockviewPanelProps) => (
-      <DockviewProviders>
+      <KeyboardAwareDockviewProviders>
         <div class="portfolio-dockview-panel-body">
           <FactorsPanel
             beta={betaResult.beta}
@@ -535,14 +617,14 @@ const PortfolioPage = () => {
             betaMethodology={betaResult.methodology}
           />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     ),
     risk: (_props: IDockviewPanelProps) => (
-      <DockviewProviders>
+      <KeyboardAwareDockviewProviders>
         <div class="portfolio-dockview-panel-body">
           <RiskPanel />
         </div>
-      </DockviewProviders>
+      </KeyboardAwareDockviewProviders>
     ),
   }
 
@@ -560,7 +642,7 @@ const PortfolioPage = () => {
     api.addPanel({
       id: "allSymbols",
       component: "allSymbols",
-      tabComponent: "lockedTab",
+      tabComponent: "allSymbolsTab",
       title: "ALL SYMBOLS",
       position: { referencePanel: "portfolio", direction: "within" },
     })
@@ -576,7 +658,7 @@ const PortfolioPage = () => {
     const stagedPanel = api.addPanel({
       id: "staged",
       component: "staged",
-      tabComponent: "lockedTab",
+      tabComponent: "stagedTab",
       title: "STAGED CHANGES",
       position: { referencePanel: "performance", direction: "below" },
     })
@@ -648,83 +730,193 @@ const PortfolioPage = () => {
       writePortfolioDockviewLayout(event.api.toJSON())
     })
     layoutChangeDisposable = layoutChange
+
+    const activeChange = event.api.onDidActivePanelChange(panel => {
+      const panelId = panel?.id
+      if (
+        panelId === "portfolio" ||
+        panelId === "allSymbols" ||
+        panelId === "staged"
+      ) {
+        keyboardBridge?.onPanelActivated(panelId)
+      }
+    })
+    activePanelChangeDisposable = activeChange
   }
 
   onCleanup(() => {
     layoutChangeDisposable?.dispose()
+    activePanelChangeDisposable?.dispose()
   })
 
-  return (
-    <>
-      <header class="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-3 py-1.5">
-        <div class="flex items-center gap-5">
-          <span class="font-semibold">Moneymentum</span>
-          <div class="h-4 border-l border-border" />
-          <WalletHeader
-            handleDisconnect={portfolio.handleDisconnect}
-            handleNetworkSwitch={portfolio.resetPortfolioStateForNetworkChange}
-          />
-          <div class="h-4 border-l border-border" />
-          <div class="flex gap-1.5">
-            <span class="text-muted-foreground">NAV</span>
-            <span class="font-mono">${portfolio.accountValue.toFixed(2)}</span>
-          </div>
-          <div class="flex gap-1.5">
-            <span class="text-muted-foreground">Notional</span>
-            <span class="font-mono">
-              ${portfolio.targetTotalNotional.toFixed(2)}
-            </span>
-          </div>
-          <span class="text-muted-foreground">coming soon...</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-muted-foreground">Δ</span>
-          <span class="font-mono">coming soon...</span>
-          <span class="text-muted-foreground">Γ</span>
-          <span class="font-mono">coming soon...</span>
-          <span class="text-muted-foreground">Θ</span>
-          <span class="font-mono">coming soon...</span>
-          <div class="h-4 border-l border-border" />
-          <span class="text-muted-foreground">VaR</span>
-          <span class="font-mono text-red-400">coming soon...</span>
-          <ModeToggle />
-          <kbd
-            class="cursor-pointer rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] hover:bg-muted/80"
-            onClick={() => {
-              alert("coming soon...")
-            }}
-          >
-            ?
-          </kbd>
-        </div>
-      </header>
+  const keyboardActions = (): PortfolioKeyboardActions => ({
+    activatePanel: (panelId: KeyboardPanelId) => {
+      dockviewApi?.getPanel(panelId)?.api.setActive()
+    },
+    getPortfolioSymbols: () =>
+      Object.keys({
+        ...portfolio.currentPortfolio,
+        ...portfolio.targetPortfolio,
+      }),
+    getAllSymbolSymbols: () => screenerSymbols(),
+    isPinDialogOpen: () => pinDialogOpen(),
+    connectionState: () => stagedConnectionState(),
+    onRemove: portfolio.handleRemoveToken,
+    onUndoRemove: portfolio.handleUndoRemoveToken,
+    onSideChange: portfolio.handleSideChange,
+    onLeverageChange: portfolio.handleLeverageChange,
+    getPositionSide: symbol =>
+      (
+        portfolio.targetPortfolio[symbol] ??
+        portfolio.deletedArchive[symbol] ??
+        portfolio.currentPortfolio[symbol]
+      )?.side,
+    getPositionLeverage: symbol =>
+      (
+        portfolio.targetPortfolio[symbol] ??
+        portfolio.deletedArchive[symbol] ??
+        portfolio.currentPortfolio[symbol]
+      )?.leverage,
+    getMaxLeverage: symbol => portfolio.leverageLimitsMap[symbol],
+    getCrossAccountLeverage: () => portfolio.targetCrossAccountLeverage,
+    onCrossAccountLeverageChange: portfolio.handleCrossAccountLeverageChange,
+    isPositionClosing: symbol =>
+      positionStatus(
+        symbol,
+        portfolio.currentPortfolio,
+        portfolio.targetPortfolio,
+      ) === "closing",
+    onAllSymbolEnter: symbol => {
+      const action = resolveAllSymbolClick(
+        allSymbolPortfolioState(
+          symbol,
+          portfolio.targetPortfolio,
+          portfolio.deletedArchive,
+        ),
+      )
+      if (action === "remove") {
+        portfolio.handleRemoveToken(symbol)
+        return
+      }
+      if (action === "undoRemove") {
+        portfolio.handleUndoRemoveToken(symbol)
+        return
+      }
+      portfolio.handleAddToken(symbol)
+    },
+    onStagedSubmit: handlePrimaryStagedAction,
+    onStagedClearAll: portfolio.handleResetToCurrent,
+    onOpenWalletPinDialog: () => {
+      setPinDialogOpen(true)
+    },
+  })
 
-      <div
-        ref={dockviewContainer}
-        class={cn(
-          "portfolio-dockview-shell min-h-0 flex-1 p-1",
-          isNetworkSwitching() && "pointer-events-none opacity-50",
-        )}
-      >
-        <DockviewSolid
-          theme={portfolioDockviewTheme}
-          components={panelComponents}
-          tabComponents={{
-            portfolioTab: PortfolioTab,
-            lockedTab: LockedTab,
-            closableTab: ClosableTab,
-          }}
-          rightHeaderActionsComponent={AddPanelMenu}
-          onReady={handleReady}
+  let keyboardBridge: ReturnType<typeof usePortfolioKeyboardContext> | undefined
+  let activePanelChangeDisposable: { dispose: () => void } | undefined
+
+  const KeyboardBridge = () => {
+    keyboardBridge = usePortfolioKeyboardContext()
+    return null
+  }
+
+  const HotkeyBarHost = () => {
+    const keyboard = usePortfolioKeyboardContext()
+    return <PortfolioHotkeyBar focusedPanel={keyboard.focusedPanel()} />
+  }
+
+  /** Bind dockview portals under the keyboard provider owner so panels see hotkeys. */
+  const DockviewOwnerBinder = () => {
+    const owner = getOwner()
+    bindDockviewSolidOwner(owner)
+    onCleanup(() => {
+      bindDockviewSolidOwner(null)
+    })
+    return null
+  }
+
+  return (
+    <PortfolioKeyboardProvider actions={keyboardActions()}>
+      <DockviewOwnerBinder />
+      <KeyboardBridge />
+      <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <header class="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-3 py-1.5">
+          <div class="flex items-center gap-5">
+            <span class="font-semibold">Moneymentum</span>
+            <div class="h-4 border-l border-border" />
+            <WalletHeader
+              handleDisconnect={portfolio.handleDisconnect}
+              handleNetworkSwitch={
+                portfolio.resetPortfolioStateForNetworkChange
+              }
+            />
+            <div class="h-4 border-l border-border" />
+            <div class="flex gap-1.5">
+              <span class="text-muted-foreground">NAV</span>
+              <span class="font-mono">
+                ${portfolio.accountValue.toFixed(2)}
+              </span>
+            </div>
+            <div class="flex gap-1.5">
+              <span class="text-muted-foreground">Notional</span>
+              <span class="font-mono">
+                ${portfolio.targetTotalNotional.toFixed(2)}
+              </span>
+            </div>
+            <span class="text-muted-foreground">coming soon...</span>
+          </div>
+          <div class="flex items-center gap-4">
+            <span class="text-muted-foreground">Δ</span>
+            <span class="font-mono">coming soon...</span>
+            <span class="text-muted-foreground">Γ</span>
+            <span class="font-mono">coming soon...</span>
+            <span class="text-muted-foreground">Θ</span>
+            <span class="font-mono">coming soon...</span>
+            <div class="h-4 border-l border-border" />
+            <span class="text-muted-foreground">VaR</span>
+            <span class="font-mono text-red-400">coming soon...</span>
+            <ModeToggle />
+            <kbd
+              class="cursor-pointer rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] hover:bg-muted/80"
+              onClick={() => {
+                alert("coming soon...")
+              }}
+            >
+              ?
+            </kbd>
+          </div>
+        </header>
+
+        <div
+          ref={dockviewContainer}
+          class={cn(
+            "portfolio-dockview-shell min-h-0 flex-1 p-1",
+            isNetworkSwitching() && "pointer-events-none opacity-50",
+          )}
+        >
+          <DockviewSolid
+            theme={portfolioDockviewTheme}
+            components={panelComponents}
+            tabComponents={{
+              portfolioTab: PortfolioTab,
+              lockedTab: LockedTab,
+              allSymbolsTab: AllSymbolsTab,
+              stagedTab: StagedTab,
+              closableTab: ClosableTab,
+            }}
+            rightHeaderActionsComponent={AddPanelMenu}
+            onReady={handleReady}
+          />
+        </div>
+
+        <HotkeyBarHost />
+
+        <WalletPinDialog
+          open={pinDialogOpen()}
+          mode="authorize"
+          onOpenChange={setPinDialogOpen}
         />
       </div>
-
-      <WalletPinDialog
-        open={pinDialogOpen()}
-        mode="authorize"
-        onOpenChange={setPinDialogOpen}
-      />
-    </>
+    </PortfolioKeyboardProvider>
   )
 }
 

--- a/frontend/src/pages/Portfolio/keyboard/PortfolioHotkeyBar.tsx
+++ b/frontend/src/pages/Portfolio/keyboard/PortfolioHotkeyBar.tsx
@@ -1,0 +1,40 @@
+import { For, Show, type JSX } from "solid-js"
+
+import { cn } from "@/lib/cn"
+
+import { hotkeyHintsForPanel, type KeyboardPanelId } from "./hotkeyHints"
+
+interface PortfolioHotkeyBarProps {
+  focusedPanel: KeyboardPanelId
+  class?: string
+}
+
+export const PortfolioHotkeyBar = (
+  props: PortfolioHotkeyBarProps,
+): JSX.Element => {
+  const hints = () => hotkeyHintsForPanel(props.focusedPanel)
+
+  return (
+    <div
+      class={cn(
+        "flex h-7 shrink-0 items-center gap-3 overflow-x-auto border-t border-border bg-muted/30 px-3 text-[10px] text-muted-foreground",
+        props.class,
+      )}
+      data-testid="portfolio-hotkey-bar"
+      aria-label="Keyboard shortcuts"
+    >
+      <Show when={hints().length > 0}>
+        <For each={hints()}>
+          {hint => (
+            <span class="inline-flex shrink-0 items-center gap-1 whitespace-nowrap">
+              <kbd class="rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-foreground">
+                {hint.keys}
+              </kbd>
+              <span>{hint.description}</span>
+            </span>
+          )}
+        </For>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/pages/Portfolio/keyboard/hotkeyHints.test.ts
+++ b/frontend/src/pages/Portfolio/keyboard/hotkeyHints.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { hotkeyHintsForPanel, panelIdForDigitKey } from "./hotkeyHints"
+import { modifierKeyLabel } from "./modifierLabel"
+
+describe("hotkeyHints", () => {
+  it("maps digits to fixed panel ids", () => {
+    expect(panelIdForDigitKey("1")).toBe("portfolio")
+    expect(panelIdForDigitKey("2")).toBe("allSymbols")
+    expect(panelIdForDigitKey("3")).toBe("staged")
+    expect(panelIdForDigitKey("9")).toBeUndefined()
+  })
+
+  it("returns portfolio hints including edit keys", () => {
+    const hints = hotkeyHintsForPanel("portfolio")
+    const keys = hints.map(hint => hint.keys)
+    expect(keys).toContain("j/k")
+    expect(keys).toContain("w")
+    expect(keys).toContain("n")
+    expect(keys).toContain("t")
+    expect(keys).toContain("l")
+    expect(keys).toContain("d")
+    expect(keys).toContain("Shift+[ ]")
+  })
+
+  it("returns staged hints with platform modifier", () => {
+    const mod = modifierKeyLabel()
+    const hints = hotkeyHintsForPanel("staged")
+    expect(hints.some(hint => hint.keys.includes(`${mod}+Enter`))).toBe(true)
+    expect(
+      hints.some(hint => hint.keys.includes(`${mod}+Shift+Backspace`)),
+    ).toBe(true)
+  })
+})
+
+describe("modifierKeyLabel", () => {
+  it("returns Cmd glyph on Mac-like platforms", () => {
+    vi.stubGlobal("navigator", {
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X)",
+    })
+    expect(modifierKeyLabel()).toBe("⌘")
+    vi.unstubAllGlobals()
+  })
+
+  it("returns Ctrl on non-Mac platforms", () => {
+    vi.stubGlobal("navigator", { userAgent: "Mozilla/5.0 (Windows NT 10.0)" })
+    expect(modifierKeyLabel()).toBe("Ctrl")
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/src/pages/Portfolio/keyboard/hotkeyHints.ts
+++ b/frontend/src/pages/Portfolio/keyboard/hotkeyHints.ts
@@ -1,0 +1,61 @@
+import { modifierKeyLabel } from "./modifierLabel"
+
+export type KeyboardPanelId = "portfolio" | "allSymbols" | "staged"
+
+export interface HotkeyHint {
+  keys: string
+  description: string
+}
+
+export const PANEL_DIGIT_BY_ID: Record<KeyboardPanelId, string> = {
+  portfolio: "1",
+  allSymbols: "2",
+  staged: "3",
+}
+
+export const panelIdForDigitKey = (
+  key: string,
+): KeyboardPanelId | undefined => {
+  switch (key) {
+    case "1":
+      return "portfolio"
+    case "2":
+      return "allSymbols"
+    case "3":
+      return "staged"
+    default:
+      return undefined
+  }
+}
+
+export const hotkeyHintsForPanel = (panelId: KeyboardPanelId): HotkeyHint[] => {
+  const mod = modifierKeyLabel()
+
+  switch (panelId) {
+    case "portfolio":
+      return [
+        { keys: "j/k", description: "move" },
+        { keys: "w", description: "weight" },
+        { keys: "n", description: "notional" },
+        { keys: "t", description: "side" },
+        { keys: "l", description: "leverage" },
+        { keys: "d", description: "delete" },
+        { keys: "[ ]", description: "step lev" },
+        { keys: "Shift+[ ]", description: "acct lev" },
+      ]
+    case "allSymbols":
+      return [
+        { keys: "j/k", description: "move" },
+        { keys: "Enter", description: "add/remove" },
+        { keys: "s", description: "search" },
+      ]
+    case "staged":
+      return [
+        { keys: `${mod}+Enter`, description: "rebalance" },
+        {
+          keys: `${mod}+Shift+Backspace`,
+          description: "clear all",
+        },
+      ]
+  }
+}

--- a/frontend/src/pages/Portfolio/keyboard/index.ts
+++ b/frontend/src/pages/Portfolio/keyboard/index.ts
@@ -1,0 +1,33 @@
+export {
+  hotkeyHintsForPanel,
+  PANEL_DIGIT_BY_ID,
+  panelIdForDigitKey,
+} from "./hotkeyHints"
+export type { HotkeyHint, KeyboardPanelId } from "./hotkeyHints"
+export { PortfolioHotkeyBar } from "./PortfolioHotkeyBar"
+export {
+  isEditableKeyboardTarget,
+  isKeyboardSuppressed,
+} from "./isKeyboardSuppressed"
+export { isPrimaryModifierPressed, modifierKeyLabel } from "./modifierLabel"
+export {
+  ALL_SYMBOLS_SEARCH_ATTR,
+  PORTFOLIO_CELL_ATTR,
+  PORTFOLIO_PANEL_ATTR,
+  PORTFOLIO_SYMBOL_ATTR,
+  STAGED_PANEL_ATTR,
+  STAGED_PIN_ATTR,
+  blurActiveElement,
+  focusAllSymbolsSearch,
+  focusPanelContainer,
+  focusPortfolioCell,
+  focusStagedPin,
+} from "./portfolioCellFocus"
+export type { PortfolioCellKind } from "./portfolioCellFocus"
+export {
+  PortfolioKeyboardContext,
+  PortfolioKeyboardProvider,
+  tryUsePortfolioKeyboardContext,
+  usePortfolioKeyboardContext,
+} from "./usePortfolioKeyboard"
+export type { PortfolioKeyboardActions } from "./usePortfolioKeyboard"

--- a/frontend/src/pages/Portfolio/keyboard/isKeyboardSuppressed.test.ts
+++ b/frontend/src/pages/Portfolio/keyboard/isKeyboardSuppressed.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isEditableKeyboardTarget,
+  isKeyboardSuppressed,
+} from "./isKeyboardSuppressed"
+
+describe("isEditableKeyboardTarget", () => {
+  it("detects input textarea select and contenteditable", () => {
+    const input = document.createElement("input")
+    const textarea = document.createElement("textarea")
+    const select = document.createElement("select")
+    const editable = document.createElement("div")
+    editable.contentEditable = "true"
+    const plain = document.createElement("div")
+
+    expect(isEditableKeyboardTarget(input)).toBe(true)
+    expect(isEditableKeyboardTarget(textarea)).toBe(true)
+    expect(isEditableKeyboardTarget(select)).toBe(true)
+    expect(isEditableKeyboardTarget(editable)).toBe(true)
+    expect(isEditableKeyboardTarget(plain)).toBe(false)
+    expect(isEditableKeyboardTarget(null)).toBe(false)
+  })
+})
+
+describe("isKeyboardSuppressed", () => {
+  it("suppresses when pin dialog is open", () => {
+    expect(
+      isKeyboardSuppressed({
+        eventTarget: document.createElement("div"),
+        isPinDialogOpen: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("suppresses when focus is in an input", () => {
+    expect(
+      isKeyboardSuppressed({
+        eventTarget: document.createElement("input"),
+        isPinDialogOpen: false,
+      }),
+    ).toBe(true)
+  })
+
+  it("allows when focus is on a plain element", () => {
+    expect(
+      isKeyboardSuppressed({
+        eventTarget: document.createElement("div"),
+        isPinDialogOpen: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/frontend/src/pages/Portfolio/keyboard/isKeyboardSuppressed.ts
+++ b/frontend/src/pages/Portfolio/keyboard/isKeyboardSuppressed.ts
@@ -1,0 +1,31 @@
+import { isPositionCellInput } from "../components/PositionsPanel/positionCellInput"
+
+export const isEditableKeyboardTarget = (
+  target: EventTarget | null,
+): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  if (isPositionCellInput(target)) {
+    return true
+  }
+
+  const tagName = target.tagName
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+    return true
+  }
+
+  return target.isContentEditable
+}
+
+export const isKeyboardSuppressed = (options: {
+  eventTarget: EventTarget | null
+  isPinDialogOpen: boolean
+}): boolean => {
+  if (options.isPinDialogOpen) {
+    return true
+  }
+
+  return isEditableKeyboardTarget(options.eventTarget)
+}

--- a/frontend/src/pages/Portfolio/keyboard/modifierLabel.ts
+++ b/frontend/src/pages/Portfolio/keyboard/modifierLabel.ts
@@ -1,0 +1,19 @@
+export const modifierKeyLabel = (): "⌘" | "Ctrl" => {
+  if (typeof navigator === "undefined") {
+    return "Ctrl"
+  }
+
+  const userAgent = navigator.userAgent.toLowerCase()
+  if (
+    userAgent.includes("mac") ||
+    userAgent.includes("iphone") ||
+    userAgent.includes("ipad")
+  ) {
+    return "⌘"
+  }
+
+  return "Ctrl"
+}
+
+export const isPrimaryModifierPressed = (event: KeyboardEvent): boolean =>
+  event.metaKey || event.ctrlKey

--- a/frontend/src/pages/Portfolio/keyboard/portfolioCellFocus.ts
+++ b/frontend/src/pages/Portfolio/keyboard/portfolioCellFocus.ts
@@ -1,0 +1,61 @@
+export const PORTFOLIO_CELL_ATTR = "data-portfolio-cell"
+export const PORTFOLIO_SYMBOL_ATTR = "data-portfolio-symbol"
+export const PORTFOLIO_PANEL_ATTR = "data-portfolio-panel"
+export const ALL_SYMBOLS_SEARCH_ATTR = "data-all-symbols-search"
+export const STAGED_PANEL_ATTR = "data-staged-panel"
+export const STAGED_PIN_ATTR = "data-staged-pin"
+
+export type PortfolioCellKind = "weight" | "notional"
+
+export const focusPortfolioCell = (
+  symbol: string,
+  cell: PortfolioCellKind,
+): boolean => {
+  const selector = `input[${PORTFOLIO_CELL_ATTR}="${cell}"][${PORTFOLIO_SYMBOL_ATTR}="${CSS.escape(symbol)}"]`
+  const input = document.querySelector(selector)
+  if (!(input instanceof HTMLInputElement)) {
+    return false
+  }
+
+  input.focus()
+  input.select()
+  return true
+}
+
+export const focusPanelContainer = (panelId: string): void => {
+  const container = document.querySelector(
+    `[${PORTFOLIO_PANEL_ATTR}="${CSS.escape(panelId)}"]`,
+  )
+  if (container instanceof HTMLElement) {
+    container.focus()
+  }
+}
+
+export const focusAllSymbolsSearch = (): boolean => {
+  const input = document.querySelector(`[${ALL_SYMBOLS_SEARCH_ATTR}]`)
+  if (!(input instanceof HTMLInputElement)) {
+    return false
+  }
+
+  input.focus()
+  input.select()
+  return true
+}
+
+export const focusStagedPin = (): boolean => {
+  const input = document.querySelector(`[${STAGED_PIN_ATTR}]`)
+  if (!(input instanceof HTMLInputElement)) {
+    return false
+  }
+
+  input.focus()
+  input.select()
+  return true
+}
+
+export const blurActiveElement = (): void => {
+  const active = document.activeElement
+  if (active instanceof HTMLElement) {
+    active.blur()
+  }
+}

--- a/frontend/src/pages/Portfolio/keyboard/portfolioKeyboardWorkflow.test.tsx
+++ b/frontend/src/pages/Portfolio/keyboard/portfolioKeyboardWorkflow.test.tsx
@@ -1,0 +1,412 @@
+/**
+ * Portfolio keyboard workflow tests (acceptance gate).
+ *
+ * Exercises the keyboard controller with a mocked Dockview activate callback
+ * and light panel DOM, without mounting the full Dockview shell.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, cleanup, fireEvent } from "@solidjs/testing-library"
+import { createSignal, For, type JSX } from "solid-js"
+
+import {
+  PortfolioHotkeyBar,
+  PortfolioKeyboardProvider,
+  PORTFOLIO_CELL_ATTR,
+  PORTFOLIO_PANEL_ATTR,
+  PORTFOLIO_SYMBOL_ATTR,
+  ALL_SYMBOLS_SEARCH_ATTR,
+  STAGED_PIN_ATTR,
+  usePortfolioKeyboardContext,
+  type PortfolioKeyboardActions,
+  type KeyboardPanelId,
+} from "./index"
+import type { StagedConnectionState } from "../components/StagedChangesPanel"
+import type { OrderSide } from "@/hooks/useTrading"
+
+const activatePanel = vi.fn<(panelId: KeyboardPanelId) => void>()
+const onRemove = vi.fn()
+const onUndoRemove = vi.fn()
+const onSideChange = vi.fn()
+const onLeverageChange = vi.fn()
+const onCrossAccountLeverageChange = vi.fn()
+const onAllSymbolEnter = vi.fn()
+const onStagedSubmit = vi.fn()
+const onStagedClearAll = vi.fn()
+const onOpenWalletPinDialog = vi.fn()
+
+const [pinDialogOpen, setPinDialogOpen] = createSignal(false)
+const [connectionState, setConnectionState] =
+  createSignal<StagedConnectionState>("ready")
+const [portfolioSymbols, setPortfolioSymbols] = createSignal([
+  "BTC",
+  "ETH",
+  "SOL",
+])
+const [allSymbols, setAllSymbols] = createSignal(["BTC", "ETH", "SOL", "DOGE"])
+const [sides, setSides] = createSignal<Record<string, OrderSide>>({
+  BTC: "buy",
+  ETH: "buy",
+  SOL: "sell",
+})
+const [leverages, setLeverages] = createSignal<Record<string, number>>({
+  BTC: 2,
+  ETH: 3,
+  SOL: 1,
+})
+const [crossAccountLeverage, setCrossAccountLeverage] = createSignal(1)
+const [closing, setClosing] = createSignal<Record<string, boolean>>({})
+
+const buildActions = (): PortfolioKeyboardActions => ({
+  activatePanel: panelId => {
+    activatePanel(panelId)
+  },
+  getPortfolioSymbols: () => portfolioSymbols(),
+  getAllSymbolSymbols: () => allSymbols(),
+  isPinDialogOpen: () => pinDialogOpen(),
+  connectionState: () => connectionState(),
+  onRemove,
+  onUndoRemove,
+  onSideChange,
+  onLeverageChange,
+  getPositionSide: symbol => sides()[symbol],
+  getPositionLeverage: symbol => leverages()[symbol],
+  getMaxLeverage: () => 20,
+  getCrossAccountLeverage: () => crossAccountLeverage(),
+  onCrossAccountLeverageChange: leverage => {
+    setCrossAccountLeverage(leverage)
+    onCrossAccountLeverageChange(leverage)
+  },
+  isPositionClosing: symbol => closing()[symbol] ?? false,
+  onAllSymbolEnter,
+  onStagedSubmit,
+  onStagedClearAll,
+  onOpenWalletPinDialog,
+})
+
+const SelectionProbe = () => {
+  const keyboard = usePortfolioKeyboardContext()
+  return (
+    <div>
+      <div data-testid="focused-panel">{keyboard.focusedPanel()}</div>
+      <div data-testid="selected-symbol">
+        {keyboard.selectedPortfolioSymbol() ?? "none"}
+      </div>
+      <div data-testid="selected-all-index">
+        {keyboard.selectedAllSymbolsIndex() ?? "none"}
+      </div>
+      <div data-testid="leverage-symbol">
+        {keyboard.leverageEditorSymbol() ?? "none"}
+      </div>
+      <PortfolioHotkeyBar focusedPanel={keyboard.focusedPanel()} />
+    </div>
+  )
+}
+
+const Harness = (props: { children?: JSX.Element }) => (
+  <PortfolioKeyboardProvider actions={buildActions()}>
+    <div
+      tabIndex={0}
+      {...{ [PORTFOLIO_PANEL_ATTR]: "portfolio" }}
+      data-testid="portfolio-panel"
+    >
+      <For each={portfolioSymbols()}>
+        {symbol => (
+          <div data-portfolio-row={symbol}>
+            <input
+              {...{
+                [PORTFOLIO_CELL_ATTR]: "weight",
+                [PORTFOLIO_SYMBOL_ATTR]: symbol,
+              }}
+              defaultValue="10"
+              aria-label={`${symbol} weight`}
+            />
+            <input
+              {...{
+                [PORTFOLIO_CELL_ATTR]: "notional",
+                [PORTFOLIO_SYMBOL_ATTR]: symbol,
+              }}
+              defaultValue="100"
+              aria-label={`${symbol} notional`}
+            />
+          </div>
+        )}
+      </For>
+    </div>
+    <div
+      tabIndex={0}
+      {...{ [PORTFOLIO_PANEL_ATTR]: "allSymbols" }}
+      data-testid="all-symbols-panel"
+    >
+      <input
+        {...{ [ALL_SYMBOLS_SEARCH_ATTR]: "" }}
+        aria-label="Search symbols"
+        defaultValue=""
+      />
+    </div>
+    <div
+      tabIndex={0}
+      {...{ [PORTFOLIO_PANEL_ATTR]: "staged" }}
+      data-testid="staged-panel"
+    >
+      <input
+        {...{ [STAGED_PIN_ATTR]: "" }}
+        aria-label="Enter PIN"
+        defaultValue=""
+      />
+    </div>
+    <SelectionProbe />
+    {props.children}
+  </PortfolioKeyboardProvider>
+)
+
+describe("portfolio keyboard workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setPinDialogOpen(false)
+    setConnectionState("ready")
+    setPortfolioSymbols(["BTC", "ETH", "SOL"])
+    setAllSymbols(["BTC", "ETH", "SOL", "DOGE"])
+    setSides({ BTC: "buy", ETH: "buy", SOL: "sell" })
+    setLeverages({ BTC: 2, ETH: 3, SOL: 1 })
+    setCrossAccountLeverage(1)
+    setClosing({})
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("activates panels with 1 2 3 and ignores repeat", () => {
+    render(() => <Harness />)
+
+    fireEvent.keyDown(window, { key: "2" })
+    expect(activatePanel).toHaveBeenCalledWith("allSymbols")
+    expect(screen.getByTestId("focused-panel").textContent).toBe("allSymbols")
+
+    activatePanel.mockClear()
+    fireEvent.keyDown(window, { key: "2" })
+    expect(activatePanel).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(window, { key: "3" })
+    expect(activatePanel).toHaveBeenCalledWith("staged")
+    expect(screen.getByTestId("focused-panel").textContent).toBe("staged")
+
+    fireEvent.keyDown(window, { key: "1" })
+    expect(activatePanel).toHaveBeenCalledWith("portfolio")
+  })
+
+  it("navigates portfolio rows with j/k and restores selection", () => {
+    render(() => <Harness />)
+
+    fireEvent.keyDown(window, { key: "j" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("BTC")
+
+    fireEvent.keyDown(window, { key: "j" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("ETH")
+
+    fireEvent.keyDown(window, { key: "k" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("BTC")
+
+    fireEvent.keyDown(window, { key: "j" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("ETH")
+
+    fireEvent.keyDown(window, { key: "2" })
+    fireEvent.keyDown(window, { key: "1" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("ETH")
+  })
+
+  it("focuses weight and notional with w and n", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "j" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("BTC")
+
+    fireEvent.keyDown(window, { key: "w" })
+    expect(document.activeElement).toBe(screen.getByLabelText("BTC weight"))
+
+    fireEvent.keyDown(screen.getByLabelText("BTC weight"), { key: "Escape" })
+    fireEvent.keyDown(window, { key: "n" })
+    expect(document.activeElement).toBe(screen.getByLabelText("BTC notional"))
+  })
+
+  it("suppresses panel digits while an input is focused", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "j" })
+    fireEvent.keyDown(window, { key: "w" })
+    activatePanel.mockClear()
+
+    fireEvent.keyDown(screen.getByLabelText("BTC weight"), { key: "2" })
+    expect(activatePanel).not.toHaveBeenCalled()
+    expect(screen.getByTestId("focused-panel").textContent).toBe("portfolio")
+  })
+
+  it("toggles side with t and delete with d", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "j" })
+    fireEvent.keyDown(window, { key: "t" })
+    expect(onSideChange).toHaveBeenCalledWith("BTC", "sell")
+
+    fireEvent.keyDown(window, { key: "d" })
+    expect(onRemove).toHaveBeenCalledWith("BTC")
+
+    setClosing({ BTC: true })
+    fireEvent.keyDown(window, { key: "d" })
+    expect(onUndoRemove).toHaveBeenCalledWith("BTC")
+  })
+
+  it("opens leverage with l and steps with brackets", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "j" })
+    fireEvent.keyDown(window, { key: "l" })
+    expect(screen.getByTestId("leverage-symbol").textContent).toBe("BTC")
+
+    fireEvent.keyDown(window, { key: "]" })
+    expect(onLeverageChange).toHaveBeenCalledWith("BTC", 3)
+
+    fireEvent.keyDown(window, { key: "Escape" })
+    expect(screen.getByTestId("leverage-symbol").textContent).toBe("none")
+  })
+
+  it("steps cross-account leverage with Shift+brackets", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "1" })
+
+    fireEvent.keyDown(window, {
+      key: "}",
+      code: "BracketRight",
+      shiftKey: true,
+    })
+    expect(onCrossAccountLeverageChange).toHaveBeenCalledWith(1.1)
+
+    fireEvent.keyDown(window, {
+      key: "{",
+      code: "BracketLeft",
+      shiftKey: true,
+    })
+    expect(onCrossAccountLeverageChange).toHaveBeenCalledWith(1)
+
+    setPortfolioSymbols([])
+    onCrossAccountLeverageChange.mockClear()
+    fireEvent.keyDown(window, {
+      key: "}",
+      code: "BracketRight",
+      shiftKey: true,
+    })
+    expect(onCrossAccountLeverageChange).toHaveBeenCalledWith(1.1)
+  })
+
+  it("navigates all symbols and Enter toggles", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "2" })
+    expect(screen.getByTestId("selected-all-index").textContent).toBe("0")
+
+    fireEvent.keyDown(window, { key: "j" })
+    expect(screen.getByTestId("selected-all-index").textContent).toBe("1")
+
+    fireEvent.keyDown(window, { key: "Enter" })
+    expect(onAllSymbolEnter).toHaveBeenCalledWith("ETH")
+  })
+
+  it("focuses search with s and keeps query on Escape", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "2" })
+    const search = screen.getByLabelText("Search symbols")
+    fireEvent.input(search, { target: { value: "btc" } })
+    fireEvent.keyDown(window, { key: "s" })
+    expect(document.activeElement).toBe(search)
+
+    fireEvent.keyDown(search, { key: "Escape" })
+    expect(search).toHaveProperty("value", "btc")
+    expect(document.activeElement).not.toBe(search)
+  })
+
+  it("submits staged with mod+Enter and clears with mod+shift+backspace", () => {
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "3" })
+
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true })
+    expect(onStagedSubmit).toHaveBeenCalled()
+
+    fireEvent.keyDown(window, {
+      key: "Backspace",
+      metaKey: true,
+      shiftKey: true,
+    })
+    expect(onStagedClearAll).toHaveBeenCalled()
+  })
+
+  it("opens wallet pin dialog on mod+Enter when agent missing", () => {
+    setConnectionState("agentMissing")
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "3" })
+    fireEvent.keyDown(window, { key: "Enter", ctrlKey: true })
+    expect(onOpenWalletPinDialog).toHaveBeenCalled()
+    expect(onStagedSubmit).not.toHaveBeenCalled()
+  })
+
+  it("opens wallet pin dialog on mod+Enter when wallet disconnected from any panel", () => {
+    setConnectionState("walletDisconnected")
+    render(() => <Harness />)
+
+    fireEvent.keyDown(window, { key: "1" })
+    fireEvent.keyDown(window, { key: "w" })
+    expect(document.activeElement).toBe(screen.getByLabelText("BTC weight"))
+
+    fireEvent.keyDown(screen.getByLabelText("BTC weight"), { key: "Escape" })
+    fireEvent.keyDown(window, { key: "t" })
+    expect(onSideChange).toHaveBeenCalledWith("BTC", "sell")
+
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true })
+    expect(onOpenWalletPinDialog).toHaveBeenCalled()
+    expect(onStagedSubmit).not.toHaveBeenCalled()
+  })
+
+  it("allows portfolio edits without a trading agent", () => {
+    setConnectionState("agentMissing")
+    render(() => <Harness />)
+
+    fireEvent.keyDown(window, { key: "2" })
+    expect(activatePanel).toHaveBeenCalledWith("allSymbols")
+
+    fireEvent.keyDown(window, { key: "1" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("BTC")
+    fireEvent.keyDown(window, { key: "j" })
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("ETH")
+
+    fireEvent.keyDown(window, { key: "w" })
+    expect(document.activeElement).toBe(screen.getByLabelText("ETH weight"))
+
+    fireEvent.keyDown(screen.getByLabelText("ETH weight"), { key: "Escape" })
+    fireEvent.keyDown(window, { key: "t" })
+    expect(onSideChange).toHaveBeenCalledWith("ETH", "sell")
+
+    fireEvent.keyDown(window, { key: "l" })
+    fireEvent.keyDown(window, { key: "Escape" })
+    fireEvent.keyDown(window, { key: "d" })
+    expect(onRemove).toHaveBeenCalledWith("ETH")
+  })
+
+  it("no-ops portfolio keys when empty", () => {
+    setPortfolioSymbols([])
+    render(() => <Harness />)
+    fireEvent.keyDown(window, { key: "1" })
+    fireEvent.keyDown(window, { key: "j" })
+    fireEvent.keyDown(window, { key: "w" })
+    fireEvent.keyDown(window, { key: "d" })
+    expect(onRemove).not.toHaveBeenCalled()
+    expect(screen.getByTestId("selected-symbol").textContent).toBe("none")
+  })
+
+  it("swaps hotkey bar content with focused panel", () => {
+    render(() => <Harness />)
+    const bar = screen.getByTestId("portfolio-hotkey-bar")
+    expect(bar.textContent).toContain("weight")
+
+    fireEvent.keyDown(window, { key: "2" })
+    expect(bar.textContent).toContain("search")
+    expect(bar.textContent).not.toContain("weight")
+
+    fireEvent.keyDown(window, { key: "3" })
+    expect(bar.textContent).toContain("rebalance")
+  })
+})

--- a/frontend/src/pages/Portfolio/keyboard/usePortfolioKeyboard.tsx
+++ b/frontend/src/pages/Portfolio/keyboard/usePortfolioKeyboard.tsx
@@ -1,0 +1,575 @@
+import {
+  createContext,
+  createSignal,
+  onCleanup,
+  onMount,
+  useContext,
+  type Accessor,
+  type JSX,
+  type Setter,
+} from "solid-js"
+
+import type { OrderSide } from "@/hooks/useTrading"
+import type { StagedConnectionState } from "@/pages/Portfolio/components/StagedChangesPanel"
+import { steppedCrossAccountLeverage } from "@/pages/Portfolio/components/PositionsPanel/crossAccountLeverage"
+
+import { panelIdForDigitKey, type KeyboardPanelId } from "./hotkeyHints"
+import {
+  isEditableKeyboardTarget,
+  isKeyboardSuppressed,
+} from "./isKeyboardSuppressed"
+import { isPrimaryModifierPressed } from "./modifierLabel"
+import {
+  blurActiveElement,
+  focusAllSymbolsSearch,
+  focusPanelContainer,
+  focusPortfolioCell,
+  focusStagedPin,
+  STAGED_PIN_ATTR,
+} from "./portfolioCellFocus"
+
+export interface PortfolioKeyboardActions {
+  activatePanel: (panelId: KeyboardPanelId) => void
+  getPortfolioSymbols: () => string[]
+  getAllSymbolSymbols: () => string[]
+  isPinDialogOpen: () => boolean
+  connectionState: () => StagedConnectionState
+  onRemove: (symbol: string) => void
+  onUndoRemove: (symbol: string) => void
+  onSideChange: (symbol: string, side: OrderSide) => void
+  onLeverageChange: (symbol: string, leverage: number) => void
+  getPositionSide: (symbol: string) => OrderSide | undefined
+  getPositionLeverage: (symbol: string) => number | undefined
+  getMaxLeverage: (symbol: string) => number | undefined
+  getCrossAccountLeverage: () => number
+  onCrossAccountLeverageChange: (leverage: number) => void
+  isPositionClosing: (symbol: string) => boolean
+  onAllSymbolEnter: (symbol: string) => void
+  onStagedSubmit: () => void
+  onStagedClearAll: () => void
+  onOpenWalletPinDialog: () => void
+}
+
+interface PortfolioKeyboardContextValue {
+  focusedPanel: Accessor<KeyboardPanelId>
+  setFocusedPanel: Setter<KeyboardPanelId>
+  selectedPortfolioSymbol: Accessor<string | null>
+  setSelectedPortfolioSymbol: Setter<string | null>
+  selectedAllSymbolsIndex: Accessor<number | null>
+  setSelectedAllSymbolsIndex: Setter<number | null>
+  leverageEditorSymbol: Accessor<string | null>
+  setLeverageEditorSymbol: Setter<string | null>
+  portfolioSymbolOrder: Accessor<string[]>
+  setPortfolioSymbolOrder: Setter<string[]>
+  allSymbolOrder: Accessor<string[]>
+  setAllSymbolOrder: Setter<string[]>
+  ensurePortfolioSelection: () => void
+  ensureAllSymbolsSelection: () => void
+  onPanelActivated: (panelId: KeyboardPanelId) => void
+  registerStagedUnlockSubmit: (submit: (() => void) | null) => void
+}
+
+const PortfolioKeyboardContext = createContext<PortfolioKeyboardContextValue>()
+
+export { PortfolioKeyboardContext }
+
+export const usePortfolioKeyboardContext =
+  (): PortfolioKeyboardContextValue => {
+    const context = useContext(PortfolioKeyboardContext)
+    if (!context) {
+      throw new Error(
+        "usePortfolioKeyboardContext must be used within PortfolioKeyboardProvider",
+      )
+    }
+    return context
+  }
+
+/** Returns undefined when rendered outside the provider (e.g. isolated panel tests). */
+export const tryUsePortfolioKeyboardContext = ():
+  | PortfolioKeyboardContextValue
+  | undefined => useContext(PortfolioKeyboardContext)
+
+const moveIndex = (
+  current: number | null,
+  length: number,
+  delta: number,
+): number | null => {
+  if (length === 0) {
+    return null
+  }
+
+  if (current === null) {
+    return delta > 0 ? 0 : length - 1
+  }
+
+  const next = current + delta
+  if (next < 0) {
+    return 0
+  }
+  if (next >= length) {
+    return length - 1
+  }
+  return next
+}
+
+const resolvePortfolioSelection = (
+  previous: string | null,
+  symbols: string[],
+): string | null => {
+  if (symbols.length === 0) {
+    return null
+  }
+  if (previous !== null && symbols.includes(previous)) {
+    return previous
+  }
+  return symbols[0] ?? null
+}
+
+const resolveAllSymbolsIndex = (
+  previous: number | null,
+  length: number,
+): number | null => {
+  if (length === 0) {
+    return null
+  }
+  if (previous !== null && previous >= 0 && previous < length) {
+    return previous
+  }
+  return 0
+}
+
+export const PortfolioKeyboardProvider = (props: {
+  actions: PortfolioKeyboardActions
+  children: JSX.Element
+}): JSX.Element => {
+  const [focusedPanel, setFocusedPanel] =
+    createSignal<KeyboardPanelId>("portfolio")
+  const [selectedPortfolioSymbol, setSelectedPortfolioSymbol] = createSignal<
+    string | null
+  >(null)
+  const [selectedAllSymbolsIndex, setSelectedAllSymbolsIndex] = createSignal<
+    number | null
+  >(null)
+  const [leverageEditorSymbol, setLeverageEditorSymbol] = createSignal<
+    string | null
+  >(null)
+  const [portfolioSymbolOrder, setPortfolioSymbolOrder] = createSignal<
+    string[]
+  >([])
+  const [allSymbolOrder, setAllSymbolOrder] = createSignal<string[]>([])
+  let stagedUnlockSubmit: (() => void) | null = null
+
+  const registerStagedUnlockSubmit = (submit: (() => void) | null) => {
+    stagedUnlockSubmit = submit
+  }
+
+  const getPortfolioSymbols = () => {
+    const ordered = portfolioSymbolOrder()
+    if (ordered.length > 0) {
+      return ordered
+    }
+    return props.actions.getPortfolioSymbols()
+  }
+
+  const getAllSymbolSymbols = () => {
+    const ordered = allSymbolOrder()
+    if (ordered.length > 0) {
+      return ordered
+    }
+    return props.actions.getAllSymbolSymbols()
+  }
+
+  const ensurePortfolioSelection = () => {
+    setSelectedPortfolioSymbol(previous =>
+      resolvePortfolioSelection(previous, getPortfolioSymbols()),
+    )
+  }
+
+  const ensureAllSymbolsSelection = () => {
+    const symbols = getAllSymbolSymbols()
+    setSelectedAllSymbolsIndex(previous =>
+      resolveAllSymbolsIndex(previous, symbols.length),
+    )
+  }
+
+  const onPanelActivated = (panelId: KeyboardPanelId) => {
+    setFocusedPanel(panelId)
+    setLeverageEditorSymbol(null)
+
+    if (panelId === "portfolio") {
+      ensurePortfolioSelection()
+      focusPanelContainer("portfolio")
+      return
+    }
+
+    if (panelId === "allSymbols") {
+      ensureAllSymbolsSelection()
+      focusPanelContainer("allSymbols")
+      return
+    }
+
+    focusPanelContainer("staged")
+    if (props.actions.connectionState() === "agentLocked") {
+      // Defer so the PIN field is mounted when switching into staged.
+      queueMicrotask(() => {
+        focusStagedPin()
+      })
+    }
+  }
+
+  const stepLeverage = (delta: number) => {
+    const symbol = leverageEditorSymbol() ?? selectedPortfolioSymbol()
+    if (symbol === null) {
+      return
+    }
+
+    const current = props.actions.getPositionLeverage(symbol)
+    if (current === undefined) {
+      return
+    }
+
+    const maxLeverage = Math.floor(props.actions.getMaxLeverage(symbol) ?? 1)
+    const next = Math.min(maxLeverage, Math.max(1, current + delta))
+    if (next === current) {
+      return
+    }
+
+    props.actions.onLeverageChange(symbol, next)
+  }
+
+  const stepCrossAccountLeverage = (deltaSteps: number) => {
+    const current = props.actions.getCrossAccountLeverage()
+    const next = steppedCrossAccountLeverage(current, deltaSteps)
+    if (next === current) {
+      return
+    }
+
+    props.actions.onCrossAccountLeverageChange(next)
+  }
+
+  const handlePortfolioKeys = (event: KeyboardEvent) => {
+    // Account leverage: Shift+[ ] (event.key is {/} on many layouts).
+    if (
+      event.shiftKey &&
+      (event.code === "BracketLeft" || event.code === "BracketRight")
+    ) {
+      event.preventDefault()
+      stepCrossAccountLeverage(event.code === "BracketRight" ? 1 : -1)
+      return
+    }
+
+    const symbols = getPortfolioSymbols()
+    if (symbols.length === 0) {
+      return
+    }
+
+    const selected = selectedPortfolioSymbol()
+    const selectedIndex = selected === null ? -1 : symbols.indexOf(selected)
+    const hasValidSelection =
+      selectedIndex >= 0 && selectedIndex < symbols.length
+    const leverageOpen = leverageEditorSymbol() !== null
+
+    if (leverageOpen) {
+      if (event.key === "Escape" || event.key === "Enter") {
+        event.preventDefault()
+        setLeverageEditorSymbol(null)
+        focusPanelContainer("portfolio")
+        return
+      }
+
+      if (event.key === "ArrowLeft" || event.key === "[") {
+        event.preventDefault()
+        stepLeverage(-1)
+        return
+      }
+
+      if (event.key === "ArrowRight" || event.key === "]") {
+        event.preventDefault()
+        stepLeverage(1)
+        return
+      }
+
+      // Digits are handled inside PositionsPanelRow while editor is open.
+      return
+    }
+
+    if (event.key === "ArrowDown" || event.key === "j") {
+      event.preventDefault()
+      if (!hasValidSelection) {
+        setSelectedPortfolioSymbol(symbols[0] ?? null)
+        return
+      }
+      const nextIndex = moveIndex(selectedIndex, symbols.length, 1)
+      if (nextIndex !== null) {
+        setSelectedPortfolioSymbol(symbols[nextIndex] ?? null)
+      }
+      return
+    }
+
+    if (event.key === "ArrowUp" || event.key === "k") {
+      event.preventDefault()
+      if (!hasValidSelection) {
+        setSelectedPortfolioSymbol(symbols[symbols.length - 1] ?? null)
+        return
+      }
+      const nextIndex = moveIndex(selectedIndex, symbols.length, -1)
+      if (nextIndex !== null) {
+        setSelectedPortfolioSymbol(symbols[nextIndex] ?? null)
+      }
+      return
+    }
+
+    ensurePortfolioSelection()
+    const ensured = selectedPortfolioSymbol()
+    if (ensured === null) {
+      return
+    }
+
+    if (event.key === "w") {
+      event.preventDefault()
+      focusPortfolioCell(ensured, "weight")
+      return
+    }
+
+    if (event.key === "n") {
+      event.preventDefault()
+      focusPortfolioCell(ensured, "notional")
+      return
+    }
+
+    if (event.key === "t") {
+      event.preventDefault()
+      const side = props.actions.getPositionSide(ensured)
+      if (side === undefined || props.actions.isPositionClosing(ensured)) {
+        return
+      }
+      props.actions.onSideChange(ensured, side === "buy" ? "sell" : "buy")
+      return
+    }
+
+    if (event.key === "d") {
+      event.preventDefault()
+      if (props.actions.isPositionClosing(ensured)) {
+        props.actions.onUndoRemove(ensured)
+      } else {
+        props.actions.onRemove(ensured)
+      }
+      return
+    }
+
+    if (event.key === "l") {
+      event.preventDefault()
+      if (props.actions.isPositionClosing(ensured)) {
+        return
+      }
+      setLeverageEditorSymbol(ensured)
+      return
+    }
+
+    if (event.key === "[" || event.key === "]") {
+      event.preventDefault()
+      if (props.actions.isPositionClosing(ensured)) {
+        return
+      }
+      setLeverageEditorSymbol(ensured)
+      stepLeverage(event.key === "]" ? 1 : -1)
+    }
+  }
+
+  const handleAllSymbolsKeys = (event: KeyboardEvent) => {
+    const symbols = getAllSymbolSymbols()
+
+    if (event.key === "s") {
+      event.preventDefault()
+      focusAllSymbolsSearch()
+      return
+    }
+
+    if (symbols.length === 0) {
+      return
+    }
+
+    const selectedIndex = selectedAllSymbolsIndex()
+    const hasValidSelection =
+      selectedIndex !== null &&
+      selectedIndex >= 0 &&
+      selectedIndex < symbols.length
+
+    if (event.key === "ArrowDown" || event.key === "j") {
+      event.preventDefault()
+      if (!hasValidSelection) {
+        setSelectedAllSymbolsIndex(0)
+        return
+      }
+      setSelectedAllSymbolsIndex(moveIndex(selectedIndex, symbols.length, 1))
+      return
+    }
+
+    if (event.key === "ArrowUp" || event.key === "k") {
+      event.preventDefault()
+      if (!hasValidSelection) {
+        setSelectedAllSymbolsIndex(symbols.length - 1)
+        return
+      }
+      setSelectedAllSymbolsIndex(moveIndex(selectedIndex, symbols.length, -1))
+      return
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault()
+      if (!hasValidSelection) {
+        setSelectedAllSymbolsIndex(0)
+        props.actions.onAllSymbolEnter(symbols[0])
+        return
+      }
+      props.actions.onAllSymbolEnter(symbols[selectedIndex])
+    }
+  }
+
+  const handleStagedKeys = (event: KeyboardEvent) => {
+    if (
+      isPrimaryModifierPressed(event) &&
+      event.shiftKey &&
+      event.key === "Backspace"
+    ) {
+      event.preventDefault()
+      props.actions.onStagedClearAll()
+      return
+    }
+
+    if (isPrimaryModifierPressed(event) && event.key === "Enter") {
+      event.preventDefault()
+
+      const connection = props.actions.connectionState()
+      if (
+        connection === "walletDisconnected" ||
+        connection === "agentMissing"
+      ) {
+        props.actions.onOpenWalletPinDialog()
+        return
+      }
+      if (connection === "agentLocked") {
+        if (stagedUnlockSubmit) {
+          stagedUnlockSubmit()
+        } else {
+          focusStagedPin()
+        }
+        return
+      }
+      props.actions.onStagedSubmit()
+    }
+  }
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const leverageOpen = leverageEditorSymbol() !== null
+    const isPinField =
+      event.target instanceof HTMLElement &&
+      event.target.hasAttribute(STAGED_PIN_ATTR)
+
+    // Staged modifier chords work from any panel, and while the PIN field is
+    // focused. Draft edits do not require canTrade; connect opens when needed.
+    if (
+      isPrimaryModifierPressed(event) &&
+      !props.actions.isPinDialogOpen() &&
+      (isPinField || !isEditableKeyboardTarget(event.target))
+    ) {
+      if (event.shiftKey && event.key === "Backspace") {
+        handleStagedKeys(event)
+        return
+      }
+      if (event.key === "Enter") {
+        handleStagedKeys(event)
+        return
+      }
+    }
+
+    // While typing in an input, only allow Enter/Esc blur (keeps query / value).
+    if (isEditableKeyboardTarget(event.target)) {
+      if (
+        (event.key === "Enter" || event.key === "Escape") &&
+        event.target instanceof HTMLInputElement &&
+        !isPrimaryModifierPressed(event)
+      ) {
+        event.preventDefault()
+        blurActiveElement()
+        focusPanelContainer(focusedPanel())
+      }
+      return
+    }
+
+    if (
+      isKeyboardSuppressed({
+        eventTarget: event.target,
+        isPinDialogOpen: props.actions.isPinDialogOpen(),
+      })
+    ) {
+      return
+    }
+
+    // Leverage editor owns digits and step keys; mute panel switching.
+    if (leverageOpen && focusedPanel() === "portfolio") {
+      handlePortfolioKeys(event)
+      return
+    }
+
+    const panelFromDigit = panelIdForDigitKey(event.key)
+    if (
+      panelFromDigit !== undefined &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey
+    ) {
+      if (focusedPanel() === panelFromDigit) {
+        return
+      }
+      event.preventDefault()
+      props.actions.activatePanel(panelFromDigit)
+      onPanelActivated(panelFromDigit)
+      return
+    }
+
+    switch (focusedPanel()) {
+      case "portfolio":
+        handlePortfolioKeys(event)
+        break
+      case "allSymbols":
+        handleAllSymbolsKeys(event)
+        break
+      case "staged":
+        handleStagedKeys(event)
+        break
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeyDown)
+    onCleanup(() => {
+      window.removeEventListener("keydown", handleKeyDown)
+    })
+  })
+
+  const contextValue: PortfolioKeyboardContextValue = {
+    focusedPanel,
+    setFocusedPanel,
+    selectedPortfolioSymbol,
+    setSelectedPortfolioSymbol,
+    selectedAllSymbolsIndex,
+    setSelectedAllSymbolsIndex,
+    leverageEditorSymbol,
+    setLeverageEditorSymbol,
+    portfolioSymbolOrder,
+    setPortfolioSymbolOrder,
+    allSymbolOrder,
+    setAllSymbolOrder,
+    ensurePortfolioSelection,
+    ensureAllSymbolsSelection,
+    onPanelActivated,
+    registerStagedUnlockSubmit,
+  }
+
+  return (
+    <PortfolioKeyboardContext.Provider value={contextValue}>
+      {props.children}
+    </PortfolioKeyboardContext.Provider>
+  )
+}

--- a/frontend/src/pages/Portfolio/portfolio-dockview.css
+++ b/frontend/src/pages/Portfolio/portfolio-dockview.css
@@ -25,7 +25,7 @@
   --dv-tabs-and-actions-container-font-size: 11px;
   --dv-activegroup-visiblepanel-tab-background-color: var(--background);
   --dv-activegroup-hiddenpanel-tab-background-color: transparent;
-  --dv-inactivegroup-visiblepanel-tab-background-color: var(--background);
+  --dv-inactivegroup-visiblepanel-tab-background-color: transparent;
   --dv-inactivegroup-hiddenpanel-tab-background-color: transparent;
   --dv-activegroup-visiblepanel-tab-color: var(--foreground);
   --dv-activegroup-hiddenpanel-tab-color: var(--muted-foreground);
@@ -56,10 +56,25 @@
   border-radius: 0.25rem;
   overflow: hidden;
   background-color: var(--background);
+  transition: border-color 120ms ease;
+}
+
+.portfolio-dockview-theme .dv-groupview.dv-active-group {
+  border-color: color-mix(in oklch, var(--primary) 65%, var(--border));
 }
 
 .portfolio-dockview-theme .dv-tabs-and-actions-container {
   border-bottom: 1px solid var(--border);
+}
+
+/* Tabs stay transparent until the tab is selected in the focused group.
+   A separate window alone must not paint its selected tab black. */
+.portfolio-dockview-theme .dv-tab {
+  background-color: transparent !important;
+}
+
+.portfolio-dockview-theme .dv-groupview.dv-active-group .dv-tab.dv-active-tab {
+  background-color: var(--background) !important;
 }
 
 .portfolio-dockview-theme .dv-default-tab,

--- a/stories/0x025.navigate-portfolio-with-keyboard.md
+++ b/stories/0x025.navigate-portfolio-with-keyboard.md
@@ -1,0 +1,53 @@
+---
+status: in-progress
+---
+
+# Navigate Portfolio With Keyboard
+
+As a trader, I want to drive the `/portfolio` desk with the keyboard so that I
+can switch Dockview panels, edit positions, stage changes, and submit rebalances
+without reaching for the mouse.
+
+## Acceptance Criteria
+
+- [ ] Digits `1` / `2` / `3` activate Portfolio / All Symbols / Staged Changes
+      by fixed panel id (bring a hidden tab forward and focus it). Repeating the
+      same digit is a no-op.
+- [ ] A thin bottom hotkey bar lists the active panel's shortcuts with short
+      comments and uses `⌘` on Mac or `Ctrl` elsewhere. Tab headers show the
+      panel digit badges. Only the focused group's active Dockview tab uses the
+      solid `var(--background)` plate; tabs in inactive groups stay transparent
+      (no primary tint, no underline). The focused group keeps a primary border.
+- [ ] While any input, textarea, select, contenteditable, Wallet PIN dialog, or
+      open leverage digit entry is focused, app hotkeys (including `1`/`2`/`3`)
+      are suppressed. Enter/Esc on cell inputs only blur (values already commit
+      on input). Staged `Cmd/Ctrl+Enter` and `Cmd/Ctrl+Shift+Backspace` still
+      work while the PIN field is focused.
+- [ ] Portfolio: `j`/`k` and arrows move row selection (first press selects the
+      first/last row); selection is restored when returning to the panel; empty
+      list no-ops. `w` / `n` focus weight/notional with content selected; `t`
+      toggles side; `d` delete/undo; `l` opens leverage; `[`/`]` and left/right
+      arrows step leverage while the editor is open; Esc or Enter closes
+      leverage. The inline leverage slider spans only side/weight/notional (not
+      metric columns) and the close control is labeled `esc`. `Shift+[` /
+      `Shift+]` step the portfolio (cross-account) leverage slider even when the
+      position list is empty.
+- [ ] All Symbols: arrows/`j`/`k` move selection with virtualizer scroll; Enter
+      toggles add/remove/undo (same as click) and stays on the panel; `s`
+      focuses search; Esc blurs search and keeps the query; empty filtered list
+      no-ops.
+- [ ] Staged: activates PIN focus when `agentLocked`; `Cmd/Ctrl+Enter` from any
+      panel submits or opens connect (ready -> rebalance, agentMissing or
+      walletDisconnected -> WalletPinDialog, agentLocked -> unlock submit);
+      `Cmd/Ctrl+Shift+Backspace` clears all staged draft changes.
+- [ ] Draft edit hotkeys (`w`/`n`/`t`/`d`/`l`/`[`/`]`/`Shift+[`/`]`) work
+      without an agent / `canTrade`; only the live rebalance button remains
+      gated by wallet readiness in the UI.
+- [ ] Selected-row mini-hints use reserved width/opacity so the layout does not
+      jump when selection moves.
+- [ ] Acceptance tests cover the contract above (unit + keyboard workflow).
+
+## Out of scope
+
+Performance, Risk, and Factors panels have no digit bindings or panel-local
+hotkeys in this story.

--- a/stories/README.md
+++ b/stories/README.md
@@ -44,6 +44,7 @@ from Hyperliquid-only positions to read-only wallets and protective hedges.
 - [Show Risk Analytics For Active Portfolio](./0x01b.show-risk-analytics-for-active-portfolio.md)
 - [Screen Perps By Factor](./0x01c.screen-perps-by-factor.md)
 - [Simulate Staged Portfolio Metrics](./0x01d.simulate-staged-portfolio-metrics.md)
+- [Navigate Portfolio With Keyboard](./0x025.navigate-portfolio-with-keyboard.md)
 - [Trade Hyperliquid Spot Positions](./0x01e.trade-hyperliquid-spot-positions.md)
 - [Protocol Revenue Buybacks](./0x01f.protocol-revenue-buybacks.md)
 - [Transparent Fee Calculations](./0x020.transparent-fee-calculations.md)


### PR DESCRIPTION
Самописный навигатор по табам и позициям при помощи клавиатуры. Пример взят из /prototype

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive keyboard navigation for Portfolio panels, rows, symbols, staged changes, and editing actions.
  * Added panel-specific shortcut hints and keyboard shortcut bar.
  * Added selection highlighting, focus management, and accessibility state indicators.
  * Added keyboard controls for leverage editing, including Enter/Escape handling and stepped adjustments.
  * Added responsive panel navigation and wallet/PIN workflows via keyboard shortcuts.
* **Bug Fixes**
  * Improved leverage bounds, stepping, and editor layout consistency.
* **Tests**
  * Added unit and end-to-end coverage for keyboard workflows, focus suppression, hotkeys, and leverage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->