### PR TITLE
ignore runtime-managed Vite watch trees

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -284,6 +284,9 @@ provides the component library. Converted page by page -- same logic, different
 primitives.
 
 - [x] Project setup: Vite + solid-js, TypeScript config, dev server
+- [x] Vite watches runtime-managed environment trees --
+      [#467](https://github.com/dataclique/moneymentum/issues/467) /
+      [#468](https://github.com/dataclique/moneymentum/pull/468)
 - [x] Routing: migrate from react-router to @solidjs/router
 - [x] State & data fetching: migrate from @tanstack/react-query to
       @tanstack/solid-query

--- a/frontend/src/test/vite-config.test.ts
+++ b/frontend/src/test/vite-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+
+import viteConfig from "../../vite.config"
+
+describe("Vite development server watcher", () => {
+  it("ignores only runtime-managed environment trees", () => {
+    expect(viteConfig.server?.watch?.ignored).toEqual([
+      "**/.devenv/**",
+      "**/.direnv/**",
+    ])
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -71,6 +71,9 @@ export default defineConfig({
   },
   server: {
     host: "0.0.0.0",
+    watch: {
+      ignored: ["**/.devenv/**", "**/.direnv/**"],
+    },
     proxy: {
       "/api/hyperliquid": {
         target: "http://127.0.0.1:8000",


### PR DESCRIPTION
## Motivation

The local Vite server can follow repository-local `.devenv` and `.direnv` runtime trees, saturating its fsevents path-matching loop while port 5174 remains open but stops serving HTTP.

Closes #467

## Solution

- Ignore only `.devenv` and `.direnv` trees in the development watcher.
- Preserve normal frontend source HMR by leaving every source path watched.
- Add a focused Vite configuration contract for the exact ignored patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development server file watching by ignoring `.devenv` and `.direnv` environment directories, reducing unnecessary reloads and interruptions during development.

- **Tests**
  - Added coverage to verify that only the intended environment directories are excluded from development server watching.

- **Documentation**
  - Updated the project roadmap to track remaining work related to environment-directory watching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->